### PR TITLE
Use "constants" instead of magic strings.

### DIFF
--- a/examples/get_iss_data.py
+++ b/examples/get_iss_data.py
@@ -8,6 +8,7 @@ import requests
 from skimage.io import imread, imsave
 from slicedimage import ImageFormat, ImagePartition, Tile, Writer
 
+from starfish.image import Coordinates, Indices
 from starfish.util.argparse import FsExistsType
 
 
@@ -21,18 +22,23 @@ def download(input_dir, url):
 def build_hybridization_stack(input_dir):
     default_shape = imread(os.path.join(input_dir, str(1), "c{}.TIF".format(1))).shape
 
-    hybridization_images = ImagePartition(["x", "y", "hyb", "ch"], {'hyb': 4, 'ch': 4}, default_shape, ImageFormat.TIFF)
+    hybridization_images = ImagePartition(
+        [Coordinates.X, Coordinates.Y, Indices.HYB, Indices.CH],
+        {Indices.HYB: 4, Indices.CH: 4},
+        default_shape,
+        ImageFormat.TIFF,
+    )
 
     for hyb in range(4):
         for ch in range(4):
             tile = Tile(
                 {
-                    'x': (0.0, 0.0001),
-                    'y': (0.0, 0.0001),
+                    Coordinates.X: (0.0, 0.0001),
+                    Coordinates.Y: (0.0, 0.0001),
                 },
                 {
-                    'hyb': hyb,
-                    'ch': ch,
+                    Indices.HYB: hyb,
+                    Indices.CH: ch,
                 },
             )
             path = os.path.join(input_dir, str(hyb + 1), "c{}.TIF".format(ch + 2))
@@ -98,8 +104,8 @@ def tile_opener(toc_path, tile, ext):
     return open(
         "{}-H{}-C{}.{}".format(
             tile_basename,
-            tile.indices['hyb'],
-            tile.indices['ch'],
+            tile.indices[Indices.HYB],
+            tile.indices[Indices.CH],
             "tiff",  # this is not `ext` because ordinarily, output is saved as .npy.  since we're copying the data, it
                      # should stay .tiff
         ),

--- a/starfish/image/__init__.py
+++ b/starfish/image/__init__.py
@@ -1,2 +1,3 @@
 from ._base import ImageBase
+from ._constants import Coordinates, Indices
 from ._stack import ImageStack

--- a/starfish/image/_constants.py
+++ b/starfish/image/_constants.py
@@ -1,0 +1,29 @@
+from enum import Enum
+
+
+class Coordinates(Enum):
+    X = 'x'
+    Y = 'y'
+    Z = 'z'
+
+    def __hash__(self):
+        return self.value.__hash__()
+
+    def __eq__(self, other):
+        if isinstance(other, Coordinates) or isinstance(other, str):
+            return self.value == other
+        return False
+
+
+class Indices(Enum):
+    HYB = 'hyb'
+    CH = 'ch'
+    Z = 'z'
+
+    def __hash__(self):
+        return self.value.__hash__()
+
+    def __eq__(self, other):
+        if isinstance(other, Indices) or isinstance(other, str):
+            return self.value == other
+        return False

--- a/starfish/io.py
+++ b/starfish/io.py
@@ -6,7 +6,7 @@ import pandas as pd
 from slicedimage import ImageFormat
 from slicedimage.io import resolve_url
 
-from .image import ImageStack
+from .image import ImageStack, Indices
 from .munge import list_to_stack
 
 
@@ -105,9 +105,9 @@ class Stack:
         self.squeeze_map = pd.DataFrame(dict(ind=ind, hyb=hyb, ch=ch))
 
         if bit_map_flag:
-            mp = [(d['hyb'], d['ch'], d['bit']) for d in self.org['data']]
-            mp = pd.DataFrame(mp, columns=['hyb', 'ch', 'bit'])
-            self.squeeze_map = pd.merge(self.squeeze_map, mp, on=['ch', 'hyb'], how='left')
+            mp = [(d[Indices.HYB], d[Indices.CH], d['bit']) for d in self.org['data']]
+            mp = pd.DataFrame(mp, columns=[Indices.HYB, Indices.CH, 'bit'])
+            self.squeeze_map = pd.merge(self.squeeze_map, mp, on=[Indices.CH, Indices.HYB], how='left')
 
         return new_data
 

--- a/starfish/pipeline/registration/fourier_shift.py
+++ b/starfish/pipeline/registration/fourier_shift.py
@@ -1,3 +1,4 @@
+from starfish.image import Indices
 from ._base import RegistrationAlgorithmBase
 
 
@@ -24,7 +25,7 @@ class FourierShiftRegistration(RegistrationAlgorithmBase):
     def register(self, stack):
         import numpy as np
 
-        mp = stack.max_proj('ch')
+        mp = stack.max_proj(Indices.CH)
         res = np.zeros(stack.image.shape)
 
         for h in range(stack.image.num_hybs):

--- a/starfish/starfish.py
+++ b/starfish/starfish.py
@@ -7,6 +7,7 @@ import os
 import sys
 from pstats import Stats
 
+from .image import Indices
 from .pipeline import registration
 from .pipeline.decoder import Decoder
 from .util.argparse import FsExistsType
@@ -125,7 +126,7 @@ def filter(args, print_help=False):
 
     print("Writing results ...")
     # create a 'stain' for segmentation
-    stain = np.mean(s.max_proj('ch'), axis=0)
+    stain = np.mean(s.max_proj(Indices.CH), axis=0)
     stain = stain / stain.max()
 
     # update stack


### PR DESCRIPTION
Things like 'hyb', 'ch', etc. should be referred to by constants rather than magic strings.  That makes 1) usage easier to track, and 2) easier to refactor.