### PR TITLE
Clean up the API around gene assignment.

### DIFF
--- a/notebooks/Mignardi_Pipeline.ipynb
+++ b/notebooks/Mignardi_Pipeline.ipynb
@@ -202,9 +202,11 @@
    "outputs": [],
    "source": [
     "from starfish.assign import assign\n",
+    "from starfish.stats import label_to_regions\n",
     "\n",
     "points = spots_viz.loc[:, ['x', 'y']].values\n",
-    "ass = assign(cells_labels, points, use_hull=True)\n",
+    "regions = label_to_regions(cells_labels)\n",
+    "ass = assign(regions, points, use_hull=True)\n",
     "ass.groupby('cell_id',as_index=False).count().rename(columns={'spot_id':'num spots'})"
    ]
   },

--- a/notebooks/Mignardi_Pipeline.py
+++ b/notebooks/Mignardi_Pipeline.py
@@ -139,9 +139,11 @@ seg.show()
 
 # EPY: START code
 from starfish.assign import assign
+from starfish.stats import label_to_regions
 
 points = spots_viz.loc[:, ['x', 'y']].values
-ass = assign(cells_labels, points, use_hull=True)
+regions = label_to_regions(cells_labels)
+ass = assign(regions, points, use_hull=True)
 ass.groupby('cell_id',as_index=False).count().rename(columns={'spot_id':'num spots'})
 # EPY: END code
 

--- a/starfish/assign.py
+++ b/starfish/assign.py
@@ -2,12 +2,8 @@ import numpy as np
 import pandas as pd
 from skimage.measure import points_in_poly
 
-from .stats import label_to_regions
 
-
-def assign(cells_label, spots, use_hull=True, verbose=False):
-    cells_region = label_to_regions(cells_label)
-
+def assign(cells_region, spots, use_hull=True, verbose=False):
     res = pd.DataFrame({'spot_id': range(0, spots.shape[0])})
     res['cell_id'] = None
 

--- a/starfish/starfish.py
+++ b/starfish/starfish.py
@@ -205,8 +205,8 @@ def segment(args, print_help=False):
     seg = WatershedSegmenter(s.aux_dict['dapi'], s.aux_dict[args.aux_image])
     cells_labels = seg.segment(args.dt, args.st, size_lim, disk_size_markers, disk_size_mask, args.md)
 
-    r = label_to_regions(cells_labels)
-    geojson = regions_to_geojson(r)
+    regions = label_to_regions(cells_labels)
+    geojson = regions_to_geojson(regions)
 
     path = os.path.join(args.results_dir, 'regions.geojson')
     print("Writing | regions geojson to: {}".format(path))
@@ -216,7 +216,7 @@ def segment(args, print_help=False):
     spots = pd.read_json(os.path.join(args.results_dir, 'spots.json'), orient="records")
     # TODO only works in 3D
     points = spots.loc[:, ['x', 'y']].values
-    res = assign(cells_labels, points, use_hull=True)
+    res = assign(regions, points, use_hull=True)
 
     path = os.path.join(args.results_dir, 'regions.json')
     print("Writing | cell_id | spot_id to: {}".format(path))


### PR DESCRIPTION
1. Both assignment and the output of segmentation convert from labels to regions.  This ensures we only do the work once.
2. Rename the variable `r` to `regions`.

Depends on #99 