### PR TITLE
[ENH] Enable 3-d support for gaussian high-pass

### DIFF
--- a/starfish/pipeline/filter/gaussian_high_pass.py
+++ b/starfish/pipeline/filter/gaussian_high_pass.py
@@ -1,9 +1,12 @@
 import argparse
 from functools import partial
-from typing import Callable, Optional
+from numbers import Number
+from typing import Callable, Union, Tuple, Optional
 
 import numpy as np
+from skimage import img_as_uint
 
+from starfish.errors import DataFormatWarning
 from starfish.image import ImageStack
 from starfish.pipeline.filter.gaussian_low_pass import GaussianLowPass
 from ._base import FilterAlgorithmBase
@@ -11,47 +14,70 @@ from ._base import FilterAlgorithmBase
 
 class GaussianHighPass(FilterAlgorithmBase):
 
-    def __init__(self, sigma, **kwargs) -> None:
+    def __init__(
+            self, sigma: Union[Number, Tuple[Number]], is_volume: bool=False, verbose: bool=False, **kwargs
+    ) -> None:
         """Gaussian high pass filter
 
         Parameters
         ----------
-        sigma : int (default = 1)
+        sigma : Union[Number, Tuple[Number]]
             standard deviation of gaussian kernel
+        is_volume : bool
+            If True, 3d (z, y, x) volumes will be filtered, otherwise, filter 2d tiles independently.
+        verbose : bool
+            if True, report on filtering progress (default = False)
 
         """
+        if isinstance(sigma, tuple):
+            message = ("if passing an anisotropic kernel, the dimensionality must match the data shape ({shape}), not "
+                       "{passed_shape}")
+            if is_volume and len(sigma) != 3:
+                raise ValueError(message.format(shape=3, passed_shape=len(sigma)))
+            if not is_volume and len(sigma) != 2:
+                raise ValueError(message.format(shape=2, passed_shape=len(sigma)))
+
         self.sigma = sigma
+        self.is_volume = is_volume
+        self.verbose = verbose
 
     @classmethod
     def add_arguments(cls, group_parser: argparse.ArgumentParser) -> None:
         group_parser.add_argument(
-            "--sigma", default=1, type=int, help="standard deviation of gaussian kernel")
+            "--sigma", type=float, help="standard deviation of gaussian kernel")
+        group_parser.add_argument(
+            "--is-volume", action="store_true", help="indicates that the image stack should be filtered in 3d")
 
     @staticmethod
-    def gaussian_high_pass(img: np.ndarray, sigma) -> np.ndarray:
+    def high_pass(image: np.ndarray, sigma: Union[Number, Tuple[Number]]) -> np.ndarray:
         """
         Applies a gaussian high pass filter to an image
 
         Parameters
         ----------
-        img : numpy.ndarray
-            Image to filter
-        sigma : Union[float, int]
+        image : numpy.ndarray[np.uint32]
+            2-d or 3-d image data
+        sigma : Union[Number, Tuple[Number]]
             Standard deviation of gaussian kernel
 
         Returns
         -------
-        numpy.ndarray :
-            Filtered image, same shape as input
+        np.ndarray :
+            Standard deviation of the Gaussian kernel that will be applied. If a float, an isotropic kernel will be
+            assumed, otherwise the dimensions of the kernel give (z, y, x)
 
         """
-        blurred: np.ndarray = GaussianLowPass.low_pass(img, sigma)
+        if image.dtype != np.uint16:
+            DataFormatWarning('gaussian filters currently only support uint16 images. Image data will be converted.')
+            image = img_as_uint(image)
 
-        over_flow_ind: np.ndarray[bool] = img < blurred
-        res: np.ndarray = img - blurred
-        res[over_flow_ind] = 0
+        blurred: np.ndarray = GaussianLowPass.low_pass(image, sigma)
 
-        return res
+        over_flow_ind: np.ndarray[bool] = image < blurred
+        filtered: np.ndarray = image - blurred
+        filtered[over_flow_ind] = 0
+
+        return filtered
 
     def filter(self, stack: ImageStack, in_place: bool=True) -> Optional[ImageStack]:
         """Perform filtering of an image stack
@@ -69,8 +95,8 @@ class GaussianHighPass(FilterAlgorithmBase):
             if in-place is False, return the results of filter as a new stack
 
         """
-        high_pass: Callable = partial(self.gaussian_high_pass, sigma=self.sigma)
-        result = stack.apply(high_pass, in_place=in_place)
+        high_pass: Callable = partial(self.high_pass, sigma=self.sigma)
+        result = stack.apply(high_pass, is_volume=self.is_volume, verbose=self.verbose, in_place=in_place)
         if not in_place:
             return result
         return None

--- a/starfish/test/pipeline/test_filter.py
+++ b/starfish/test/pipeline/test_filter.py
@@ -1,3 +1,4 @@
+from numbers import Number
 from typing import Tuple, Union
 
 import numpy as np
@@ -9,7 +10,7 @@ from starfish.pipeline.filter import gaussian_high_pass
 
 
 @pytest.mark.parametrize('sigma', (1, (1, 1)))
-def test_gaussian_high_pass(merfish_stack: Stack, sigma: Union[int, Tuple[int]]):
+def test_gaussian_high_pass(merfish_stack: Stack, sigma: Union[Number, Tuple[Number]]):
     """high pass is subtractive, sum of array should be less after running
 
     Parameters
@@ -26,9 +27,18 @@ def test_gaussian_high_pass(merfish_stack: Stack, sigma: Union[int, Tuple[int]])
 
 
 @pytest.mark.parametrize('sigma', (1, (1, 1)))
-def test_gaussian_high_pass_apply(merfish_stack: Stack, sigma: Union[int, Tuple[int]]):
+def test_gaussian_high_pass_apply(merfish_stack: Stack, sigma: Union[Number, Tuple[Number]]):
     """same as test_gaussian_high_pass, but tests apply loop functionality"""
     sum_before = np.sum(merfish_stack.image.numpy_array)
     ghp = gaussian_high_pass.GaussianHighPass(sigma=sigma)
+    ghp.filter(merfish_stack.image)
+    assert np.sum(merfish_stack.image.numpy_array) < sum_before
+
+
+@pytest.mark.parametrize('sigma', (1, (1, 0, 1)))
+def test_gaussian_high_pass_apply_3d(merfish_stack: Stack, sigma: Union[Number, Tuple[Number]]):
+    """same as test_gaussian_high_pass, but tests apply loop functionality"""
+    sum_before = np.sum(merfish_stack.image.numpy_array)
+    ghp = gaussian_high_pass.GaussianHighPass(sigma=sigma, is_volume=True)
     ghp.filter(merfish_stack.image)
     assert np.sum(merfish_stack.image.numpy_array) < sum_before


### PR DESCRIPTION
- Makes `gaussian_high_pass` and `gaussian_low_pass` consistent
- Fixes typing through use of `Number`
- Adds 3D support for gaussian_high_pass (`osmFISH` needs it)
- Adds a test for new functionality