### PR TITLE
Separate assignment from segmentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ starfish detect_spots /tmp/starfish/filtered/experiment.json /tmp/starfish/resul
 
 starfish segment /tmp/starfish/filtered/experiment.json /tmp/starfish/results stain --dt .16 --st .22 --md 57
 
+starfish gene_assignment --coordinates-geojson /tmp/starfish/results/regions.geojson --spots-json /tmp/starfish/results/spots.json --output /tmp/starfish/results/regions.json point_in_poly
+
 starfish decode -i /tmp/starfish/results/encoder_table.json --codebook /tmp/starfish/results/encoder_table.json -o /tmp/starfish/results/decoded_table.json iss
 ```
 

--- a/starfish/pipeline/gene_assignment/__init__.py
+++ b/starfish/pipeline/gene_assignment/__init__.py
@@ -1,0 +1,55 @@
+import json
+
+from starfish.pipeline.pipelinecomponent import PipelineComponent
+from starfish.util.argparse import FsExistsType
+from . import _base
+from . import point_in_poly
+
+
+class GeneAssignment(PipelineComponent):
+    @classmethod
+    def implementing_algorithms(cls):
+        return _base.GeneAssignmentAlgorithm.__subclasses__()
+
+    @classmethod
+    def add_to_parser(cls, subparsers):
+        """Adds the gene_assignment component to the CLI argument parser."""
+        gene_assignment_group = subparsers.add_parser("gene_assignment")
+        gene_assignment_group.add_argument("--coordinates-geojson", type=FsExistsType(), required=True)
+        gene_assignment_group.add_argument("--spots-json", type=FsExistsType(), required=True)
+        gene_assignment_group.add_argument("-o", "--output", required=True)
+        gene_assignment_group.set_defaults(starfish_command=GeneAssignment._cli)
+        gene_assignment_subparsers = gene_assignment_group.add_subparsers(dest="gene_assignment_algorithm_class")
+
+        for algorithm_cls in cls.algorithm_to_class_map().values():
+            group_parser = gene_assignment_subparsers.add_parser(algorithm_cls.get_algorithm_name())
+            group_parser.set_defaults(gene_assignment_algorithm_class=algorithm_cls)
+            algorithm_cls.add_arguments(group_parser)
+
+        cls.gene_assignment_group = gene_assignment_group
+
+    @classmethod
+    def _cli(cls, args, print_help=False):
+        """Runs the gene_assignment component based on parsed arguments."""
+        import pandas
+        from starfish import munge
+
+        if args.gene_assignment_algorithm_class is None or print_help:
+            cls.gene_assignment_group.print_help()
+            cls.gene_assignment_group.exit(status=2)
+
+        with open(args.coordinates_geojson, "r") as fh:
+            coordinates = json.load(fh)
+        regions = munge.geojson_to_region(coordinates)
+
+        spots = pandas.read_json(args.spots_json, orient="records")
+
+        instance = args.gene_assignment_algorithm_class.from_cli_args(args)
+
+        result = instance.assign_genes(spots, regions)
+
+        print("Writing | cell_id | spot_id to: {}".format(args.output))
+        result.to_json(args.output, orient="records")
+
+
+GeneAssignment._ensure_algorithms_setup()

--- a/starfish/pipeline/gene_assignment/_base.py
+++ b/starfish/pipeline/gene_assignment/_base.py
@@ -1,0 +1,27 @@
+class GeneAssignmentAlgorithm(object):
+    @classmethod
+    def from_cli_args(cls, args):
+        """
+        Given parsed arguments, construct an instance of this gene_assignment algorithm.
+
+        Generally, this involves retrieving the appropriate attributes from args to pass to the gene_assignment
+        algorithm's constructor.
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def get_algorithm_name(cls):
+        """
+        Returns the name of the algorithm.  This should be a valid python identifier, i.e.,
+        https://docs.python.org/3/reference/lexical_analysis.html#identifiers
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def add_arguments(cls, parser):
+        """Adds the arguments for the algorithm."""
+        raise NotImplementedError()
+
+    def assign_genes(self, spots, regions):
+        """Performs gene assignment given the spots and the regions."""
+        raise NotImplementedError()

--- a/starfish/pipeline/gene_assignment/point_in_poly.py
+++ b/starfish/pipeline/gene_assignment/point_in_poly.py
@@ -1,0 +1,22 @@
+from ._base import GeneAssignmentAlgorithm
+
+
+class PointInPoly(GeneAssignmentAlgorithm):
+    @classmethod
+    def from_cli_args(cls, args):
+        return PointInPoly()
+
+    @classmethod
+    def get_algorithm_name(cls):
+        return "point_in_poly"
+
+    @classmethod
+    def add_arguments(cls, parser):
+        pass
+
+    def assign_genes(self, spots, regions):
+        from starfish.assign import assign
+
+        # TODO only works in 3D
+        points = spots.loc[:, ['x', 'y']].values
+        return assign(regions, points, use_hull=True)

--- a/tests/test_iss_data.py
+++ b/tests/test_iss_data.py
@@ -72,6 +72,14 @@ class TestWithIssData(unittest.TestCase):
             "--md", "57",
         ],
         [
+            "starfish", "gene_assignment",
+            "--coordinates-geojson",
+            lambda tempdir, *args, **kwargs: os.path.join(tempdir, "results", "regions.geojson"),
+            "--spots-json", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "results", "spots.json"),
+            "--output", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "results", "regions.json"),
+            "point_in_poly",
+        ],
+        [
             "starfish", "decode",
             "-i", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "results", "encoder_table.json"),
             "--codebook", lambda tempdir, *args, **kwargs: get_codebook(tempdir),


### PR DESCRIPTION
Create a gene assignment pipeline component, and move the relevant code there.

Note that this changes the output of segmentation to output the full geometry of the regions, rather than the hull.

Depends on #102, #101, #100