### PR TITLE
osmFISH pipeline functions [Not for merging]

### DIFF
--- a/notebooks/simone_pipeline.md
+++ b/notebooks/simone_pipeline.md
@@ -1,0 +1,123 @@
+
+
+# Summary of Simone's pipeline
+
+## `process_standalone_experiment.py`
+
+This is primarily about munging files, and loads in `counting.filtering_and_counting` to do the work.
+
+### Arguments:
+
+1. path - path to experiment
+2. analysis name - prefix for experiment
+3. stringency (default 0) - ? TODO
+4. min-distance (default 5) - minimum distance between peaks
+5. min-plane (default None) - allows selection of a plane to start from (exclude out-of-focus)
+6. max-plane (default None) - allows selection of a plane to end at (exclude out-of-focus)
+
+## `counting.filtering_and_counting`:
+
+### Arguments:
+
+```
+fpath_img_to_filter: str
+path to the file to process
+filtered_png_img_gene_dirs: list
+list of the paths of the directories where the filtered images as are
+saved as pngs.
+filtered_img_gene_dirs: list
+list of the paths of the directories where the filtered images are saved
+as .npy.
+counting_gene_dirs: list
+list of the paths of the directories where the countings of the filtered
+images are saved.
+illumination_correction: bool
+if True the illumination correction is run on the dataset.
+plane_keep: list
+start and end point of the z-planes to keep. Default None
+keep all the planes (ex. [2,-3]).
+min_distance: int
+minimum distance between dots. (peaks)
+stringency: int
+stringency use to select the threshold used for counting. (default 0)
+skip_genes_counting: list
+list of the genes to skip for counting count.
+skip_tags_counting: list
+list of the tags inside the genes/stainings name to avoid to count.
+```
+
+
+Pipeline:
+
+Expects np.float64 images (how to address this? will everything work?)
+
+1. `filtering.nuclei_filtering`
+	1. called if this is in part of skip-genes, designed to skip nuclei, I think
+  2. 3d gaussian filter, sigma (2, 100, 100) (z, y, x?)  # todo check, not explicit
+  3. set negative values to zero
+  4. max project over z (np.amax(stack, axis=0)
+2. `filtering.smFISH_filtering`
+  1. Gaussian filter, sigma=(1, 8, 8)
+  2. `gaussian_laplace(stack, (0.2, 0.5, 0.5)`  # todo look up
+    3. this makes the peaks negative, so invert signal `img_stack = -img_stack`
+    4. ... and zero out the negative values again
+    5. max project over z `(np.amax(img_stack, axis=0)`
+3. `dots_calling.thr_calculator`
+  1. Counts dots across the whole image using `img_filtered` results, `min_distance`, and `stringency`
+
+### Thr Calculator
+
+This method calculates a threshold to determine if dots are peaks or not.
+
+Arguments:
+1. `min_distance`: if two peaks are not > 5 pixels apart they are the same peak
+2. stringency: higher stringency == higher threshold from `thr_array` to get peaks (tuning parameter)
+
+Returns:
+
+Lots of stuff in the form of a dictionary
+1. `selected_thr`: threshold for counting after application of stringency
+2. `calculated_thr`: threshold after all the trimming is calculated but before stringency application
+3. `selected_peaks`: 2d coordinates of the peaks
+4. `thr_array`: array of 100 points between Img.min() and Img.max(); this is a linspace between min and max
+5. `peaks_coords`: coordinates of peaks at each threshold value.
+6. `total peaks`: number of peaks at each threshold
+7. `thr_idx`: index of the calculated threshold (some value within Thr index)
+
+Procedure:
+- for each of 100 thresholds between min and max, call peaks with `peak_local_max`
+- when number of peaks is <= 3, stop
+- if there's only one section with > 3 peaks, return No peaks, else:
+- identify the threshold that was the stopping point
+- calculate the gradient of the number of peaks detected at each threshold
+- identify the minimum gradient value, and remove (1) all threshold values below that peak and all peaks before that value.
+- if there's at least one peak left:
+- create a line joining the ends of the gradient
+- get the distances of all points from the line
+- throw out the end points
+- throw out points from both ends == stringency value (simone thinks this method oversamples)
+- create a mask at the selected threshold (from before)
+- do some magic where a mask is examined for large and small objects (area < 6 or area > 200) which are removed
+
+```
+# Threshold the image using the selected threshold
+if selected_thr>0:
+		img_mask = filtered_img>selected_thr
+
+labels = nd.label(img_mask)[0]
+
+properties = measure.regionprops(labels)
+
+for ob in properties:
+		if ob.area<6 or ob.area>200:
+				img_mask[ob.coords[:,0],ob.coords[:,1]]=0
+
+labels = nd.label(img_mask)[0]
+selected_peaks = feature.peak_local_max(filtered_img, min_distance=min_distance, threshold_abs=selected_thr, exclude_border=False, indices=True, num_peaks=np.inf, footprint=None, labels=labels)
+```
+
+- then at the end, call `peak_local_max` on the `filtered_image` (original input to this function) with `threshold_abs` as selected threshold.
+- get intensites by extracting the values that correspond to the peaks returned by peak local max
+`selected_peaks_int = filtered_img[selected_peaks[:,0],selected_peaks[:,1]]`
+
+- then, convert the float image to uint16 and save the filtered image

--- a/notebooks/simone_pipeline.md
+++ b/notebooks/simone_pipeline.md
@@ -7,7 +7,7 @@
 	1. Can we assume that any trimming of the image to fit within the dynamic range should be associated with the function that produces the aberration? E.g. `gaussian_laplace` can produce negative values -- should we wrap that function so that it doesn't have this characteristic?
   2. If no, we will need some clean-up functions
 3. `max_projection` over z -> `starfish.image._stack` (currently present)
-4. Threshold finding (is there an equivalent library function for the gradient calculation + trimming that this func does? -> `starfish.stats.calculate_peak_threshold_abs`. Replace `calculate` with your favorite word.
+4. Threshold finding. Is there an equivalent library function for the gradient calculation + trimming that this func does? -> `starfish.stats.calculate_peak_threshold_abs`. Replace `calculate` with your favorite word.
 5. `peak_local_max` -> `starfish.spots.peakfinder` (location from brian-long)
 
 ## The pipeline:

--- a/notebooks/simone_smFISH.ipynb
+++ b/notebooks/simone_smFISH.ipynb
@@ -1,0 +1,188 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create an org.json, convert that to the new json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import json\n",
+    "import numpy as np\n",
+    "import glob\n",
+    "from skimage.io import imread, imsave\n",
+    "from collections import Counter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_dir = os.path.expanduser('~/google_drive/scratch/starfish/linnarsson/TIFF/series_1/')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metadata = {\n",
+    "    \"num_hybs\": 1,\n",
+    "    \"num_chs\": 2,\n",
+    "    \"shape\": [2048, 2048],\n",
+    "    \"is_volume\": True,\n",
+    "    \"format\": \"TIFF\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fluor_to_file_mapping = {\n",
+    "    \"c001\": 0,\n",
+    "    \"c002\": 1,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = []\n",
+    "for f in glob.glob(os.path.join(data_dir, '*.tif')):\n",
+    "    if 'c003' in f: \n",
+    "        continue  # DAPI\n",
+    "    _, _, suffix = f.partition('100X_')\n",
+    "    file_ = os.path.basename(f)\n",
+    "    z, ch = suffix.strip('.tif').split('_')\n",
+    "    data.append({\n",
+    "        \"hyb\": 0,\n",
+    "        \"ch\": fluor_to_file_mapping[ch],\n",
+    "        \"file\": file_,\n",
+    "        \"z\": int(z[1:]) - 1  # one based. I guess at some point I should just write a way to do this from the new spec. \n",
+    "    })"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# grab the dapi images and max_project them, then define that result\n",
+    "\n",
+    "# get all z-images\n",
+    "dapi_data = []\n",
+    "for f in glob.glob(os.path.join(data_dir, '*.tif')):\n",
+    "    if 'c003' in f: \n",
+    "        dapi_data.append(f)  # DAPI\n",
+    "    _, _, suffix = f.partition('100X_')\n",
+    "    file_ = os.path.basename(f)\n",
+    "    z, ch = suffix.strip('.tif').split('_')\n",
+    "\n",
+    "# concatenate them over z\n",
+    "np_data = [imread(f) for f in dapi_data]\n",
+    "x, y = np_data[0].shape\n",
+    "z = len(np_data)\n",
+    "volume = np.zeros((x, y, z), dtype=np_data[0].dtype)\n",
+    "for i, m in enumerate(np_data): \n",
+    "    volume[:, :, i] = m\n",
+    "\n",
+    "# take max over z\n",
+    "maxproj = np.max(volume, 2)\n",
+    "\n",
+    "# write result\n",
+    "imsave(os.path.join(data_dir, 'c003_max_projection.tif'), maxproj)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define the aux section\n",
+    "# fake this by just including one of them\n",
+    "aux = [\n",
+    "    {\n",
+    "        \"type\": \"dapi\",\n",
+    "        \"file\": os.path.join(data_dir, 'c003_max_projection.tif'),\n",
+    "        \"format\": \"TIFF\"\n",
+    "    }\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(os.path.join(data_dir, 'org.json'), 'w') as f:\n",
+    "    json.dump(dict(data=data, aux=aux, metadata=metadata), f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Load the new spec into Starfish"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from starfish.io import Stack"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s = Stack()\n",
+    "s.read(os.path.join(data_dir, 'experiment.json'))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Similar to the allen_smFISH notebook, the markdown file contains: 
1. an analysis of the parts of osmFISH pipeline
2. a suggestion about where they could fit into starfish
3. where relevant, an enumeration of basic parameters. 

I'm wondering if @dganguli has any suggestions about existing implementations of what I'm calling `calculate_peak_threshold_abs` (see `md` file, point 4 in `Overview of methods needed`)

The notebook is safe to ignore. 