### PR TITLE
use the slice operations to get and set data.

### DIFF
--- a/starfish/image/_stack.py
+++ b/starfish/image/_stack.py
@@ -65,13 +65,13 @@ class ImageStack(ImageBase):
             ImageStack axes: H, C, and Z with shape 3, 4, 5, respectively.
             ImageStack Implicit axes: X, Y with shape 10, 20, respectively.
             Called to slice with indices {Z: 5}.
-            Result: a 4-dimensional numpy array with shape (3, 4, 10, 20) and the remaining axes [H, C].
+            Result: a 4-dimensional numpy array with shape (3, 4, 20, 10) and the remaining axes [H, C].
 
         Example:
             Original axes: H, C, and Z.
             Implicit axes: X, Y.
             Called to slice with indices {Z: 5, C: slice(2, 4)}.
-            Result: a 4-dimensional numpy array with shape (3, 2, 10, 20) and the remaining axes [H, C].
+            Result: a 4-dimensional numpy array with shape (3, 2, 20, 10) and the remaining axes [H, C].
         """
         slice_list, axes = self._build_slice_list(indices)
         result = self._data[slice_list]

--- a/starfish/starfish.py
+++ b/starfish/starfish.py
@@ -116,23 +116,23 @@ def filter(args, print_help=False):
     print("Filtering dots ...")
     dots_filt = white_top_hat(s.aux_dict['dots'], args.ds)
 
-    print("Writing results ...")
     # create a 'stain' for segmentation
     # TODO: (ambrosejcarr) is this the appropriate way of dealing with Z in stain generation?
     stain = np.mean(s.max_proj(Indices.CH, Indices.Z), axis=0)
     stain = stain / stain.max()
-
-    res = np.zeros(s.image.shape)
 
     # filter raw images, for all hybs, channels
     for hyb in range(s.image.num_hybs):
         for ch in range(s.image.num_chs):
             for zlayer in range(s.image.num_zlayers):
                 print("Filtering image: hyb={} ch={} zlayer={}...".format(hyb, ch, zlayer))
-                res[hyb, ch, zlayer, :, :] = white_top_hat(s.image.numpy_array[hyb, ch, zlayer, :, :], args.ds)
+                indices = {Indices.HYB: hyb, Indices.CH: ch, Indices.Z: zlayer}
+                data, axes = s.image.get_slice(indices=indices)
+                assert len(axes) == 0
+                result = white_top_hat(data, args.ds)
+                s.image.set_slice(indices=indices, data=result)
 
-    # update stack
-    s.set_stack(res)
+    print("Writing results ...")
     s.set_aux('dots', dots_filt)
     s.set_aux('stain', stain)
 


### PR DESCRIPTION
This removes the need to allocate a new array, and makes the pipeline code unaware of the ordering of the axes.

Depends on #134 