### PR TITLE
removed the int type requirement in WhiteTophat filter

### DIFF
--- a/starfish/pipeline/filter/white_tophat.py
+++ b/starfish/pipeline/filter/white_tophat.py
@@ -42,8 +42,6 @@ class WhiteTophat(FilterAlgorithmBase):
         from skimage.morphology import disk
 
         def white_tophat(image):
-            if image.dtype.kind != "u":
-                raise TypeError("images should be stored in an unsigned integer array")
             structuring_element = disk(self.disk_size)
             min_filtered = minimum_filter(image, footprint=structuring_element)
             max_filtered = maximum_filter(min_filtered, footprint=structuring_element)


### PR DESCRIPTION
I removed the uint check for the input images for the WhiteTophat filter. It doesn't seem necessary for the Scipy implementation of the min/max filters and none of the other filters have a type requirement. Please let me know if I missed a type spec for images upstream. Thanks!