### PR TITLE
Remove the indirection for the synthetic stack factory

### DIFF
--- a/starfish/test/dataset_fixtures.py
+++ b/starfish/test/dataset_fixtures.py
@@ -50,58 +50,51 @@ DEFAULT_HEIGHT = 30
 DEFAULT_WIDTH = 20
 
 
-@pytest.fixture(scope='session')
-def synthetic_stack_factory():
+def synthetic_stack(
+        num_hyb: int=DEFAULT_NUM_HYB,
+        num_ch: int=DEFAULT_NUM_CH,
+        num_z: int=DEFAULT_NUM_Z,
+        tile_height: int=DEFAULT_HEIGHT,
+        tile_width: int=DEFAULT_WIDTH,
+        tile_data_provider: Callable[[int, int, int, int, int], np.ndarray]=default_tile_data_provider,
+        tile_extras_provider: Callable[[int, int, int], Any]=default_tile_extras_provider
+) -> ImageStack:
+    """generate a synthetic ImageStack
+
+    Returns
+    -------
+    ImageStack :
+        imagestack containing a tensor of (2, 3, 4, 30, 20) whose values are all 1.
+
     """
-    Inject this factory, which is a method to produce image stacks.
-    """
-    def synthetic_stack(
-            num_hyb: int=DEFAULT_NUM_HYB,
-            num_ch: int=DEFAULT_NUM_CH,
-            num_z: int=DEFAULT_NUM_Z,
-            tile_height: int=DEFAULT_HEIGHT,
-            tile_width: int=DEFAULT_WIDTH,
-            tile_data_provider: Callable[[int, int, int, int, int], np.ndarray]=default_tile_data_provider,
-            tile_extras_provider: Callable[[int, int, int], Any]=default_tile_extras_provider
-    ) -> ImageStack:
-        """generate a synthetic ImageStack
+    img = TileSet(
+        {Coordinates.X, Coordinates.Y, Indices.HYB, Indices.CH, Indices.Z},
+        {
+            Indices.HYB: num_hyb,
+            Indices.CH: num_ch,
+            Indices.Z: num_z,
+        },
+        default_tile_shape=(tile_height, tile_width),
+    )
+    for hyb in range(num_hyb):
+        for ch in range(num_ch):
+            for z in range(num_z):
+                tile = Tile(
+                    {
+                        Coordinates.X: (0.0, 0.001),
+                        Coordinates.Y: (0.0, 0.001),
+                        Coordinates.Z: (0.0, 0.001),
+                    },
+                    {
+                        Indices.HYB: hyb,
+                        Indices.CH: ch,
+                        Indices.Z: z,
+                    },
+                    extras=tile_extras_provider(hyb, ch, z),
+                )
+                tile.numpy_array = tile_data_provider(hyb, ch, z, tile_height, tile_width)
 
-        Returns
-        -------
-        ImageStack :
-            imagestack containing a tensor of (2, 3, 4, 30, 20) whose values are all 1.
+                img.add_tile(tile)
 
