### PR TITLE
[1/8] DOC: fix raw shape docs and types

### DIFF
--- a/starfish/image/_stack.py
+++ b/starfish/image/_stack.py
@@ -582,16 +582,14 @@ class ImageStack:
         return pd.DataFrame(data)
 
     @property
-    def raw_shape(self) -> Tuple[int]:
+    def raw_shape(self) -> Tuple[int, int, int, int, int]:
         """
-        Returns the shape of the space that this image inhabits.  It does not include the dimensions of the image
-        itself.  For instance, if this is an X-Y image in a C-H-Y-X space, then the shape would include the dimensions C
-        and H.
+        Returns the shape of the 5-d image tensor stored as self.image
 
         Returns
         -------
-        Tuple[int] :
-            The sizes of the indices.
+        Tuple[int, int, int, int, int] :
+            The size of the image tensor
         """
         return self._data.shape
 


### PR DESCRIPTION
- raw shape's type + doc was out of date. 

This set of 8 Pull Requests supports pixel-based decoding using the IntensityTable and Codebook, updating the MERFISH notebook and all the pipeline components that it depends on. 

Note: depends on #313 