### PR TITLE
Ajc out of place apply

### DIFF
--- a/starfish/pipeline/features/spots/detector/local_max_peak_finder.py
+++ b/starfish/pipeline/features/spots/detector/local_max_peak_finder.py
@@ -121,8 +121,8 @@ class LocalMaxPeakFinder(SpotFinderAlgorithmBase):
         stack : ImageStack
             Stack where we find the spots in.
         """
-        spot_attributes: List[SpotAttributes] = stack.apply(
-            self.find_attributes, in_place=False, is_volume=self.is_volume, verbose=self.verbose)
+        spot_attributes: List[SpotAttributes] = stack.transform(
+            self.find_attributes, is_volume=self.is_volume, verbose=self.verbose)
 
         # TODO ambrosejcarr: do we need to find spots in the aux_dict too?
 

--- a/starfish/pipeline/filter/_base.py
+++ b/starfish/pipeline/filter/_base.py
@@ -1,8 +1,10 @@
+from typing import Optional
+
 from starfish.image import ImageStack
 from starfish.pipeline.algorithmbase import AlgorithmBase
 
 
 class FilterAlgorithmBase(AlgorithmBase):
-    def filter(self, stack: ImageStack) -> None:
+    def filter(self, stack: ImageStack) -> Optional[ImageStack]:
         """Performs in-place filtering on an ImageStack."""
         raise NotImplementedError()

--- a/starfish/pipeline/filter/bandpass.py
+++ b/starfish/pipeline/filter/bandpass.py
@@ -1,6 +1,8 @@
 from functools import partial
+from typing import Optional
 
 from trackpy import bandpass
+import numpy as np
 
 from starfish.image import ImageStack
 from ._base import FilterAlgorithmBase
@@ -39,7 +41,7 @@ class Bandpass(FilterAlgorithmBase):
         group_parser.add_argument("--truncate", default=4, type=int)
 
     @staticmethod
-    def bandpass(image, lshort, llong, threshold, truncate):
+    def bandpass(image, lshort, llong, threshold, truncate) -> np.ndarray:
         """Apply a bandpass filter to remove noise and background variation
 
         Parameters
@@ -66,16 +68,26 @@ class Bandpass(FilterAlgorithmBase):
         )
         return bandpassed
 
-    def filter(self, stack: ImageStack) -> None:
-        """Perform in-place filtering of an image stack and all contained aux images.
+    def filter(self, stack: ImageStack, in_place: bool=True) -> Optional[ImageStack]:
+        """Perform filtering of an image stack
 
         Parameters
         ----------
         stack : ImageStack
             Stack to be filtered.
+        in_place : bool
+            if True, process ImageStack in-place, otherwise return a new stack
+
+        Returns
+        -------
+        Optional[ImageStack] :
+            if in-place is False, return the results of filter as a new stack
 
         """
         bandpass_ = partial(
             self.bandpass, lshort=self.lshort, llong=self.llong, threshold=self.threshold, truncate=self.truncate
         )
-        stack.apply(bandpass_, verbose=self.verbose)
+        result = stack.apply(bandpass_, verbose=self.verbose, in_place=in_place)
+        if not in_place:
+            return result
+        return None

--- a/starfish/pipeline/filter/clip.py
+++ b/starfish/pipeline/filter/clip.py
@@ -1,4 +1,5 @@
 from functools import partial
+from typing import Optional
 
 import numpy
 
@@ -64,14 +65,24 @@ class Clip(FilterAlgorithmBase):
         image = image.clip(min=v_min, max=v_max)
         return image.astype(dtype)
 
-    def filter(self, stack: ImageStack) -> None:
-        """Perform in-place filtering of an image stack and all contained aux images.
+    def filter(self, stack: ImageStack, in_place: bool=True) -> Optional[ImageStack]:
+        """Perform filtering of an image stack
 
         Parameters
         ----------
         stack : ImageStack
             Stack to be filtered.
+        in_place : bool
+            if True, process ImageStack in-place, otherwise return a new stack
+
+        Returns
+        -------
+        Optional[ImageStack] :
+            if in-place is False, return the results of filter as a new stack
 
         """
         clip = partial(self.clip, p_min=self.p_min, p_max=self.p_max)
-        stack.apply(clip, is_volume=self.is_volume, verbose=self.verbose)
+        result = stack.apply(clip, is_volume=self.is_volume, verbose=self.verbose, in_place=in_place)
+        if not in_place:
+            return result
+        return None

--- a/starfish/pipeline/filter/gaussian_high_pass.py
+++ b/starfish/pipeline/filter/gaussian_high_pass.py
@@ -1,6 +1,6 @@
 import argparse
 from functools import partial
-from typing import Callable
+from typing import Callable, Optional
 
 import numpy as np
 
@@ -53,16 +53,24 @@ class GaussianHighPass(FilterAlgorithmBase):
 
         return res
 
-    def filter(self, stack: ImageStack) -> None:
-        """
-        Perform in-place filtering of an image stack and all contained aux images.
+    def filter(self, stack: ImageStack, in_place: bool=True) -> Optional[ImageStack]:
+        """Perform filtering of an image stack
 
         Parameters
         ----------
         stack : ImageStack
             Stack to be filtered.
