### PR TITLE
Refactor decode stage into a PipelineComponent.

### DIFF
--- a/starfish/pipeline/decoder/__init__.py
+++ b/starfish/pipeline/decoder/__init__.py
@@ -1,0 +1,48 @@
+from starfish.pipeline.pipelinecomponent import PipelineComponent
+from starfish.util.argparse import FsExistsType
+from . import _base
+from . import _iss
+
+
+class Decoder(PipelineComponent):
+    @classmethod
+    def implementing_algorithms(cls):
+        return _base.DecoderAlgorithmBase.__subclasses__()
+
+    @classmethod
+    def add_to_parser(cls, subparsers):
+        """Adds the decoder component to the CLI argument parser."""
+        decoder_group = subparsers.add_parser("decode")
+        decoder_group.add_argument("-i", "--input", type=FsExistsType(), required=True)
+        decoder_group.add_argument("-o", "--output", required=True)
+        decoder_group.add_argument("-c", "--codebook", type=FsExistsType(), required=True)
+        decoder_group.set_defaults(starfish_command=Decoder._cli)
+        decoder_subparsers = decoder_group.add_subparsers(dest="decoder_algorithm_class")
+
+        for algorithm_cls in cls.algorithm_to_class_map().values():
+            group_parser = decoder_subparsers.add_parser(algorithm_cls.get_algorithm_name())
+            group_parser.set_defaults(decoder_algorithm_class=algorithm_cls)
+            algorithm_cls.add_arguments(group_parser)
+
+        cls.decoder_group = decoder_group
+
+    @classmethod
+    def _cli(cls, args, print_help=False):
+        """Runs the decoder component based on parsed arguments."""
+        import pandas
+
+        if args.decoder_algorithm_class is None or print_help:
+            cls.decoder_group.print_help()
+            cls.decoder_group.exit(status=2)
+
+        instance = args.decoder_algorithm_class.from_cli_args(args)
+
+        encoded = pandas.read_json(args.input, orient="records")
+        codebook = pandas.read_json(args.codebook, orient="records")
+
+        results = instance.decode(encoded, codebook)
+        print("Writing | spot_id | gene_id to: {}".format(args.output))
+        results.to_json(args.output, orient="records")
+
+
+Decoder._ensure_algorithms_setup()

--- a/starfish/pipeline/decoder/_base.py
+++ b/starfish/pipeline/decoder/_base.py
@@ -1,0 +1,27 @@
+class DecoderAlgorithmBase(object):
+    @classmethod
+    def from_cli_args(cls, args):
+        """
+        Given parsed arguments, construct an instance of this decoder algorithm.
+
+        Generally, this involves retrieving the appropriate attributes from args to pass to the decoder algorithm's
+        constructor.
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def get_algorithm_name(cls):
+        """
+        Returns the name of the algorithm.  This should be a valid python identifier, i.e.,
+        https://docs.python.org/3/reference/lexical_analysis.html#identifiers
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def add_arguments(cls, group_parser):
+        """Adds the arguments for the algorithm."""
+        raise NotImplementedError()
+
+    def decode(self, encoded, codebook):
+        """Performs decoding on the spots found, using the codebook specified."""
+        raise NotImplementedError()

--- a/starfish/pipeline/decoder/_iss.py
+++ b/starfish/pipeline/decoder/_iss.py
@@ -1,0 +1,26 @@
+from starfish.decoders import iss
+from ._base import DecoderAlgorithmBase
+
+
+class IssDecoder(DecoderAlgorithmBase):
+    @classmethod
+    def from_cli_args(cls, args):
+        return IssDecoder()
+
+    @classmethod
+    def get_algorithm_name(cls):
+        return "iss"
+
+    @classmethod
+    def add_arguments(cls, group_parser):
+        pass
+
+    def decode(self, encoded, codebook):
+        import pandas
+
+        # TODO this should be loaded from disk
+        d = {'barcode': ['AAGC', 'AGGC'], 'gene': ['ACTB_human', 'ACTB_mouse']}
+        codebook = pandas.DataFrame(d)
+        decoder = iss.IssDecoder(codebook, letters=['T', 'G', 'C', 'A'])
+
+        return decoder.decode(encoded)

--- a/tests/test_iss_data.py
+++ b/tests/test_iss_data.py
@@ -66,8 +66,11 @@ class TestWithIssData(unittest.TestCase):
         ],
         [
             "starfish", "decode",
-            lambda tempdir, *args, **kwargs: os.path.join(tempdir, "results"),
-            "--decoder_type", "iss",
+            "-i", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "results", "encoder_table.json"),
+            # TODO: this should reflect the codebook path.  right now we're pointing at the encoder table.
+            "-c", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "results", "encoder_table.json"),
+            "-o", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "results", "decoder_table.json"),
+            "iss",
         ],
     )
 


### PR DESCRIPTION
Follow-on changes:
1. Get the codebook from a file.  This requires us to add the codebook to the pipeline API. (#96)
2. Merge `starfish.decoders.iss` into `starfish.pipeline.decoder._iss` (this will require refactoring the notebooks, but with @ambrosejcarr having landed the notebooks, it should be a lot easier). (#97)