### PR TITLE
Convert to float64 before white top hat filter

### DIFF
--- a/starfish/pipeline/filter/white_tophat.py
+++ b/starfish/pipeline/filter/white_tophat.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from ._base import FilterAlgorithmBase
 
 
@@ -47,7 +49,7 @@ class WhiteTophat(FilterAlgorithmBase):
             structuring_element = disk(self.disk_size)
             min_filtered = minimum_filter(image, footprint=structuring_element)
             max_filtered = maximum_filter(min_filtered, footprint=structuring_element)
-            filtered_image = image - max_filtered
+            filtered_image = image - np.minimum(image, max_filtered)
             return filtered_image
 
         stack.image.apply(white_tophat)


### PR DESCRIPTION
White top hat filter can generate negative values, and if it's an uint type, it will wrap around.  Raise the threshold for spot detection.

Depends on #242 