### PR TITLE
remove from __future__ import

### DIFF
--- a/starfish/spots/gaussian.py
+++ b/starfish/spots/gaussian.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
@ambrosejcarr  is making me clean up the codebase.  this is removed because we dropped 2.7 support.