### PR TITLE
Remove import hack

### DIFF
--- a/tests/test_get_slice_api.py
+++ b/tests/test_get_slice_api.py
@@ -5,11 +5,6 @@ import unittest
 import numpy
 from slicedimage import ImagePartition, Tile
 
-
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
-sys.path.insert(0, pkg_root)  # noqa
-
-
 from starfish.image import Coordinates, ImageStack, Indices
 
 

--- a/tests/test_iss_data.py
+++ b/tests/test_iss_data.py
@@ -7,11 +7,6 @@ import sys
 import tempfile
 import unittest
 
-
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
-sys.path.insert(0, pkg_root)  # noqa
-
-
 from starfish.util import clock
 
 

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -3,11 +3,6 @@ import subprocess
 import sys
 import unittest
 
-
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
-sys.path.insert(0, pkg_root)  # noqa
-
-
 from starfish.starfish import PROFILER_NOOP_ENVVAR
 
 

--- a/tests/test_set_slice_api.py
+++ b/tests/test_set_slice_api.py
@@ -5,11 +5,6 @@ import unittest
 import numpy
 from slicedimage import ImagePartition, Tile
 
-
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
-sys.path.insert(0, pkg_root)  # noqa
-
-
 from starfish.image import Coordinates, ImageStack, Indices
 
 


### PR DESCRIPTION
This is necessary when users don't `pip install -e .`, but we recommend that in README.md.