### PR TITLE
[auximg 6/13] [easy] allow assignments from lambdas

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length=120
-ignore: E301, E302, E305, E401, F401
+ignore: E301, E302, E305, E401, F401, E731


### PR DESCRIPTION
This allows statements like

```
x = lambda: 1
```

flake8 is asking that we do:

```
def x():
    return 1
```