### PR TITLE
get the actual numpy shape for comparison in set_stack

### DIFF
--- a/starfish/image/_base.py
+++ b/starfish/image/_base.py
@@ -1,3 +1,6 @@
+import typing
+
+
 class ImageBase(object):
     @property
     def numpy_array(self):
@@ -5,8 +8,13 @@ class ImageBase(object):
         raise NotImplementedError()
 
     @property
+    def raw_shape(self) -> typing.Optional[list]:
+        """Retrieves the shape of the image data, as a list of the sizes of the indices."""
+        raise NotImplementedError()
+
+    @property
     def shape(self):
-        """Retrieves the shape of the image data."""
+        """Retrieves the shape of the image data, as an ordered mapping between index names to the size of the index."""
         raise NotImplementedError()
 
     def write(self, filepath):

--- a/starfish/image/_stack.py
+++ b/starfish/image/_stack.py
@@ -156,6 +156,13 @@ class ImageStack(ImageBase):
         return tuple(slice_list), axes
 
     @property
+    def raw_shape(self) -> typing.Optional[list]:
+        if self._data is None:
+            return None
+
+        return self._data.shape
+
+    @property
     def shape(self) -> typing.Optional[dict]:
         if self._data is None:
             return None

--- a/starfish/io.py
+++ b/starfish/io.py
@@ -65,7 +65,7 @@ class Stack:
             self.write_fn(os.path.join(dir_name, fname), self.aux_dict[aux_key])
 
     def set_stack(self, new_stack):
-        if new_stack.shape != self.image.shape:
+        if self.image.raw_shape != new_stack.shape:
             msg = "Shape mismatch. Current data shape: {}, new data shape: {}".format(
                 self.image.shape, new_stack.shape)
             raise AttributeError(msg)


### PR DESCRIPTION
image.shape now returns an ordered index_name -> index_size map.