-        """
-        img = TileSet(
-            {Coordinates.X, Coordinates.Y, Indices.HYB, Indices.CH, Indices.Z},
-            {
-                Indices.HYB: num_hyb,
-                Indices.CH: num_ch,
-                Indices.Z: num_z,
-            },
-            default_tile_shape=(tile_height, tile_width),
-        )
-        for hyb in range(num_hyb):
-            for ch in range(num_ch):
-                for z in range(num_z):
-                    tile = Tile(
-                        {
-                            Coordinates.X: (0.0, 0.001),
-                            Coordinates.Y: (0.0, 0.001),
-                            Coordinates.Z: (0.0, 0.001),
-                        },
-                        {
-                            Indices.HYB: hyb,
-                            Indices.CH: ch,
-                            Indices.Z: z,
-                        },
-                        extras=tile_extras_provider(hyb, ch, z),
-                    )
-                    tile.numpy_array = tile_data_provider(hyb, ch, z, tile_height, tile_width)
-
-                    img.add_tile(tile)
-
-        stack = ImageStack(img)
-        return stack
-
-    return synthetic_stack
+    stack = ImageStack(img)
+    return stack

--- a/starfish/test/image/test_imagestack.py
+++ b/starfish/test/image/test_imagestack.py
@@ -1,129 +1,124 @@
-from copy import deepcopy
-
 import numpy as np
 
 from starfish.constants import Indices
-from starfish.test.dataset_fixtures import synthetic_stack_factory
+from starfish.test.dataset_fixtures import synthetic_stack
 
 
-def test_get_slice_simple_index(synthetic_stack_factory):
+def test_get_slice_simple_index():
     """
     Retrieve a slice across one of the indices at the end.  For instance, if the dimensions are
     (P, Q0,..., Qn-1, R), slice across either P or R.
     """
-    synthetic_stack = synthetic_stack_factory()
+    stack = synthetic_stack()
     hyb = 1
-    imageslice, axes = synthetic_stack.get_slice(
+    imageslice, axes = stack.get_slice(
         {Indices.HYB: hyb}
     )
     assert axes == [Indices.CH, Indices.Z]
 
-    Y, X = synthetic_stack.tile_shape
+    Y, X = stack.tile_shape
 
-    for ch in range(synthetic_stack.shape[Indices.CH]):
-        for z in range(synthetic_stack.shape[Indices.Z]):
+    for ch in range(stack.shape[Indices.CH]):
+        for z in range(stack.shape[Indices.Z]):
             data = np.empty((Y, X))
-            data.fill((hyb * synthetic_stack.shape[Indices.CH] + ch) * synthetic_stack.shape[Indices.Z] + z)
+            data.fill((hyb * stack.shape[Indices.CH] + ch) * stack.shape[Indices.Z] + z)
 
             assert data.all() == imageslice[ch, z].all()
 
 
-def test_get_slice_middle_index(synthetic_stack_factory):
+def test_get_slice_middle_index():
     """
     Retrieve a slice across one of the indices in the middle.  For instance, if the dimensions are
     (P, Q0,..., Qn-1, R), slice across one of the Q axes.
     """
-    synthetic_stack = synthetic_stack_factory()
+    stack = synthetic_stack()
     ch = 1
-    imageslice, axes = synthetic_stack.get_slice(
+    imageslice, axes = stack.get_slice(
         {Indices.CH: ch}
     )
     assert axes == [Indices.HYB, Indices.Z]
 
-    Y, X = synthetic_stack.tile_shape
+    Y, X = stack.tile_shape
 
-    for hyb in range(synthetic_stack.shape[Indices.HYB]):
-        for z in range(synthetic_stack.shape[Indices.Z]):
+    for hyb in range(stack.shape[Indices.HYB]):
+        for z in range(stack.shape[Indices.Z]):
             data = np.empty((Y, X))
-            data.fill((hyb * synthetic_stack.shape[Indices.CH] + ch) * synthetic_stack.shape[Indices.Z] + z)
+            data.fill((hyb * stack.shape[Indices.CH] + ch) * stack.shape[Indices.Z] + z)
 
             assert data.all() == imageslice[hyb, z].all()
 
 
-def test_get_slice_range(synthetic_stack_factory):
+def test_get_slice_range():
     """
     Retrieve a slice across a range of one of the dimensions.
     """
-    synthetic_stack = synthetic_stack_factory()
+    stack = synthetic_stack()
     zrange = slice(1, 3)
-    imageslice, axes = synthetic_stack.get_slice(
+    imageslice, axes = stack.get_slice(
         {Indices.Z: zrange}
     )
-    Y, X = synthetic_stack.tile_shape
+    Y, X = stack.tile_shape
     assert axes == [Indices.HYB, Indices.CH, Indices.Z]
 
-    for hyb in range(synthetic_stack.shape[Indices.HYB]):
-        for ch in range(synthetic_stack.shape[Indices.CH]):
+    for hyb in range(stack.shape[Indices.HYB]):
+        for ch in range(stack.shape[Indices.CH]):
             for z in range(zrange.stop - zrange.start):
                 data = np.empty((Y, X))
-                data.fill((hyb * synthetic_stack.shape[Indices.CH] + ch) * synthetic_stack.shape[Indices.Z] +
+                data.fill((hyb * stack.shape[Indices.CH] + ch) * stack.shape[Indices.Z] +
                           (z + zrange.start))
 
                 assert data.all() == imageslice[hyb, ch, z].all()
 
 
-def test_set_slice_simple_index(synthetic_stack_factory):
+def test_set_slice_simple_index():
     """
     Sets a slice across one of the indices at the end.  For instance, if the dimensions are
     (P, Q0,..., Qn-1, R), sets a slice across either P or R.
     """
-    synthetic_stack = synthetic_stack_factory()
-    synthetic_stack = deepcopy(synthetic_stack)
+    stack = synthetic_stack()
     hyb = 1
-    Y, X = synthetic_stack.tile_shape
+    Y, X = stack.tile_shape
 
-    expected = np.ones((synthetic_stack.shape[Indices.CH], synthetic_stack.shape[Indices.Z], Y, X)) * 2
+    expected = np.ones((stack.shape[Indices.CH], stack.shape[Indices.Z], Y, X)) * 2
     index = {Indices.HYB: hyb}
 
-    synthetic_stack.set_slice(index, expected)
+    stack.set_slice(index, expected)
 
-    assert np.array_equal(synthetic_stack.get_slice(index)[0], expected)
+    assert np.array_equal(stack.get_slice(index)[0], expected)
 
 
-def test_set_slice_middle_index(synthetic_stack_factory):
+def test_set_slice_middle_index():
     """
     Sets a slice across one of the indices in the middle.  For instance, if the dimensions are
     (P, Q0,..., Qn-1, R), slice across one of the Q axes.
     """
-    synthetic_stack = synthetic_stack_factory()
-    synthetic_stack = deepcopy(synthetic_stack)
+    stack = synthetic_stack()
     ch = 1
-    Y, X = synthetic_stack.tile_shape
+    Y, X = stack.tile_shape
 
-    expected = np.ones((synthetic_stack.shape[Indices.HYB], synthetic_stack.shape[Indices.Z], Y, X)) * 2
+    expected = np.ones((stack.shape[Indices.HYB], stack.shape[Indices.Z], Y, X)) * 2
     index = {Indices.CH: ch}
 
-    synthetic_stack.set_slice(index, expected)
+    stack.set_slice(index, expected)
 
-    assert np.array_equal(synthetic_stack.get_slice(index)[0], expected)
+    assert np.array_equal(stack.get_slice(index)[0], expected)
 
 
-def test_set_slice_range(synthetic_stack_factory):
+def test_set_slice_range():
     """
     Sets a slice across a range of one of the dimensions.
     """
-    synthetic_stack = synthetic_stack_factory()
-    synthetic_stack = deepcopy(synthetic_stack)
+    stack = synthetic_stack()
     zrange = slice(1, 3)
-    Y, X = synthetic_stack.tile_shape
+    Y, X = stack.tile_shape
 
     expected = np.ones((
-        synthetic_stack.shape[Indices.HYB],
-        synthetic_stack.shape[Indices.CH],
+        stack.shape[Indices.HYB],
+        stack.shape[Indices.CH],
         zrange.stop - zrange.start,
         Y, X)) * 10
     index = {Indices.Z: zrange}
 
-    synthetic_stack.set_slice(index, expected)
+    stack.set_slice(index, expected)
 
-    assert np.array_equal(synthetic_stack.get_slice(index)[0], expected)
+    assert np.array_equal(stack.get_slice(index)[0], expected)

--- a/starfish/test/image/test_imagestack_metadata.py
+++ b/starfish/test/image/test_imagestack_metadata.py
@@ -3,10 +3,10 @@ from typing import Any
 import pytest
 
 from starfish.constants import Indices
-from starfish.test.dataset_fixtures import DEFAULT_NUM_HYB, DEFAULT_NUM_CH, DEFAULT_NUM_Z, synthetic_stack_factory
+from starfish.test.dataset_fixtures import DEFAULT_NUM_HYB, DEFAULT_NUM_CH, DEFAULT_NUM_Z, synthetic_stack
 
 
-def test_metadata(synthetic_stack_factory):
+def test_metadata():
     """
     Normal situation where all the tiles have uniform keys for both indices and extras.
     """
@@ -19,14 +19,14 @@ def test_metadata(synthetic_stack_factory):
             }
         }
 
-    stack = synthetic_stack_factory(
+    stack = synthetic_stack(
         tile_extras_provider=tile_extras_provider,
     )
     table = stack.tile_metadata
     assert len(table) == DEFAULT_NUM_HYB * DEFAULT_NUM_CH * DEFAULT_NUM_Z
 
 
-def test_missing_extras(synthetic_stack_factory):
+def test_missing_extras():
     """
     If the extras are not present on some of the tiles, it should still work.
     """
@@ -42,14 +42,14 @@ def test_missing_extras(synthetic_stack_factory):
         else:
             return None
 
-    stack = synthetic_stack_factory(
+    stack = synthetic_stack(
         tile_extras_provider=tile_extras_provider,
     )
     table = stack.tile_metadata
     assert len(table) == DEFAULT_NUM_HYB * DEFAULT_NUM_CH * DEFAULT_NUM_Z
 
 
-def test_conflict(synthetic_stack_factory):
+def test_conflict():
     """
     Tiles that have extras that conflict with indices should produce an error.
     """
@@ -60,7 +60,7 @@ def test_conflict(synthetic_stack_factory):
             Indices.Z: z,
         }
 
-    stack = synthetic_stack_factory(
+    stack = synthetic_stack(
         tile_extras_provider=tile_extras_provider,
     )
     with pytest.raises(ValueError):

--- a/starfish/test/image/test_slicedimage_dtype.py
+++ b/starfish/test/image/test_slicedimage_dtype.py
@@ -4,7 +4,7 @@ import numpy
 import pytest
 
 from starfish.errors import DataFormatWarning
-from starfish.test.dataset_fixtures import synthetic_stack_factory
+from starfish.test.dataset_fixtures import synthetic_stack
 
 
 NUM_HYB = 2
@@ -39,17 +39,17 @@ def create_tile_data_provider(dtype: numpy.number, corner_dtype: numpy.number):
     return tile_data_provider
 
 
-def test_multiple_tiles_of_different_kind(synthetic_stack_factory):
+def test_multiple_tiles_of_different_kind():
     with pytest.raises(TypeError):
-        synthetic_stack_factory(
+        synthetic_stack(
             NUM_HYB, NUM_CH, NUM_Z,
             HEIGHT, WIDTH,
             tile_data_provider=create_tile_data_provider(numpy.uint32, numpy.float32),
         )
 
 
-def test_multiple_tiles_of_same_dtype(synthetic_stack_factory):
-    stack = synthetic_stack_factory(
+def test_multiple_tiles_of_same_dtype():
+    stack = synthetic_stack(
         NUM_HYB, NUM_CH, NUM_Z,
         HEIGHT, WIDTH,
         tile_data_provider=create_tile_data_provider(numpy.uint32, numpy.uint32),
@@ -63,9 +63,9 @@ def test_multiple_tiles_of_same_dtype(synthetic_stack_factory):
     assert numpy.array_equal(stack.numpy_array, expected)
 
 
-def test_int_type_promotion(synthetic_stack_factory):
+def test_int_type_promotion():
     with warnings.catch_warnings(record=True) as w:
-        stack = synthetic_stack_factory(
+        stack = synthetic_stack(
             NUM_HYB, NUM_CH, NUM_Z,
             HEIGHT, WIDTH,
             tile_data_provider=create_tile_data_provider(numpy.int32, numpy.int8),
@@ -86,9 +86,9 @@ def test_int_type_promotion(synthetic_stack_factory):
     assert numpy.array_equal(stack.numpy_array, expected)
 
 
-def test_uint_type_promotion(synthetic_stack_factory):
+def test_uint_type_promotion():
     with warnings.catch_warnings(record=True) as w:
-        stack = synthetic_stack_factory(
+        stack = synthetic_stack(
             NUM_HYB, NUM_CH, NUM_Z,
             HEIGHT, WIDTH,
             tile_data_provider=create_tile_data_provider(numpy.uint32, numpy.uint8),
@@ -109,9 +109,9 @@ def test_uint_type_promotion(synthetic_stack_factory):
     assert numpy.array_equal(stack.numpy_array, expected)
 
 
-def test_float_type_promotion(synthetic_stack_factory):
+def test_float_type_promotion():
     with warnings.catch_warnings(record=True) as w:
-        stack = synthetic_stack_factory(
+        stack = synthetic_stack(
             NUM_HYB, NUM_CH, NUM_Z,
             HEIGHT, WIDTH,
             tile_data_provider=create_tile_data_provider(numpy.float64, numpy.float32),

--- a/starfish/test/test_apply.py
+++ b/starfish/test/test_apply.py
@@ -1,39 +1,23 @@
-from copy import deepcopy
-
 import numpy as np
 
-from starfish.test.dataset_fixtures import synthetic_stack_factory
+from starfish.test.dataset_fixtures import synthetic_stack
 
 
 def multiply(array, value):
     return array * value
 
 
-def test_apply(synthetic_stack_factory):
-    """test that apply correctly applies a simple function across 2d tiles of a Stack
-
-    Parameters
-    ----------
-    synthetic_stack : Stack
-        synthetic data pytest fixture that passes a Stack object
-
-    """
-    synthetic_stack = deepcopy(synthetic_stack_factory())
-    assert (synthetic_stack.numpy_array == 1).all()
-    synthetic_stack.apply(multiply, value=2)
-    assert (synthetic_stack.numpy_array == 2).all()
+def test_apply():
+    """test that apply correctly applies a simple function across 2d tiles of a Stack"""
+    stack = synthetic_stack()
+    assert (stack.numpy_array == 1).all()
+    stack.apply(multiply, value=2)
+    assert (stack.numpy_array == 2).all()
 
 
-def test_apply_3d(synthetic_stack_factory):
-    """test that apply correctly applies a simple function across 3d volumes of a Stack
-
-    Parameters
-    ----------
-    synthetic_stack : Stack
-        synthetic data pytest fixture that passes a Stack object
-
-    """
-    synthetic_stack = deepcopy(synthetic_stack_factory())
-    assert np.all(synthetic_stack.numpy_array == 1)
-    synthetic_stack.apply(multiply, value=4, is_volume=True)
-    assert (synthetic_stack.numpy_array == 4).all()
+def test_apply_3d():
+    """test that apply correctly applies a simple function across 3d volumes of a Stack"""
+    stack = synthetic_stack()
+    assert np.all(stack.numpy_array == 1)
+    stack.apply(multiply, value=4, is_volume=True)
+    assert (stack.numpy_array == 4).all()


### PR DESCRIPTION
1. Made it a simple function.
2. Remove the now unnecessary deepcopy calls.