### PR TITLE
use **val(args) to call algorithm's constructor

### DIFF
--- a/starfish/pipeline/decoder/__init__.py
+++ b/starfish/pipeline/decoder/__init__.py
@@ -35,7 +35,7 @@ class Decoder(PipelineComponent):
             cls.decoder_group.print_help()
             cls.decoder_group.exit(status=2)
 
-        instance = args.decoder_algorithm_class.from_cli_args(args)
+        instance = args.decoder_algorithm_class(**vars(args))
 
         encoded = pandas.read_json(args.input, orient="records")
         codebook = pandas.read_json(args.codebook, orient="records")

--- a/starfish/pipeline/decoder/_base.py
+++ b/starfish/pipeline/decoder/_base.py
@@ -1,15 +1,5 @@
 class DecoderAlgorithmBase(object):
     @classmethod
-    def from_cli_args(cls, args):
-        """
-        Given parsed arguments, construct an instance of this decoder algorithm.
-
-        Generally, this involves retrieving the appropriate attributes from args to pass to the decoder algorithm's
-        constructor.
-        """
-        raise NotImplementedError()
-
-    @classmethod
     def get_algorithm_name(cls):
         """
         Returns the name of the algorithm.  This should be a valid python identifier, i.e.,

--- a/starfish/pipeline/decoder/iss.py
+++ b/starfish/pipeline/decoder/iss.py
@@ -2,9 +2,8 @@ from ._base import DecoderAlgorithmBase
 
 
 class IssDecoder(DecoderAlgorithmBase):
-    @classmethod
-    def from_cli_args(cls, args):
-        return IssDecoder()
+    def __init__(self, **kwargs):
+        pass
 
     @classmethod
     def get_algorithm_name(cls):

--- a/starfish/pipeline/gene_assignment/__init__.py
+++ b/starfish/pipeline/gene_assignment/__init__.py
@@ -44,7 +44,7 @@ class GeneAssignment(PipelineComponent):
 
         spots = pandas.read_json(args.spots_json, orient="records")
 
-        instance = args.gene_assignment_algorithm_class.from_cli_args(args)
+        instance = args.gene_assignment_algorithm_class(**vars(args))
 
         result = instance.assign_genes(spots, regions)
 

--- a/starfish/pipeline/gene_assignment/_base.py
+++ b/starfish/pipeline/gene_assignment/_base.py
@@ -1,15 +1,5 @@
 class GeneAssignmentAlgorithm(object):
     @classmethod
-    def from_cli_args(cls, args):
-        """
-        Given parsed arguments, construct an instance of this gene_assignment algorithm.
-
-        Generally, this involves retrieving the appropriate attributes from args to pass to the gene_assignment
-        algorithm's constructor.
-        """
-        raise NotImplementedError()
-
-    @classmethod
     def get_algorithm_name(cls):
         """
         Returns the name of the algorithm.  This should be a valid python identifier, i.e.,

--- a/starfish/pipeline/gene_assignment/point_in_poly.py
+++ b/starfish/pipeline/gene_assignment/point_in_poly.py
@@ -2,9 +2,8 @@ from ._base import GeneAssignmentAlgorithm
 
 
 class PointInPoly(GeneAssignmentAlgorithm):
-    @classmethod
-    def from_cli_args(cls, args):
-        return PointInPoly()
+    def __init__(self, **kwargs):
+        pass
 
     @classmethod
     def get_algorithm_name(cls):

--- a/starfish/pipeline/registration/__init__.py
+++ b/starfish/pipeline/registration/__init__.py
@@ -32,7 +32,7 @@ class Registration(PipelineComponent):
             cls.register_group.print_help()
             cls.register_group.exit(status=2)
 
-        instance = args.registration_algorithm_class.from_cli_args(args)
+        instance = args.registration_algorithm_class(**vars(args))
 
         from starfish.io import Stack
 

--- a/starfish/pipeline/registration/_base.py
+++ b/starfish/pipeline/registration/_base.py
@@ -1,15 +1,5 @@
 class RegistrationAlgorithmBase(object):
     @classmethod
-    def from_cli_args(cls, args):
-        """
-        Given parsed arguments, construct an instance of this registration algorithm.
-
-        Generally, this involves retrieving the appropriate attributes from args to pass to the registration algorithm's
-        constructor.
-        """
-        raise NotImplementedError()
-
-    @classmethod
     def get_algorithm_name(cls):
         """
         Returns the name of the algorithm.  This should be a valid python identifier, i.e.,

--- a/starfish/pipeline/registration/fourier_shift.py
+++ b/starfish/pipeline/registration/fourier_shift.py
@@ -6,13 +6,8 @@ class FourierShiftRegistration(RegistrationAlgorithmBase):
     """
     Implements fourier shift registration.  TODO: (dganguli) FILL IN DETAILS HERE PLS.
     """
-
-    def __init__(self, upsampling):
+    def __init__(self, upsampling, **kwargs):
         self.upsampling = upsampling
-
-    @classmethod
-    def from_cli_args(cls, args):
-        return FourierShiftRegistration(args.u)
 
     @classmethod
     def get_algorithm_name(cls):
@@ -20,7 +15,7 @@ class FourierShiftRegistration(RegistrationAlgorithmBase):
 
     @classmethod
     def add_arguments(cls, group_parser):
-        group_parser.add_argument("--u", default=1, type=int, help="Amount of up-sampling")
+        group_parser.add_argument("--upsampling", default=1, type=int, help="Amount of up-sampling")
 
     def register(self, stack):
         # TODO: (ambrosejcarr) is this the appropriate way of dealing with Z in registration?

--- a/tests/test_iss_data.py
+++ b/tests/test_iss_data.py
@@ -39,7 +39,7 @@ class TestWithIssData(unittest.TestCase):
             "--input", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "formatted", "experiment.json"),
             "--output", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "registered"),
             "fourier_shift",
-            "--u", "1000",
+            "--upsampling", "1000",
         ],
         [
             "starfish", "filter",


### PR DESCRIPTION
Upside: we can get rid of the `from_cli_args` call.  Downside: every algorithm's constructor is required to have `**kwargs`.