### PR TITLE
add stack function apply method

### DIFF
--- a/starfish/image/_stack.py
+++ b/starfish/image/_stack.py
@@ -156,27 +156,27 @@ class ImageStack(ImageBase):
 
         return tuple(slice_list), axes
 
-    def _iter_indices(self, is_3d: bool=False) -> Iterator[Mapping[Indices, int]]:
-        """Iterate over indices of image tiles or image volumes if is_3d is True
+    def _iter_indices(self, is_volume: bool=False) -> Iterator[Mapping[Indices, int]]:
+        """Iterate over indices of image tiles or image volumes if is_volume is True
 
         Parameters
         ----------
-        is_3d, bool
-          if True, yield indices necessary to extract volumes from self, else return
-          indices for tiles
+        is_volume, bool
+            If True, yield indices necessary to extract volumes from self, else return
+            indices for tiles
 
         Yields
         ------
         Dict[str, int]
-          mapping of dimension name to index
+            Mapping of dimension name to index
 
         """
-        for hyb in numpy.arange(self.shape['hyb']):
-            for ch in numpy.arange(self.shape['ch']):
-                if is_3d:
+        for hyb in numpy.arange(self.shape[Indices.HYB]):
+            for ch in numpy.arange(self.shape[Indices.CH]):
+                if is_volume:
                     yield {Indices.HYB: hyb, Indices.CH: ch}
                 else:
-                    for z in numpy.arange(self.shape['z']):
+                    for z in numpy.arange(self.shape[Indices.Z]):
                         yield {Indices.HYB: hyb, Indices.CH: ch, Indices.Z: z}
 
     def _iter_tiles(
@@ -187,41 +187,41 @@ class ImageStack(ImageBase):
         Parameters
         ----------
         indices, Iterable[Mapping[str, int]]
-          iterable of indices that map a dimension (str) to a value (int)
+            Iterable of indices that map a dimension (str) to a value (int)
 
 
         Yields
         ------
         numpy.ndarray
-          numpy array that corresponds to provided indices
+            Numpy array that corresponds to provided indices
         """
         for inds in indices:
             array, axes = self.get_slice(inds)
             yield array
 
-    def apply(self, func, is_3d=False, **kwargs):
+    def apply(self, func, is_volume=False, **kwargs):
         """Apply func over all tiles or volumes in self
 
         Parameters
         ----------
-        func, Callable
-          function to apply. must expect a first argument which is a 2d or 3d numpy array (see is_3d) and return a
-          numpy.ndarray of the same shape
-        is_3d, bool
-          (default False) if True, pass 3d volumes (x, y, z) to func
-        inplace, bool
-          (default True) if True, function is executed in place. If n_proc is not 1, the tile or
-          volume will be copied once during execution
-        kwargs, dict
-          additional arguments to pass to func
+        func : Callable
+            Function to apply. must expect a first argument which is a 2d or 3d numpy array (see is_volume) and return a
+            numpy.ndarray. If inplace is True, must return an array of the same shape.
+        is_volume : bool
+            (default False) If True, pass 3d volumes (x, y, z) to func
+        inplace : bool
+            (default True) If True, function is executed in place. If n_proc is not 1, the tile or
+            volume will be copied once during execution. Not currently implemented.
+        kwargs : dict
+            Additional arguments to pass to func
 
         Returns
         -------
         Optional[ImageStack]
-          if inplace is False, return a new ImageStack containing the output of apply
+            If inplace is False, return a new ImageStack containing the output of apply
         """
         mapfunc = map  # TODO: ambrosejcarr posix-compliant multiprocessing
-        indices = list(self._iter_indices(is_3d=is_3d))
+        indices = list(self._iter_indices(is_volume=is_volume))
         tiles = self._iter_tiles(indices)
 
         applyfunc = partial(func, **kwargs)
@@ -234,7 +234,7 @@ class ImageStack(ImageBase):
         # TODO: ambrosejcarr implement inplace=False
 
     @property
-    def raw_shape(self) -> Optional[Tuple]:
+    def raw_shape(self) -> Optional[Tuple[int]]:
         if self._data is None:
             return None
 

--- a/starfish/image/_stack.py
+++ b/starfish/image/_stack.py
@@ -1,6 +1,7 @@
 import collections
 import os
-from typing import Any, Mapping, MutableSequence, Optional, Sequence, Tuple, Union
+from typing import Any, Iterable, Iterator, Mapping, MutableSequence, Optional, Sequence, Tuple, Union
+from functools import partial
 
 import numpy
 from slicedimage import Reader, Writer
@@ -154,6 +155,83 @@ class ImageStack(ImageBase):
                 axes.append(dimension_name)
 
         return tuple(slice_list), axes
