### PR TITLE
Write relative paths correctly when writing experiment.json

### DIFF
--- a/starfish/io.py
+++ b/starfish/io.py
@@ -71,7 +71,7 @@ class Stack:
     def _write_stack(self, dir_name):
         stack_path = os.path.join(dir_name, "hybridization.json")
         self.image.write(stack_path)
-        self.org['hybridization_images'] = stack_path
+        self.org['hybridization_images'] = "hybridization.json"
 
     def _write_aux(self, dir_name):
         for aux_key, aux_data in self.org['auxiliary_images'].items():


### PR DESCRIPTION
If stack.write(..) gets an absolute path, then experiment.json['hybridization'] is an absolute path and everything works.  However, if stack.write(..) gets a relative path, then experiment.json['hybridization'] gets the relative path twice -- once from the baseurl, and once from the written entry.

This resolves the bug by always treating everything as relative paths.