### PR TITLE
Ajc doc gather

### DIFF
--- a/starfish/pipeline/features/spots/detector/gaussian.py
+++ b/starfish/pipeline/features/spots/detector/gaussian.py
@@ -5,7 +5,7 @@ import pandas as pd
 from skimage.feature import blob_log
 
 from starfish.constants import Indices
-from starfish.munge import gather
+from starfish.munge import melt
 from starfish.pipeline.features.encoded_spots import EncodedSpots
 from starfish.pipeline.features.spot_attributes import SpotAttributes
 from ._base import SpotFinderAlgorithmBase
@@ -77,8 +77,12 @@ class GaussianSpotDetector(SpotFinderAlgorithmBase):
 
         res = pd.DataFrame(d)
 
-        res = gather(res, 'barcode_index', 'intensity', inds)  # TODO ambrosejcarr this produces an object
-        res = res.infer_objects()
+        res: pd.DataFrame = melt(
+            df=res,
+            new_index_name='barcode_index',
+            new_value_name='intensity',
+            melt_columns=inds
+        )
         res = pd.merge(res, mapping, on='barcode_index', how='left')
         return EncodedSpots(res)
 

--- a/starfish/spots/binary.py
+++ b/starfish/spots/binary.py
@@ -4,7 +4,7 @@ import pandas as pd
 import scipy.ndimage.measurements as spm
 from showit import image
 
-from starfish.munge import gather
+from starfish.munge import melt
 from starfish.pipeline.filter.util import bin_thresh
 from starfish.stats import label_to_regions, measure_stack
 
@@ -61,7 +61,12 @@ class BinarySpotDetector:
         res = pd.DataFrame(d)
 
         if tidy_flag:
-            res = gather(res, 'hybs', 'vals', cols)
+            res = melt(
+                df=res,
+                new_index_name='hybs',
+                new_value_name='vals',
+                melt_columns=cols
+            )
 
         self.spots_df = res
 

--- a/starfish/spots/pixel.py
+++ b/starfish/spots/pixel.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from starfish.munge import gather
+from starfish.munge import melt
 
 
 class PixelSpotDetector:
@@ -14,13 +14,19 @@ class PixelSpotDetector:
     def detect(self):
 
         sq = self.stack.squeeze()
-        num_bits = self.stack.tile_metadata['barcode_index'].max() + 1
+        num_bits = int(self.stack.tile_metadata['barcode_index'].max() + 1)
 
+        # linearize the pixels, mat.shape = (n_hybs * n_channels * n_z_slice, x * y)
         mat = np.reshape(sq.copy(), (sq.shape[0], sq.shape[1] * sq.shape[2]))
 
         res = pd.DataFrame(mat.T)
         res['spot_id'] = range(len(res))
-        res = gather(res, 'barcode_index', 'intensity', range(num_bits.astype(int)))
+        res = melt(
+            df=res,
+            new_index_name='barcode_index',
+            new_value_name='intensity',
+            melt_columns=range(num_bits)
+        )
         spots_df_tidy = pd.merge(res, self.stack.tile_metadata, on='barcode_index', how='left')
 
         return spots_df_tidy


### PR DESCRIPTION
- Add docstring to `munge.gather`
- Rename `gather -> melt` since that's what it's calling
- Clarify how args relate to `pd.melt`, that it wraps. 
- Use kwargs when calling melt to clarify outcome of calling the function. 

N.B.  `starfish/spots/gaussian.py` is unchanged because it's vestigial and removed in #222 