### PR TITLE
RFC: Cleanup + Unification of starfish API + CLI 

### DIFF
--- a/click_starfish/click_starfish/__init__.py
+++ b/click_starfish/click_starfish/__init__.py
@@ -1,0 +1,1 @@
+from . import registration

--- a/click_starfish/click_starfish/_pipeline_component.py
+++ b/click_starfish/click_starfish/_pipeline_component.py
@@ -1,0 +1,2 @@
+class PipelineComponent:
+    pass

--- a/click_starfish/click_starfish/_util.py
+++ b/click_starfish/click_starfish/_util.py
@@ -1,0 +1,16 @@
+class Singleton(type):
+    """Metaclass to make TestComponent a singleton. Not strictly necessary."""
+
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+
+def clean_namespace(retain):
+    for name in globals():
+        if name not in retain:
+            del globals()[name]
+

--- a/click_starfish/click_starfish/cli.py
+++ b/click_starfish/click_starfish/cli.py
@@ -1,0 +1,12 @@
+import click
+
+from .registration._base import RegistrationBase
+
+
+@click.group(name='starfish')
+def cli():
+    """create the outer CLI object"""
+    pass
+
+
+cli.add_command(RegistrationBase.registration)

--- a/click_starfish/click_starfish/registration/__init__.py
+++ b/click_starfish/click_starfish/registration/__init__.py
@@ -1,0 +1,1 @@
+from .fourier_transform import fourier_transform

--- a/click_starfish/click_starfish/registration/_base.py
+++ b/click_starfish/click_starfish/registration/_base.py
@@ -1,0 +1,15 @@
+import click
+
+from .._pipeline_component import PipelineComponent
+
+
+class RegistrationBase(PipelineComponent):
+
+    @staticmethod
+    @click.group()
+    def registration():
+        """
+        Create registration category in the base class of the PipelineComponent.
+        This is equivalent to __init__.py in the API.
+        """
+        pass  # can't be NotImplementedError; could also go into outer scope for consistency.

--- a/click_starfish/click_starfish/registration/fourier_transform.py
+++ b/click_starfish/click_starfish/registration/fourier_transform.py
@@ -1,0 +1,27 @@
+import click
+
+from ._base import RegistrationBase
+from .._util import Singleton
+
+import numpy as np  # not used; importing this to demonstrate exclusion from global import namespace
+
+
+class _FourierTransform(RegistrationBase, metaclass=Singleton):
+    """Implementing algorithm of the Registration pipeline component"""
+
+    def __call__(self, input_json, output_json, *args, **kwargs) -> None:
+        print(f'input={input_json}, output={output_json}')
+
+
+# new required boilerplate starts here
+
+# this object gets imported, it's a singleton of our class which is callable
+fourier_transform = _FourierTransform()
+
+
+# this object is registered to the CLI
+@RegistrationBase.registration.command(name="fourier-transform")
+@click.option("--input-json", help="input json")
+@click.option("--output-json", help="output file")
+def _cli(input_json, output_json):
+    fourier_transform(input_json, output_json)

--- a/click_starfish/setup.py
+++ b/click_starfish/setup.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+import setuptools
+
+
+setuptools.setup(
+    name="click_starfish",
+    version="0.0.0",
+    description="Proof of concept for starfish using the click cli library",
+    author="Ambrose J. Carr",
+    author_email="mail@ambrosejcarr.com",
+    license="MIT",
+    entry_points={
+        'console_scripts': "click-starfish=click_starfish.cli:cli"
+    },
+    install_requires=['click']
+)


### PR DESCRIPTION
I've written up a doc that proposes a unification of the API and CLI: 

[https://docs.google.com/document/d/1l3f6sYhYcxanHDVhWtQzFrrz0--2YmNRXTivZ1gi4t4/edit#](https://docs.google.com/document/d/1l3f6sYhYcxanHDVhWtQzFrrz0--2YmNRXTivZ1gi4t4/edit#)

- The code in this PR contains an example of how we might adjust the CLI to use `click`, which is a small part of the proposal. See the doc for an explanation, examples, and the use patterns for this implementation. 

Possible implementation to fix #292 
Closes #218 