### PR TITLE
[auximg 11/13] move default tile shape to be configured at the experiment level.

### DIFF
--- a/examples/support/__init__.py
+++ b/examples/support/__init__.py
@@ -107,7 +107,7 @@ class RandomNoiseImageFetcher(ImageFetcher):
         return RandomNoiseImage()
 
 
-def build_image(fov_count, hyb_count, ch_count, z_count, image_fetcher: ImageFetcher, default_shape=(1536, 1024)):
+def build_image(fov_count, hyb_count, ch_count, z_count, image_fetcher: ImageFetcher, default_shape: Tuple[int, int]):
     """
     Build and returns an image set with the following characteristics:
 
@@ -168,6 +168,7 @@ def write_experiment_json(
         hyb_image_fetcher=None,
         aux_image_fetcher=None,
         postprocess_func=None,
+        default_shape=(1536, 1024),
 ):
     """
     Build and returns a top-level experiment description with the following characteristics:
@@ -193,6 +194,8 @@ def write_experiment_json(
         If provided, this is called with the experiment document for any postprocessing.  An example of this would be to
         add something to one of the top-level extras field.  The callable should return what is to be written as the
         experiment document.
+    default_shape : Tuple[int, int]
+        Default shape for the tiles in this experiment.
     """
     if hyb_image_fetcher is None:
         hyb_image_fetcher = RandomNoiseImageFetcher()
@@ -209,7 +212,9 @@ def write_experiment_json(
     hybridization_image = build_image(
         fov_count,
         hyb_dimensions[Indices.HYB], hyb_dimensions[Indices.CH], hyb_dimensions[Indices.Z],
-        hyb_image_fetcher)
+        hyb_image_fetcher,
+        default_shape=default_shape,
+    )
     Writer.write_to_path(
         hybridization_image,
         os.path.join(path, "hybridization.json"),
@@ -226,7 +231,8 @@ def write_experiment_json(
         auxiliary_image = build_image(
             fov_count,
             aux_dimensions[Indices.HYB], aux_dimensions[Indices.CH], aux_dimensions[Indices.Z],
-            aux_image_fetcher.get(aux_name, RandomNoiseImageFetcher())
+            aux_image_fetcher.get(aux_name, RandomNoiseImageFetcher()),
+            default_shape=default_shape,
         )
         Writer.write_to_path(
             auxiliary_image,


### PR DESCRIPTION
This allows callers of `build_image(..)` to provide the tile shape.

Depends on #214 