### PR TITLE
Fix decode documentation and filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ starfish detect_spots /tmp/starfish/filtered/org.json /tmp/starfish/results dots
 
 starfish segment /tmp/starfish/filtered/org.json /tmp/starfish/results stain --dt .16 --st .22 --md 57
 
-starfish decode /tmp/starfish/results --decoder_type iss
+starfish decode -i /tmp/starfish/results/encoder_table.json --codebook /tmp/starfish/results/encoder_table.json -o /tmp/starfish/results/decoded_table.json iss
 ```
 
 ## visualization quickstart

--- a/starfish/pipeline/decoder/__init__.py
+++ b/starfish/pipeline/decoder/__init__.py
@@ -15,7 +15,7 @@ class Decoder(PipelineComponent):
         decoder_group = subparsers.add_parser("decode")
         decoder_group.add_argument("-i", "--input", type=FsExistsType(), required=True)
         decoder_group.add_argument("-o", "--output", required=True)
-        decoder_group.add_argument("-c", "--codebook", type=FsExistsType(), required=True)
+        decoder_group.add_argument("--codebook", type=FsExistsType(), required=True)
         decoder_group.set_defaults(starfish_command=Decoder._cli)
         decoder_subparsers = decoder_group.add_subparsers(dest="decoder_algorithm_class")
 

--- a/tests/test_iss_data.py
+++ b/tests/test_iss_data.py
@@ -68,8 +68,8 @@ class TestWithIssData(unittest.TestCase):
             "starfish", "decode",
             "-i", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "results", "encoder_table.json"),
             # TODO: this should reflect the codebook path.  right now we're pointing at the encoder table.
-            "-c", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "results", "encoder_table.json"),
-            "-o", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "results", "decoder_table.json"),
+            "--codebook", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "results", "encoder_table.json"),
+            "-o", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "results", "decoded_table.json"),
             "iss",
         ],
     )
@@ -101,7 +101,7 @@ class TestWithIssData(unittest.TestCase):
                     cmdline = coverage_cmdline
                 with clock.timeit(callback):
                     subprocess.check_call(cmdline)
-            with open(os.path.join(tempdir, "results", "decoder_table.json")) as fh:
+            with open(os.path.join(tempdir, "results", "decoded_table.json")) as fh:
                 results = json.load(fh)
 
             counts = collections.defaultdict(lambda: 0)


### PR DESCRIPTION
#95 changed how decode works.  This fixes up the documentation.

Removed -c as an option for specifying codebook.

I also snuck in a change renaming decoder_table to decoded_table. :)