### PR TITLE
pin slicedimage

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -6,4 +6,4 @@ regional
 requests
 scikit-image
 showit
-slicedimage
+-e git+https://github.com/spacetx/slicedimage.git@fda8e19a38a59246f4946024440c910852640c3a#egg=slicedimage


### PR DESCRIPTION
- pin git-based `slicedimage` requirement, use develop mode. 

Future PRs can regenerate with `pip3 freeze | grep slicedimage` to grab the currently installed version. 