### PR TITLE
Fix the dtype test.

### DIFF
--- a/starfish/image/_stack.py
+++ b/starfish/image/_stack.py
@@ -88,21 +88,11 @@ class ImageStack:
             zlayer = tile.indices.get(Indices.Z, 0)
             data = tile.numpy_array
             if max_size != data.dtype.itemsize:
-                # this source tile has a smaller data size than the other ones, though the same kind.  need to scale the
-                # data.
-                if data.dtype.kind == "f":
-                    # floating point can be done with numpy.interp.
-                    src_finfo = numpy.finfo(data.dtype)
-                    dst_finfo = numpy.finfo(self._data.dtype)
-                    data = numpy.interp(
-                        data,
-                        (src_finfo.min, src_finfo.max),
-                        (dst_finfo.min, dst_finfo.max))
-                else:
+                if data.dtype.kind == "i" or data.dtype.kind == "u":
                     # fixed point can be done with a simple multiply.
-                    src_max = numpy.iinfo(data.dtype).max
-                    dst_max = numpy.iinfo(self._data.dtype).max
-                    data = data * (dst_max / src_max)
+                    src_range = numpy.iinfo(data.dtype).max - numpy.iinfo(data.dtype).min + 1
+                    dst_range = numpy.iinfo(self._data.dtype).max - numpy.iinfo(self._data.dtype).min + 1
+                    data = data * (dst_range / src_range)
                 warn(
                     f"Tile "
                     f"(H: {tile.indices[Indices.HYB]} C: {tile.indices[Indices.CH]} Z: {tile.indices[Indices.Z]}) has "

--- a/starfish/test/image/test_slicedimage_dtype.py
+++ b/starfish/test/image/test_slicedimage_dtype.py
@@ -42,7 +42,10 @@ def create_tile_data_provider(dtype: numpy.number, corner_dtype: numpy.number):
 def test_multiple_tiles_of_different_kind(synthetic_stack_factory):
     with pytest.raises(TypeError):
         synthetic_stack_factory(
-            tile_data_provider=create_tile_data_provider(numpy.uint32, numpy.float32))
+            NUM_HYB, NUM_CH, NUM_Z,
+            HEIGHT, WIDTH,
+            tile_data_provider=create_tile_data_provider(numpy.uint32, numpy.float32),
+        )
 
 
 def test_multiple_tiles_of_same_dtype(synthetic_stack_factory):
@@ -51,7 +54,13 @@ def test_multiple_tiles_of_same_dtype(synthetic_stack_factory):
         HEIGHT, WIDTH,
         tile_data_provider=create_tile_data_provider(numpy.uint32, numpy.uint32),
     )
-    assert stack.numpy_array.all() == 1
+    expected = numpy.ones(
+        (NUM_HYB,
+         NUM_CH,
+         NUM_Z,
+         HEIGHT,
+         WIDTH), dtype=numpy.uint32)
+    assert numpy.array_equal(stack.numpy_array, expected)
 
 
 def test_int_type_promotion(synthetic_stack_factory):
@@ -63,18 +72,41 @@ def test_int_type_promotion(synthetic_stack_factory):
         )
         assert len(w) == 1
         assert issubclass(w[0].category, DataFormatWarning)
-    expected = numpy.empty(
+    expected = numpy.ones(
         (NUM_HYB,
          NUM_CH,
          NUM_Z,
          HEIGHT,
          WIDTH), dtype=numpy.int32)
-    expected.fill(16777216)
-    corner = numpy.ones(
+    corner = numpy.empty(
         (HEIGHT,
          WIDTH), dtype=numpy.int32)
+    corner.fill(16777216)
     expected[0, 0, 0] = corner
-    assert stack.numpy_array.all() == expected.all()
+    assert numpy.array_equal(stack.numpy_array, expected)
+
+
+def test_uint_type_promotion(synthetic_stack_factory):
+    with warnings.catch_warnings(record=True) as w:
+        stack = synthetic_stack_factory(
+            NUM_HYB, NUM_CH, NUM_Z,
+            HEIGHT, WIDTH,
+            tile_data_provider=create_tile_data_provider(numpy.uint32, numpy.uint8),
+        )
+        assert len(w) == 1
+        assert issubclass(w[0].category, DataFormatWarning)
+    expected = numpy.ones(
+        (NUM_HYB,
+         NUM_CH,
+         NUM_Z,
+         HEIGHT,
+         WIDTH), dtype=numpy.uint32)
+    corner = numpy.empty(
+        (HEIGHT,
+         WIDTH), dtype=numpy.uint32)
+    corner.fill(16777216)
+    expected[0, 0, 0] = corner
+    assert numpy.array_equal(stack.numpy_array, expected)
 
 
 def test_float_type_promotion(synthetic_stack_factory):
@@ -86,15 +118,10 @@ def test_float_type_promotion(synthetic_stack_factory):
         )
         assert len(w) == 1
         assert issubclass(w[0].category, DataFormatWarning)
-    expected = numpy.empty(
+    expected = numpy.ones(
         (NUM_HYB,
          NUM_CH,
          NUM_Z,
          HEIGHT,
-         WIDTH), dtype=numpy.int64)
-    expected.fill(2.0)
-    corner = numpy.ones(
-        (HEIGHT,
-         WIDTH), dtype=numpy.int64)
-    expected[0, 0, 0] = corner
-    assert stack.numpy_array.all() == expected.all()
+         WIDTH), dtype=numpy.float64)
+    assert numpy.array_equal(stack.numpy_array, expected)


### PR DESCRIPTION
1. Actually test the data rather than calling all().  I completely misunderstood what that function does.
2. Add a uint test (separate from int)
3. Fix how fixed-point scaling works.  It should multiply by the difference in the ranges, not the max.
4. Change how floating point scaling works (it does not interpolate the range any more).

Depends on #271 