### PR TITLE
unbreak the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 MODULES=starfish tests
 
 lint:

--- a/notebooks/subdir.mk
+++ b/notebooks/subdir.mk
@@ -12,7 +12,7 @@ regenerate_py: $(py_regenerate_targets)
 $(ipynb_validate_targets): TEMPFILE := $(shell mktemp)
 $(ipynb_validate_targets): validate__%.ipynb :
 	nbencdec encode $*.ipynb $(TEMPFILE)
-	diff -q <( cat $*.py | egrep -v '^# EPY: stripped_notebook: ') <( cat $(TEMPFILE) | egrep -v '# EPY: stripped_notebook: ' )
+	diff -q <(cat $*.py | egrep -v '^# EPY: stripped_notebook: ') <(cat $(TEMPFILE) | egrep -v '# EPY: stripped_notebook: ')
 
 $(ipynb_regenerate_targets): regenerate__%.ipynb : %.py
 	nbencdec decode $< $*.ipynb

--- a/notebooks/subdir.mk
+++ b/notebooks/subdir.mk
@@ -12,7 +12,7 @@ regenerate_py: $(py_regenerate_targets)
 $(ipynb_validate_targets): TEMPFILE := $(shell mktemp)
 $(ipynb_validate_targets): validate__%.ipynb :
 	nbencdec encode $*.ipynb $(TEMPFILE)
-	diff -q $*.py $(TEMPFILE)
+	diff -q <( cat $*.py | egrep -v '^# EPY: stripped_notebook: ') <( cat $(TEMPFILE) | egrep -v '# EPY: stripped_notebook: ' )
 
 $(ipynb_regenerate_targets): regenerate__%.ipynb : %.py
 	nbencdec decode $< $*.ipynb


### PR DESCRIPTION
Ignore the notebook metadata when validating that the .ipynb and the .py match.  This is because subtle and unimportant changes are written there, such as the version of the python interpreter used to evaluate the notebook.  None of this matters as far as how the notebook code and layout is preserved.