+
+    def _iter_indices(self, is_3d: bool=False) -> Iterator[Mapping[Indices, int]]:
+        """Iterate over indices of image tiles or image volumes if is_3d is True
+
+        Parameters
+        ----------
+        is_3d, bool
+          if True, yield indices necessary to extract volumes from self, else return
+          indices for tiles
+
+        Yields
+        ------
+        Dict[str, int]
+          mapping of dimension name to index
+
+        """
+        for hyb in numpy.arange(self.shape['hyb']):
+            for ch in numpy.arange(self.shape['ch']):
+                if is_3d:
+                    yield {Indices.HYB: hyb, Indices.CH: ch}
+                else:
+                    for z in numpy.arange(self.shape['z']):
+                        yield {Indices.HYB: hyb, Indices.CH: ch, Indices.Z: z}
+
+    # TODO: ambrosejcarr this should support slices, too (e.g. all images for a channel)
+    def _iter_tiles(
+            self, indices: Iterable[Mapping[Indices, Union[int, slice]]]
+    ) -> Iterable[numpy.ndarray]:
+        """Given an iterable of indices, return a generator of numpy arrays from self.image
+
+        Parameters
+        ----------
+        indices, Iterable[Mapping[str, int]]
+          iterable of indices that map a dimension (str) to a value (int)
+
+
+        Yields
+        ------
+        numpy.ndarray
+          numpy array that corresponds to provided indices
+        """
+        for inds in indices:
+            array, axes = self.get_slice(inds)
+            yield array
+
+    def apply(self, func, is_3d=False, **kwargs):
+        """Apply func over all tiles or volumes in self
+
+        Parameters
+        ----------
+        func, Callable
+          function to apply. Must expect a first argument which is a 2d or 3d numpy array (see is_3d)
+        is_3d, bool
+          (default False) if True, pass 3d volumes (x, y, z) to func
+        inplace, bool
+          (default True) if True, function is executed in place. If n_proc is not 1, the tile or
+          volume will be copied once during execution
+        kwargs, dict
+          additional arguments to pass to func
+
+        Returns
+        -------
+        Optional[ImageStack]
+          if inplace is False, return a new ImageStack containing the output of apply
+        """
+        mapfunc = map  # TODO: posix-compliant multiprocessing
+        indices = list(self._iter_indices(is_3d=is_3d))
+        tiles = self._iter_tiles(indices)
+
+        applyfunc = partial(func, **kwargs)
+
+        results = mapfunc(applyfunc, tiles)
+
+        for r, inds in zip(results, indices):
+            self.set_slice(inds, r)
+
+        # todo implement inplace=False
 
     @property
     def raw_shape(self) -> Optional[list]:

--- a/starfish/image/_stack.py
+++ b/starfish/image/_stack.py
@@ -1,7 +1,7 @@
 import collections
 import os
-from typing import Any, Iterable, Iterator, Mapping, MutableSequence, Optional, Sequence, Tuple, Union
 from functools import partial
+from typing import Any, Iterable, Iterator, Mapping, MutableSequence, Optional, Sequence, Tuple, Union
 
 import numpy
 from slicedimage import Reader, Writer
@@ -179,7 +179,6 @@ class ImageStack(ImageBase):
                     for z in numpy.arange(self.shape['z']):
                         yield {Indices.HYB: hyb, Indices.CH: ch, Indices.Z: z}
 
-    # TODO: ambrosejcarr this should support slices, too (e.g. all images for a channel)
     def _iter_tiles(
             self, indices: Iterable[Mapping[Indices, Union[int, slice]]]
     ) -> Iterable[numpy.ndarray]:
@@ -206,7 +205,8 @@ class ImageStack(ImageBase):
         Parameters
         ----------
         func, Callable
-          function to apply. Must expect a first argument which is a 2d or 3d numpy array (see is_3d)
+          function to apply. must expect a first argument which is a 2d or 3d numpy array (see is_3d) and return a
+          numpy.ndarray of the same shape
         is_3d, bool
           (default False) if True, pass 3d volumes (x, y, z) to func
         inplace, bool
