### PR TITLE
Convert ISS notebook to source data from the cloud.

### DIFF
--- a/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.ipynb
+++ b/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.ipynb
@@ -6,14 +6,7 @@
    "source": [
     "## Reproduce In-situ Sequencing results with Starfish\n",
     "\n",
-    "The ISS.zip file needed to follow along with this notebook can be downloaded [here](https://drive.google.com/open?id=1YQ3QcOBIoL6Yz3SStC0vigbVaH0C7DkW)\n",
-    "\n",
-    "This notebook walks through a work flow that reproduces an ISS result for one field of view using the starfish package. It assumes that you have unzipped ISS.zip in the same directory as this notebook. Thus, you should see: \n",
-    "\n",
-    "```\n",
-    "ISS/\n",
-    "ISS Pipeline - Breast - 1 FOV.ipynb\n",
-    "```\n",
+    "This notebook walks through a work flow that reproduces an ISS result for one field of view using the starfish package.\n",
     "\n",
     "## Load tiff stack and visualize one field of view"
    ]
@@ -47,7 +40,7 @@
     "from starfish.io import Stack\n",
     "\n",
     "s = Stack()\n",
-    "s.read('ISS/fov_001/experiment.json')\n",
+    "s.read('https://dmf0bdeheu4zf.cloudfront.net/ISS/fov_001/experiment.json')\n",
     "# s.squeeze() simply converts the 4D tensor H*C*X*Y into a list of len(H*C) image planes for rendering by 'tile'\n",
     "tile(s.squeeze());  "
    ]
@@ -140,7 +133,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x1116bb860>"
+       "<matplotlib.image.AxesImage at 0x108a14cc0>"
       ]
      },
      "execution_count": 4,
@@ -177,7 +170,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x118830630>"
+       "<matplotlib.image.AxesImage at 0x10b97ea90>"
       ]
      },
      "execution_count": 5,
@@ -378,7 +371,7 @@
     }
    ],
    "source": [
-    "codebook = pd.read_csv('ISS/codebook.csv', dtype={'barcode': object})\n",
+    "codebook = pd.read_csv('http://czi.starfish.data.public.s3-website-us-east-1.amazonaws.com/ISS/codebook.csv', dtype={'barcode': object})\n",
     "codebook.head(20)"
    ]
   },
@@ -1203,7 +1196,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x1265d9208>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x11fc478d0>"
       ]
      },
      "execution_count": 14,

--- a/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.py
+++ b/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.py
@@ -6,14 +6,7 @@
 # EPY: START markdown
 # ## Reproduce In-situ Sequencing results with Starfish
 # 
-# The ISS.zip file needed to follow along with this notebook can be downloaded [here](https://drive.google.com/open?id=1YQ3QcOBIoL6Yz3SStC0vigbVaH0C7DkW)
-# 
-# This notebook walks through a work flow that reproduces an ISS result for one field of view using the starfish package. It assumes that you have unzipped ISS.zip in the same directory as this notebook. Thus, you should see: 
-# 
-# ```
-# ISS/
-# ISS Pipeline - Breast - 1 FOV.ipynb
-# ```
+# This notebook walks through a work flow that reproduces an ISS result for one field of view using the starfish package.
 # 
 # ## Load tiff stack and visualize one field of view
 # EPY: END markdown
@@ -31,7 +24,7 @@ import pprint
 from starfish.io import Stack
 
 s = Stack()
-s.read('ISS/fov_001/experiment.json')
+s.read('https://dmf0bdeheu4zf.cloudfront.net/ISS/fov_001/experiment.json')
 # s.squeeze() simply converts the 4D tensor H*C*X*Y into a list of len(H*C) image planes for rendering by 'tile'
 tile(s.squeeze());  
 # EPY: END code
@@ -85,7 +78,7 @@ image(s.aux_dict['nuclei'])
 # EPY: END markdown
 
 # EPY: START code
-codebook = pd.read_csv('ISS/codebook.csv', dtype={'barcode': object})
+codebook = pd.read_csv('http://czi.starfish.data.public.s3-website-us-east-1.amazonaws.com/ISS/codebook.csv', dtype={'barcode': object})
 codebook.head(20)
 # EPY: END code
 


### PR DESCRIPTION
The stack is read fairly normally.  The codebook is currently sourced through a side channel, so I need to think of a better way to handle that. :)

Depends on #146 

You can look at s3://czi.starfish.data.public/ISS/ to see how to lay out your files (there's really nothing special, since #146 grants us the ability to resolve like a web browser)