### PR TITLE
Add slice operations to ImageStack

### DIFF
--- a/starfish/image/_stack.py
+++ b/starfish/image/_stack.py
@@ -1,4 +1,5 @@
 import os
+import typing
 
 import numpy
 from slicedimage import Reader, Writer
@@ -8,6 +9,13 @@ from ._constants import Coordinates, Indices
 
 
 class ImageStack(ImageBase):
+    AXES_MAP = {
+        Indices.HYB: 0,
+        Indices.CH: 1,
+        Indices.Z: 2,
+    }
+    N_AXES = max(AXES_MAP.values()) + 1
+
     def __init__(self, image_partition):
         self._image_partition = image_partition
         self._num_hybs = image_partition.get_dimension_shape(Indices.HYB)
@@ -25,7 +33,7 @@ class ImageStack(ImageBase):
             h = tile.indices[Indices.HYB]
             c = tile.indices[Indices.CH]
             zlayer = tile.indices.get(Indices.Z, 0)
-            self._data[h, c, zlayer, :] = tile.numpy_array
+            self.set_slice(indices={Indices.HYB: h, Indices.CH: c, Indices.Z: zlayer}, data=tile.numpy_array)
 
     @classmethod
     def from_image_stack(cls, image_stack_name_or_url, baseurl):
@@ -44,6 +52,107 @@ class ImageStack(ImageBase):
         self._data = data.view()
         self._data_needs_writeback = True
         data.setflags(write=False)
+
+    def get_slice(
+            self,
+            indices: typing.Mapping[Indices, typing.Union[int, slice]]
+    ) -> typing.Tuple[numpy.ndarray, typing.Sequence[Indices]]:
+        """
+        Given a dictionary mapping the index name to either a value or a slice range, return a numpy array representing
+        the slice, and a list of the remaining axes beyond the normal x-y tile.
+
+        Example:
+            ImageStack axes: H, C, and Z with shape 3, 4, 5, respectively.
+            ImageStack Implicit axes: X, Y with shape 10, 20, respectively.
+            Called to slice with indices {Z: 5}.
+            Result: a 4-dimensional numpy array with shape (3, 4, 10, 20) and the remaining axes [H, C].
+
+        Example:
+            Original axes: H, C, and Z.
+            Implicit axes: X, Y.
+            Called to slice with indices {Z: 5, C: slice(2, 4)}.
+            Result: a 4-dimensional numpy array with shape (3, 2, 10, 20) and the remaining axes [H, C].
+        """
+        slice_list, axes = self._build_slice_list(indices)
+        result = self._data[slice_list]
+        result.setflags(write=False)
+        return result, axes
+
+    def set_slice(
+            self,
+            indices: typing.Mapping[Indices, typing.Union[int, slice]],
+            data: numpy.ndarray,
+            axes: typing.Sequence[Indices]=None):
+        """
+        Given a dictionary mapping the index name to either a value or a slice range and a source numpy array, set the
+        slice of the array of this ImageStack to the values in the source numpy array.  If the optional parameter axes
+        is provided, that represents the axes of the numpy array beyond the x-y tile.
+
+        Example:
+            ImageStack axes: H, C, and Z with shape 3, 4, 5, respectively.
+            ImageStack Implicit axes: X, Y with shape 10, 20, respectively.
+            Called to set a slice with indices {Z: 5}.
+            Data: a 4-dimensional numpy array with shape (3, 4, 10, 20)
+            Result: Replace the data for Z=5.
+
+        Example:
+            ImageStack axes: H, C, and Z. (shape 3, 4, 5)
+            ImageStack Implicit axes: X, Y. (shape 10, 20)
+            Called to set a slice with indices {Z: 5, C: slice(2, 4)}.
+            Data: a 4-dimensional numpy array with shape (3, 2, 10, 20)
+            Result: Replace the data for Z=5, C=2-3.
+        """
+        slice_list, expected_axes = self._build_slice_list(indices)
+
+        if axes is not None:
+            if len(axes) != len(data.shape) - 2:
+                raise ValueError("data shape ({}) should be the axes ({}) and (x,y).".format(data.shape, axes))
+            move_src = list()
+            move_dst = list()
+            for src_idx, axis in enumerate(axes):
+                try:
+                    dst_idx = expected_axes.index(axis)
+                except ValueError:
+                    raise ValueError("Unexpected axis {}.  Expecting only {}.".format(axis, expected_axes))
+                if src_idx != dst_idx:
+                    move_src.append(src_idx)
+                    move_dst.append(dst_idx)
+
+            if len(move_src) != 0:
+                data = data.view()
+                numpy.moveaxis(data, move_src, move_dst)
+
+        if self._data[slice_list].shape != data.shape:
+            raise ValueError("source shape {} mismatches destination shape {}".format(
+                data.shape, self._data[slice_list].shape))
+
+        self._data[slice_list] = data
+        self._data_needs_writeback = True
+
+    def _build_slice_list(
+            self,
+            indices: typing.Mapping[Indices, typing.Union[int, slice]]
+    ) -> typing.Tuple[typing.Tuple[typing.Union[int, slice], ...], typing.Sequence[Indices]]:
+        slice_list = [
+            slice(None, None, None)
+            for _ in range(ImageStack.N_AXES)
+        ]  # type: typing.MutableSequence[typing.Union[int, slice]]
+        axes = []
+        removed_axes = set()
+        for name, value in indices.items():
+            idx = ImageStack.AXES_MAP[name]
+            if not isinstance(value, slice):
+                removed_axes.add(name)
+            slice_list[idx] = value
+
+        for dimension_value, dimension_name in sorted([
+            (dimension_value, dimension_name)
+            for dimension_name, dimension_value in ImageStack.AXES_MAP.items()
+        ]):
+            if dimension_name not in removed_axes:
+                axes.append(dimension_name)
+
+        return tuple(slice_list), axes
 
     @property
     def shape(self):
@@ -74,7 +183,8 @@ class ImageStack(ImageBase):
                 h = tile.indices[Indices.HYB]
                 c = tile.indices[Indices.CH]
                 zlayer = tile.indices.get(Indices.Z, 0)
-                tile.numpy_array = self._data[h, c, zlayer, :]
+                tile.numpy_array, axes = self.get_slice(indices={Indices.HYB: h, Indices.CH: c, Indices.Z: zlayer})
+                assert len(axes) == 0
             self._data_needs_writeback = False
 
         seen_x_coords, seen_y_coords, seen_z_coords = set(), set(), set()
@@ -126,16 +236,12 @@ class ImageStack(ImageBase):
             tile_opener=tile_opener)
 
     def max_proj(self, *dims):
-        valid_dims = {
-            Indices.HYB: 0,
-            Indices.CH: 1,
-            Indices.Z: 2,
-        }
         axes = list()
         for dim in dims:
             try:
-                axes.append(valid_dims[dim])
+                axes.append(ImageStack.AXES_MAP[dim])
             except KeyError:
-                raise ValueError("Dimension: {} not supported. Expecting one of: {}".format(dim, valid_dims.keys()))
+                raise ValueError(
+                    "Dimension: {} not supported. Expecting one of: {}".format(dim, ImageStack.AXES_MAP.keys()))
 
         return numpy.max(self._data, axis=tuple(axes))


### PR DESCRIPTION
This allows users to specify the axes and the values by which to slice the data.  This is the preferred way of accessing data, since it allows us to change the order of dimensions, though the `numpy_array()` accessor remains accessible.

Depends on #133 