@@ -220,7 +220,7 @@ class ImageStack(ImageBase):
         Optional[ImageStack]
           if inplace is False, return a new ImageStack containing the output of apply
         """
-        mapfunc = map  # TODO: posix-compliant multiprocessing
+        mapfunc = map  # TODO: ambrosejcarr posix-compliant multiprocessing
         indices = list(self._iter_indices(is_3d=is_3d))
         tiles = self._iter_tiles(indices)
 
@@ -231,10 +231,10 @@ class ImageStack(ImageBase):
         for r, inds in zip(results, indices):
             self.set_slice(inds, r)
 
-        # todo implement inplace=False
+        # TODO: ambrosejcarr implement inplace=False
 
     @property
-    def raw_shape(self) -> Optional[list]:
+    def raw_shape(self) -> Optional[Tuple]:
         if self._data is None:
             return None
 

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -44,7 +44,7 @@ class TestSetSliceAPI(unittest.TestCase):
                         }
                     )
                     tile.numpy_array = numpy.ones(
-                            (TestSetSliceAPI.HEIGHT, TestSetSliceAPI.WIDTH))
+                        (TestSetSliceAPI.HEIGHT, TestSetSliceAPI.WIDTH))
 
                     img.add_tile(tile)
 
@@ -57,4 +57,3 @@ class TestSetSliceAPI(unittest.TestCase):
     def test_apply_3d(self):
         self.stack.apply(multiply, value=4, is_3d=True)
         assert (self.stack.numpy_array == 4).all()
-

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1,8 +1,7 @@
-import os
 import unittest
 
-from slicedimage import ImagePartition, Tile
 import numpy
+from slicedimage import ImagePartition, Tile
 
 from starfish.image import Coordinates, ImageStack, Indices
 

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -14,8 +14,8 @@ class TestSetSliceAPI(unittest.TestCase):
     NUM_HYB = 2
     NUM_CH = 3
     NUM_Z = 4
-    HEIGHT = 30
-    WIDTH = 20
+    Y = 30
+    X = 20
 
     def setUp(self):
         img = ImagePartition(
@@ -25,7 +25,7 @@ class TestSetSliceAPI(unittest.TestCase):
                 Indices.CH: TestSetSliceAPI.NUM_CH,
                 Indices.Z: TestSetSliceAPI.NUM_Z,
             },
-            default_tile_shape=(TestSetSliceAPI.HEIGHT, TestSetSliceAPI.WIDTH),
+            default_tile_shape=(TestSetSliceAPI.Y, TestSetSliceAPI.X),
         )
         for hyb in range(TestSetSliceAPI.NUM_HYB):
             for ch in range(TestSetSliceAPI.NUM_CH):
@@ -43,7 +43,7 @@ class TestSetSliceAPI(unittest.TestCase):
                         }
                     )
                     tile.numpy_array = numpy.ones(
-                        (TestSetSliceAPI.HEIGHT, TestSetSliceAPI.WIDTH))
+                        (TestSetSliceAPI.Y, TestSetSliceAPI.X))
 
                     img.add_tile(tile)
 
@@ -54,5 +54,5 @@ class TestSetSliceAPI(unittest.TestCase):
         assert (self.stack.numpy_array == 2).all()
 
     def test_apply_3d(self):
-        self.stack.apply(multiply, value=4, is_3d=True)
+        self.stack.apply(multiply, value=4, is_volume=True)
         assert (self.stack.numpy_array == 4).all()

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1,0 +1,60 @@
+import os
+import unittest
+
+from slicedimage import ImagePartition, Tile
+import numpy
+
+from starfish.image import Coordinates, ImageStack, Indices
+
+
+def multiply(array, value):
+    return array * value
+
+
+class TestSetSliceAPI(unittest.TestCase):
+    NUM_HYB = 2
+    NUM_CH = 3
+    NUM_Z = 4
+    HEIGHT = 30
+    WIDTH = 20
+
+    def setUp(self):
+        img = ImagePartition(
+            {Coordinates.X, Coordinates.Y, Indices.HYB, Indices.CH, Indices.Z},
+            {
+                Indices.HYB: TestSetSliceAPI.NUM_HYB,
+                Indices.CH: TestSetSliceAPI.NUM_CH,
+                Indices.Z: TestSetSliceAPI.NUM_Z,
+            },
+            default_tile_shape=(TestSetSliceAPI.HEIGHT, TestSetSliceAPI.WIDTH),
+        )
+        for hyb in range(TestSetSliceAPI.NUM_HYB):
+            for ch in range(TestSetSliceAPI.NUM_CH):
+                for z in range(TestSetSliceAPI.NUM_Z):
+                    tile = Tile(
+                        {
+                            Coordinates.X: (0.0, 0.001),
+                            Coordinates.Y: (0.0, 0.001),
+                            Coordinates.Z: (0.0, 0.001),
+                        },
+                        {
+                            Indices.HYB: hyb,
+                            Indices.CH: ch,
+                            Indices.Z: z,
+                        }
+                    )
+                    tile.numpy_array = numpy.ones(
+                            (TestSetSliceAPI.HEIGHT, TestSetSliceAPI.WIDTH))
+
+                    img.add_tile(tile)
+
+        self.stack = ImageStack(img)
+
+    def test_apply(self):
+        self.stack.apply(multiply, value=2)
+        assert (self.stack.numpy_array == 2).all()
+
+    def test_apply_3d(self):
+        self.stack.apply(multiply, value=4, is_3d=True)
+        assert (self.stack.numpy_array == 4).all()
+


### PR DESCRIPTION
- Adds `Stack.apply` which enables the iterative application of any 2d or 3d function to the data in Stack.numpy_array using the `get_slice` and `set_slice` API. 

- I excluded multiprocessing, but left a comment where the map function could be swapped out, when we have more confidence what our numpy back-end will look like. 