### PR TITLE
Only run with coverage when running the entire test suite.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,17 @@ lint:
 
 test_srcs := $(wildcard tests/test_*.py)
 
+test: STARFISH_COVERAGE := 1
 test: $(test_srcs) lint
 	coverage combine
 	rm -f .coverage.*
 
 $(test_srcs): %.py :
-	coverage run -p --source=starfish -m unittest $(subst /,.,$*)
+	if [ "$(STARFISH_COVERAGE)" == 1 ]; then \
+		STARFISH_COVERAGE=1 coverage run -p --source=starfish -m unittest $(subst /,.,$*); \
+	else \
+		python -m unittest $(subst /,.,$*); \
+	fi
 
 .PHONY : $(test_srcs)
 

--- a/tests/test_iss_data.py
+++ b/tests/test_iss_data.py
@@ -73,6 +73,7 @@ class TestWithIssData(unittest.TestCase):
 
     def test_run_pipeline(self):
         tempdir = tempfile.mkdtemp()
+        coverage_enabled = "STARFISH_COVERAGE" in os.environ
 
         def callback(interval):
             print(" ".join(stage[:2]), " ==> {} seconds".format(interval))
@@ -86,7 +87,7 @@ class TestWithIssData(unittest.TestCase):
                     element(tempdir=tempdir) if callable(element) else element
                     for element in stage
                 ]
-                if cmdline[0] == 'starfish':
+                if cmdline[0] == 'starfish' and coverage_enabled:
                     coverage_cmdline = [
                         "coverage", "run",
                         "-p",


### PR DESCRIPTION
This will stop .coverage.xxx files from getting dropped everywhere.

Test plan: ran `make tests/test_iss_data.py` and verified that no .coverage.* files were created.