### PR TITLE
add nuclei parameter

### DIFF
--- a/starfish/pipeline/segmentation/watershed.py
+++ b/starfish/pipeline/segmentation/watershed.py
@@ -6,10 +6,11 @@ class Watershed(SegmentationAlgorithmBase):
     """
     Implements watershed segmentation.  TODO: (dganguli) FILL IN DETAILS HERE PLS.
     """
-    def __init__(self, dapi_threshold, input_threshold, min_distance, **kwargs):
+    def __init__(self, dapi_threshold, input_threshold, min_distance, auxiliary_nuclei_image_key, **kwargs):
         self.dapi_threshold = dapi_threshold
         self.input_threshold = input_threshold
         self.min_distance = min_distance
+        self.auxiliary_nuclei_image_key = auxiliary_nuclei_image_key
 
     @classmethod
     def get_algorithm_name(cls):
@@ -20,6 +21,8 @@ class Watershed(SegmentationAlgorithmBase):
         group_parser.add_argument("--dapi-threshold", default=.16, type=float, help="DAPI threshold")
         group_parser.add_argument("--input-threshold", default=.22, type=float, help="Input threshold")
         group_parser.add_argument("--min-distance", default=57, type=int, help="Minimum distance between cells")
+        group_parser.add_argument("--auxiliary-nuclei-image-key", default='nuclei',
+                                  help='Optional. Provides an alternative name for the nuclei images (dots, dapi, etc)')
 
     def segment(self, stack):
         import numpy as np
@@ -36,7 +39,7 @@ class Watershed(SegmentationAlgorithmBase):
         disk_size_markers = None
         disk_size_mask = None
 
-        seg = WatershedSegmenter(stack.aux_dict['nuclei'], stain)
+        seg = WatershedSegmenter(stack.aux_dict[self.auxiliary_nuclei_image_key], stain)
         cells_labels = seg.segment(
             self.dapi_threshold, self.input_threshold, size_lim, disk_size_markers, disk_size_mask, self.min_distance)
 


### PR DESCRIPTION
- Different pipelines call the nuclei different things. Adds flexibility for watershed to support this. 