### PR TITLE
[easy] Fix shape and raw_shape.

### DIFF
--- a/starfish/image/_base.py
+++ b/starfish/image/_base.py
@@ -1,4 +1,5 @@
-from typing import Optional
+import collections
+from typing import Tuple
 
 
 class ImageBase(object):
@@ -8,12 +9,12 @@ class ImageBase(object):
         raise NotImplementedError()
 
     @property
-    def raw_shape(self) -> Optional[list]:
+    def raw_shape(self) -> Tuple[int]:
         """Retrieves the shape of the image data, as a list of the sizes of the indices."""
         raise NotImplementedError()
 
     @property
-    def shape(self):
+    def shape(self) -> collections.OrderedDict:
         """Retrieves the shape of the image data, as an ordered mapping between index names to the size of the index."""
         raise NotImplementedError()
 

--- a/starfish/image/_stack.py
+++ b/starfish/image/_stack.py
@@ -234,17 +234,14 @@ class ImageStack(ImageBase):
         # TODO: ambrosejcarr implement inplace=False
 
     @property
-    def raw_shape(self) -> Optional[Tuple[int]]:
-        if self._data is None:
-            return None
-
+    def raw_shape(self) -> Tuple[int]:
         return self._data.shape
 
     @property
-    def shape(self) -> Optional[dict]:
-        if self._data is None:
-            return None
-
+    def shape(self) -> collections.OrderedDict:
+        # TODO: (ttung) Note that the return type should be ..OrderedDict[Any, str], but python3.6 has a bug where this
+        # breaks horribly.  Can't find a bug id to link to, but see
+        # https://stackoverflow.com/questions/41207128/how-do-i-specify-ordereddict-k-v-types-for-mypy-type-annotation
         result = collections.OrderedDict()  # type: collections.OrderedDict[Any, str]
         for name, idx in ImageStack.AXES_MAP.items():
             result[name] = self._data.shape[idx]


### PR DESCRIPTION
1. _data is always set, so we can get rid of the escape clauses for them being None.
2. Fix type annotations to match.
3. Fix type annotations in base class.