### PR TITLE
[auximg 5/13] [easy] Add dots as a possible auxiliary image

### DIFF
--- a/examples/build_sample_experiment.py
+++ b/examples/build_sample_experiment.py
@@ -17,6 +17,7 @@ from starfish.util.argparse import FsExistsType
 
 AUX_IMAGE_NAMES = {
     'nuclei',
+    'dots',
 }
 
 


### PR DESCRIPTION
The build_sample_experiment.py tool could possibly generate the data required for get_iss_data.py.