### PR TITLE
[2/8] ENH: IntensityTable tracks the shape of the ImageStack it was created from

### DIFF
--- a/starfish/pipeline/features/spots/detector/gaussian.py
+++ b/starfish/pipeline/features/spots/detector/gaussian.py
@@ -1,5 +1,6 @@
 from itertools import product
 from numbers import Number
+from typing import Tuple
 
 import numpy as np
 import pandas as pd
@@ -95,7 +96,9 @@ class GaussianSpotDetector(SpotFinderAlgorithmBase):
         n_ch = stack.shape[Indices.CH]
         n_hyb = stack.shape[Indices.HYB]
         spot_attribute_index = dataframe_to_multiindex(spot_attributes)
-        intensity_table = IntensityTable.empty_intensity_table(spot_attribute_index, n_ch, n_hyb)
+        image_shape: Tuple[int, int, int] = stack.raw_shape[2:]
+        intensity_table = IntensityTable.empty_intensity_table(
+            spot_attribute_index, n_ch, n_hyb, image_shape)
 
         indices = product(range(n_ch), range(n_hyb))
         for c, h in indices:

--- a/starfish/test/dataset_fixtures.py
+++ b/starfish/test/dataset_fixtures.py
@@ -61,7 +61,7 @@ def small_intensity_table():
         [[1, 0],
          [0, 1]],
         [[0, 0],
-         [1, 1]]
+         [1, 1]],
     ])
 
     spot_attributes = dataframe_to_multiindex(pd.DataFrame(
@@ -72,8 +72,9 @@ def small_intensity_table():
             IntensityTable.SpotAttributes.RADIUS: [0.1, 0.2, 0.3]
         }
     ))
+    image_shape = (3, 2, 2)
 
-    return IntensityTable.from_spot_data(intensities, spot_attributes)
+    return IntensityTable.from_spot_data(intensities, spot_attributes, image_shape)
 
 
 @pytest.fixture(scope='module')

--- a/starfish/test/pipeline/test_intensity_table.py
+++ b/starfish/test/pipeline/test_intensity_table.py
@@ -15,7 +15,8 @@ def test_empty_intensity_table():
     z = [1, 1]
     r = [1, 1]
     spot_attributes = pd.MultiIndex.from_arrays([x, y, z, r], names=('x', 'y', 'z', 'r'))
-    empty = IntensityTable.empty_intensity_table(spot_attributes, 2, 2)
+    image_shape = (2, 4, 4)
+    empty = IntensityTable.empty_intensity_table(spot_attributes, 2, 2, image_shape)
     assert empty.shape == (2, 2, 2)
     assert np.sum(empty.values) == 0
 


### PR DESCRIPTION
- Next PR enables direct conversion of ImageStack to IntensityTable by reshaping pixels. 
- This PR makes that reshaping process revertible by storing the shape of the ImageStack in the IntensityTable when it is created. 