### PR TITLE
convert codebook retrieval to use jsonpathrw

### DIFF
--- a/REQUIREMENTS-DEV.txt
+++ b/REQUIREMENTS-DEV.txt
@@ -1,4 +1,5 @@
 flake8
+jsonpath_rw
 pytest-cov>=2.5.1
 pytest-xdist
 mypy

--- a/starfish/test/full_pipelines/cli/test_iss.py
+++ b/starfish/test/full_pipelines/cli/test_iss.py
@@ -6,15 +6,27 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from typing import Sequence
+
+import jsonpath_rw
 
 from starfish.util import clock
 
 
-def get_codebook(tempdir):
-    json_filepath = os.path.join(tempdir, "formatted", "experiment.json")
+def get_jsonpath_from_file(json_filepath_components: Sequence[str], jsonpath: str):
+    """
+    Given a series of filepath components, join them to find a file <FILE>.  Open that file, and locate a specific value
+    in the json structure <PATH>.  Join the directory path of <FILE> and <PATH> and return that.
+
+    For example, if json_filepath_components is ["/tmp", "formatted", "experiment.json"] and jsonpath is
+    "$['hybridization']", this method will open /tmp/formatted/experiment.json, decode that as a json document, and
+    locate the value of the key 'hybridization'.  It will return /tmp/formatted/XXX, where XXX is the value of the key.
+    """
+    json_filepath = os.path.join(*json_filepath_components)
+    dirname = os.path.dirname(json_filepath)
     with open(json_filepath, "r") as fh:
         document = json.load(fh)
-        return os.path.join(tempdir, "formatted", document['codebook'])
+        return os.path.join(dirname, jsonpath_rw.parse(jsonpath).find(document)[0].value)
 
 
 class TestWithIssData(unittest.TestCase):
@@ -79,7 +91,10 @@ class TestWithIssData(unittest.TestCase):
         [
             "starfish", "decode",
             "-i", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "results", "encoder_table.json"),
-            "--codebook", lambda tempdir, *args, **kwargs: get_codebook(tempdir),
+            "--codebook", lambda tempdir, *args, **kwargs: get_jsonpath_from_file(
+                [tempdir, "formatted", "experiment.json"],
+                "$['codebook']",
+            ),
             "-o", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "results", "decoded_table.json"),
             "IssDecoder",
         ],
@@ -101,7 +116,7 @@ class TestWithIssData(unittest.TestCase):
                     element(tempdir=tempdir) if callable(element) else element
                     for element in stage
                 ]
-                if cmdline[0] == 'starfish' and coverage_enabled:
+                if cmdline[0] == "starfish" and coverage_enabled:
                     coverage_cmdline = [
                         "coverage", "run",
                         "-p",
@@ -117,7 +132,7 @@ class TestWithIssData(unittest.TestCase):
 
             counts = collections.defaultdict(lambda: 0)
             for record in results:
-                counts[record['barcode']] += 1
+                counts[record["barcode"]] += 1
             tuples = [(count, barcode) for barcode, count in counts.items()]
             tuples.sort(reverse=True)
             self.assertEqual("AAGC", tuples[0][1])


### PR DESCRIPTION
I did this a long time ago in #96, but I forgot the reason I did it by the time the code was being reviewed.  Now I remember: this is to generalize the retrieval of data fields when converting away from `Stack`.