+        in_place : bool
+            if True, process ImageStack in-place, otherwise return a new stack
+
+        Returns
+        -------
+        Optional[ImageStack] :
+            if in-place is False, return the results of filter as a new stack
 
         """
-
         high_pass: Callable = partial(self.gaussian_high_pass, sigma=self.sigma)
-        stack.apply(high_pass)
+        result = stack.apply(high_pass, in_place=in_place)
+        if not in_place:
+            return result
+        return None

--- a/starfish/pipeline/filter/gaussian_low_pass.py
+++ b/starfish/pipeline/filter/gaussian_low_pass.py
@@ -1,4 +1,5 @@
 from functools import partial
+from typing import Optional
 
 import numpy
 from skimage.filters import gaussian
@@ -58,14 +59,24 @@ class GaussianLowPass(FilterAlgorithmBase):
 
         return blurred
 
-    def filter(self, stack: ImageStack) -> None:
-        """Perform in-place filtering of an image stack and all contained aux images.
+    def filter(self, stack: ImageStack, in_place: bool=True) -> Optional[ImageStack]:
+        """Perform filtering of an image stack
 
         Parameters
         ----------
         stack : ImageStack
             Stack to be filtered.
+        in_place : bool
+            if True, process ImageStack in-place, otherwise return a new stack
+
+        Returns
+        -------
+        Optional[ImageStack] :
+            if in-place is False, return the results of filter as a new stack
 
         """
         low_pass = partial(self.low_pass, sigma=self.sigma)
-        stack.apply(low_pass, is_volume=self.is_volume, verbose=self.verbose)
+        result = stack.apply(low_pass, is_volume=self.is_volume, verbose=self.verbose, in_place=in_place)
+        if not in_place:
+            return result
+        return None

--- a/starfish/pipeline/filter/richardson_lucy_deconvolution.py
+++ b/starfish/pipeline/filter/richardson_lucy_deconvolution.py
@@ -1,6 +1,6 @@
 import argparse
 from functools import partial
-from typing import Callable
+from typing import Callable, Optional
 
 import numpy as np
 from skimage import restoration
@@ -76,14 +76,24 @@ class DeconvolvePSF(FilterAlgorithmBase):
         img_deconv = img_deconv.astype(np.uint16)
         return img_deconv
 
-    def filter(self, stack: ImageStack) -> None:
-        """Perform in-place filtering of an image stack and all contained aux images.
+    def filter(self, stack: ImageStack, in_place: bool=True) -> Optional[ImageStack]:
+        """Perform filtering of an image stack
 
         Parameters
         ----------
         stack : ImageStack
             Stack to be filtered.
+        in_place : bool
+            if True, process ImageStack in-place, otherwise return a new stack
+
+        Returns
+        -------
+        Optional[ImageStack] :
+            if in-place is False, return the results of filter as a new stack
 
         """
         func: Callable = partial(self.richardson_lucy_deconv, num_iter=self.num_iter, psf=self.psf, clip=self.clip)
-        stack.apply(func)
+        result = stack.apply(func, in_place=in_place)
+        if not in_place:
+            return result
+        return None

--- a/starfish/pipeline/filter/white_tophat.py
+++ b/starfish/pipeline/filter/white_tophat.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 
 from starfish.image import ImageStack
@@ -30,13 +32,20 @@ class WhiteTophat(FilterAlgorithmBase):
         group_parser.add_argument(
             "--disk-size", default=15, type=int, help="diameter of morphological masking disk in pixels")
 
-    def filter(self, stack: ImageStack) -> None:
-        """Perform in-place filtering of an image stack and all contained aux images
+    def filter(self, stack: ImageStack, in_place: bool=True) -> Optional[ImageStack]:
+        """Perform filtering of an image stack
 
         Parameters
         ----------
         stack : ImageStack
-            Stack to be filtered
+            Stack to be filtered.
+        in_place : bool
+            if True, process ImageStack in-place, otherwise return a new stack
+
+        Returns
+        -------
+        Optional[ImageStack] :
+            if in-place is False, return the results of filter as a new stack
 
         """
         from scipy.ndimage.filters import maximum_filter, minimum_filter
@@ -51,4 +60,7 @@ class WhiteTophat(FilterAlgorithmBase):
             filtered_image = image - np.minimum(image, max_filtered)
             return filtered_image
 
-        stack.apply(white_tophat)
+        result = stack.apply(white_tophat)
+        if not in_place:
+            return result
+        return None

--- a/starfish/test/test_apply.py
+++ b/starfish/test/test_apply.py
@@ -31,3 +31,10 @@ def test_apply_labeled_dataset():
     image = deepcopy(original.image)
     image.apply(multiply, value=2)
     assert np.all(image.numpy_array == original.image.numpy_array * 2)
+
+
+def test_apply_not_in_place():
+    """test that apply correctly applies a simple function across a starfish stack without modifying original data"""
+    image = labeled_synthetic_dataset().image
+    new = image.apply(multiply, value=2, in_place=False)
+    assert np.all(new.numpy_array == image.numpy_array * 2)


### PR DESCRIPTION
Two commits: 

- First moves the existing functionality of `apply(in_place=False)` which enables transformations of the stack into other objects to a `transform` function and enables true out-of-place `apply` functionality which always returns an `ImageStack`

- Second enables `in_place=False` for all filters. 