### PR TITLE
[3/8] ENH: add methods to reshape pixels to/from intensities

### DIFF
--- a/starfish/image/_stack.py
+++ b/starfish/image/_stack.py
@@ -19,6 +19,7 @@ from starfish.constants import Coordinates, Indices
 from starfish.errors import DataFormatWarning
 from starfish.pipeline.features.spot_attributes import SpotAttributes
 from starfish.intensity_table import IntensityTable
+from starfish.munge import dataframe_to_multiindex
 
 
 class ImageStack:
@@ -960,3 +961,91 @@ class ImageStack:
                     empty.set_slice({Indices.HYB: h, Indices.CH: c, Indices.Z: z}, view)
 
         return empty
+
+    def to_pixel_intensities(self, crop: Tuple[int, int, int]=(0, 0, 0)) -> IntensityTable:
+        """Generate an IntensityTable from all the pixels in the ImageStack
+
+        Parameters
+        ----------
+        crop : Tuple[int, int, int]
+            number of pixels from the image borders (z, y, x) to ignore
+
+        Returns
+        -------
+
+        """
+        zmin, ymin, xmin = crop
+        zmax = self.shape['z'] - zmin
+        ymax = self.shape['y'] - ymin
+        xmax = self.shape['x'] - xmin
+        data = self.numpy_array.transpose(2, 3, 4, 1, 0)  # (z, y, x, ch, hyb)
+        cropped_data = data[zmin:zmax, ymin:ymax, xmin:xmax, :, :]
+        intensity_data = cropped_data.reshape(-1, self.num_chs, self.num_hybs)  # (pixels, ch, hyb)
+        z = np.arange(zmin, zmax)
+        y = np.arange(ymin, ymax)
+        x = np.arange(xmin, xmax)
+
+        pixel_coordinates = pd.DataFrame(
+            data=np.array(list(product(z, y, x))),
+            columns=['z', 'y', 'x']
+        )
+        pixel_coordinates['r'] = np.full(pixel_coordinates.shape[0], fill_value=np.nan)
+
+        spot_attributes = dataframe_to_multiindex(pixel_coordinates)
+        image_size = cropped_data.shape[:3]
+
+        return IntensityTable.from_spot_data(intensity_data, spot_attributes, image_size)
+
+    @classmethod
+    def from_pixel_intensities(
+            cls, intensities: IntensityTable, assume_contiguous: bool=True
+    ) -> "ImageStack":
+        """
+
+        Parameters
+        ----------
+        intensities : IntensityTable
+            intensities to transform into an ImageStack
+        assume_contiguous : bool
+            if True, indicates that every pixel is present in the intensity_table. In this case,
+            the IntensityTable can simply be reshaped back into an ImageStack reversing
+            ImageStack.to_intensities()
+
+        Notes
+        -----
+        assume_contiguous == False is not implemented
+
+        Returns
+        -------
+        ImageStack :
+            ImageStack containing Intensity information
+
+
+        """
+        # if assume_contiguous is True, we can just reshape the original array
+        if assume_contiguous:
+
+            # reverses the process used to produce the intensity table in to_pixel_intensities
+            data = intensities.values.reshape([
+                *intensities.attrs['image_shape'],
+                intensities.sizes[Indices.CH],
+                intensities.sizes[Indices.HYB]])
+            data = data.transpose(4, 3, 0, 1, 2)
+            return ImageStack.from_numpy_array(data)
+
+        else:
+
+            raise NotImplementedError
+
+            # not implementing this right now, not clear it makes sense to.
+
+            # # construct an empty (z, y, x) image
+            # decoded_image = np.zeros(self.attrs['image_shape'], dtype=int)
+            #
+            # # fill it with features
+            # coordinates = self.indexes['features'].to_frame()[['z', 'y', 'x']]
+            # genes = self.gene_name.values
+            #
+            # for i in np.arange(self.sizes[self.Constants.FEATURES.value]):
+            #     z, y, x = coordinates.iloc[i]
+            #     decoded_image[z, y, x] = self._gene_to_int[genes[i]]

--- a/starfish/intensity_table.py
+++ b/starfish/intensity_table.py
@@ -280,21 +280,26 @@ class IntensityTable(xr.DataArray):
         return intensities
 
     @classmethod
-    def from_image_stack(cls, image_stack, crop: Tuple[int, int, int]=(0, 0, 0)) -> "IntensityTable":
+    def from_image_stack(cls, image_stack, crop_x: int=0, crop_y: int=0, crop_z: int=0) -> "IntensityTable":
         """Generate an IntensityTable from all the pixels in the ImageStack
 
         Parameters
         ----------
+        crop_x : int
+            number of pixels to crop from both top and bottom of x
+        crop_y : int
+            number of pixels to crop from both top and bottom of y
+        crop_z : int
+            number of pixels to crop from both top and bottom of z
         image_stack : ImageStack
-
-        crop : Tuple[int, int, int]
-            number of pixels from the image borders (z, y, x) to ignore
+            ImageStack containing pixels to be treated as intensities
 
         Returns
         -------
+        IntensityTable
+            IntensityTable containing one intensity per pixel (across channels and rounds)
 
         """
-        crop_z, crop_y, crop_x = crop
 
         # verify the image is large enough to crop
         assert crop_z * 2 < image_stack.shape['z']
@@ -328,4 +333,3 @@ class IntensityTable(xr.DataArray):
         image_size = cropped_data.shape[:3]
 
         return IntensityTable.from_spot_data(intensity_data, spot_attributes, image_size)
-

--- a/starfish/test/dataset_fixtures.py
+++ b/starfish/test/dataset_fixtures.py
@@ -238,3 +238,14 @@ def synthetic_spot_pass_through_stack(synthetic_dataset_with_truth_values):
         point_spread_function=(0, 0, 0), camera_detection_efficiency=1.0,
         background_electrons=0, graylevel=1)
     return codebook, true_intensities, img_stack
+
+
+@pytest.fixture()
+def single_synthetic_spot():
+    sd = synthesize.SyntheticData(
+        n_hyb=2, n_ch=2, n_z=2, height=20, width=30, n_codes=1, n_spots=1
+    )
+    codebook = sd.codebook()
+    intensities = sd.intensities(codebook)
+    image = sd.spots(intensities)
+    return codebook, intensities, image

--- a/starfish/test/image/test_imagestack.py
+++ b/starfish/test/image/test_imagestack.py
@@ -3,11 +3,14 @@ import pytest
 
 from starfish.constants import Indices
 from starfish.image import ImageStack
+from starfish.intensity_table import IntensityTable
 # don't inspect pytest fixtures in pycharm
 # noinspection PyUnresolvedReferences
 from starfish.test.dataset_fixtures import (
     synthetic_intensity_table, synthetic_spot_pass_through_stack, loaded_codebook,
-    synthetic_dataset_with_truth_values, simple_codebook_json, simple_codebook_array)
+    synthetic_dataset_with_truth_values, simple_codebook_json, simple_codebook_array,
+    single_synthetic_spot
+)
 
 
 def test_get_slice_simple_index():
@@ -207,3 +210,20 @@ def test_synthetic_spot_creation_produces_an_imagestack_with_correct_spot_locati
     assert np.array_equal(
         image.numpy_array[h, c, z, y, x],
         true_intensities.values[np.where(true_intensities)])
+
+
+# TODO ambrosejcarr: improve the tests here.
+def test_imagestack_to_intensity_table(single_synthetic_spot):
+    codebook, intensity_table, image = single_synthetic_spot
+    pixel_intensities = image.to_pixel_intensities()
+    pixel_intensities = codebook.decode_euclidean(
+        pixel_intensities)
+    assert isinstance(pixel_intensities, IntensityTable)
+
+
+def test_imagestack_to_intensity_table_no_noise(synthetic_spot_pass_through_stack):
+    codebook, intensity_table, image = synthetic_spot_pass_through_stack
+    pixel_intensities = image.to_pixel_intensities()
+    pixel_intensities = codebook.decode_euclidean(
+        pixel_intensities)
+    assert isinstance(pixel_intensities, IntensityTable)

--- a/starfish/test/image/test_imagestack.py
+++ b/starfish/test/image/test_imagestack.py
@@ -7,8 +7,12 @@ from starfish.intensity_table import IntensityTable
 # don't inspect pytest fixtures in pycharm
 # noinspection PyUnresolvedReferences
 from starfish.test.dataset_fixtures import (
-    synthetic_intensity_table, synthetic_spot_pass_through_stack, loaded_codebook,
-    synthetic_dataset_with_truth_values, simple_codebook_json, simple_codebook_array,
+    synthetic_intensity_table,
+    synthetic_spot_pass_through_stack,
+    loaded_codebook,
+    synthetic_dataset_with_truth_values,
+    simple_codebook_json,
+    simple_codebook_array,
     single_synthetic_spot
 )
 
@@ -215,7 +219,7 @@ def test_synthetic_spot_creation_produces_an_imagestack_with_correct_spot_locati
 # TODO ambrosejcarr: improve the tests here.
 def test_imagestack_to_intensity_table(single_synthetic_spot):
     codebook, intensity_table, image = single_synthetic_spot
-    pixel_intensities = image.to_pixel_intensities()
+    pixel_intensities = IntensityTable.from_image_stack(image)
     pixel_intensities = codebook.decode_euclidean(
         pixel_intensities)
     assert isinstance(pixel_intensities, IntensityTable)
@@ -223,7 +227,7 @@ def test_imagestack_to_intensity_table(single_synthetic_spot):
 
 def test_imagestack_to_intensity_table_no_noise(synthetic_spot_pass_through_stack):
     codebook, intensity_table, image = synthetic_spot_pass_through_stack
-    pixel_intensities = image.to_pixel_intensities()
+    pixel_intensities = IntensityTable.from_image_stack(image)
     pixel_intensities = codebook.decode_euclidean(
         pixel_intensities)
     assert isinstance(pixel_intensities, IntensityTable)

--- a/starfish/test/test_stack_intensity_table_reshaping.py
+++ b/starfish/test/test_stack_intensity_table_reshaping.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+# don't inspect pytest fixtures in pycharm
+# noinspection PyUnresolvedReferences
+from starfish.test.dataset_fixtures import single_synthetic_spot
+from starfish.image import ImageStack
+
+
+def test_reshaping_between_stack_and_intensities(single_synthetic_spot):
+    """
+    transform an pixels of an ImageStack into an IntensityTable and back again, then verify that
+    the created Imagestack is the same as the original
+    """
+    codebook, intensities, image = single_synthetic_spot
+    pixel_intensities = image.to_pixel_intensities()
+    image_from_pixels = ImageStack.from_pixel_intensities(pixel_intensities, assume_contiguous=True)
+    assert np.array_equal(image.numpy_array, image_from_pixels.numpy_array)

--- a/starfish/test/test_stack_intensity_table_reshaping.py
+++ b/starfish/test/test_stack_intensity_table_reshaping.py
@@ -1,9 +1,12 @@
 import numpy as np
+from typing import Tuple
 
+from starfish.constants import Indices
+from starfish.image import ImageStack
+from starfish.intensity_table import IntensityTable
 # don't inspect pytest fixtures in pycharm
 # noinspection PyUnresolvedReferences
 from starfish.test.dataset_fixtures import single_synthetic_spot
-from starfish.image import ImageStack
 
 
 def test_reshaping_between_stack_and_intensities(single_synthetic_spot):
@@ -12,6 +15,32 @@ def test_reshaping_between_stack_and_intensities(single_synthetic_spot):
     the created Imagestack is the same as the original
     """
     codebook, intensities, image = single_synthetic_spot
-    pixel_intensities = image.to_pixel_intensities()
-    image_from_pixels = ImageStack.from_pixel_intensities(pixel_intensities, assume_contiguous=True)
+    pixel_intensities = IntensityTable.from_image_stack(image, crop=(0, 0, 0))
+    image_shape = (image.shape['z'], image.shape['y'], image.shape['x'])
+    image_from_pixels = from_pixel_intensities(pixel_intensities, image_shape)
     assert np.array_equal(image.numpy_array, image_from_pixels.numpy_array)
+
+
+def from_pixel_intensities(intensities: IntensityTable, image_shape: Tuple[int, int, int]) -> "ImageStack":
+    """Re-create the pixel intensities from an IntensityTable
+
+    Parameters
+    ----------
+    intensities : IntensityTable
+        intensities to transform into an ImageStack
+    image_shape : Tuple[int, int, int]
+
+    Returns
+    -------
+    ImageStack :
+        ImageStack containing Intensity information
+
+
+    """
+    # reverses the process used to produce the intensity table in to_pixel_intensities
+    data = intensities.values.reshape([
+        *image_shape,
+        intensities.sizes[Indices.CH],
+        intensities.sizes[Indices.HYB]])
+    data = data.transpose(4, 3, 0, 1, 2)
+    return ImageStack.from_numpy_array(data)

--- a/starfish/test/test_stack_intensity_table_reshaping.py
+++ b/starfish/test/test_stack_intensity_table_reshaping.py
@@ -15,13 +15,15 @@ def test_reshaping_between_stack_and_intensities(single_synthetic_spot):
     the created Imagestack is the same as the original
     """
     codebook, intensities, image = single_synthetic_spot
-    pixel_intensities = IntensityTable.from_image_stack(image, crop=(0, 0, 0))
+    pixel_intensities = IntensityTable.from_image_stack(image, 0, 0, 0)
     image_shape = (image.shape['z'], image.shape['y'], image.shape['x'])
-    image_from_pixels = from_pixel_intensities(pixel_intensities, image_shape)
+    image_from_pixels = pixel_intensities_to_imagestack(pixel_intensities, image_shape)
     assert np.array_equal(image.numpy_array, image_from_pixels.numpy_array)
 
 
-def from_pixel_intensities(intensities: IntensityTable, image_shape: Tuple[int, int, int]) -> "ImageStack":
+def pixel_intensities_to_imagestack(
+        intensities: IntensityTable, image_shape: Tuple[int, int, int]
+) -> ImageStack:
     """Re-create the pixel intensities from an IntensityTable
 
     Parameters
@@ -29,12 +31,13 @@ def from_pixel_intensities(intensities: IntensityTable, image_shape: Tuple[int, 
     intensities : IntensityTable
         intensities to transform into an ImageStack
     image_shape : Tuple[int, int, int]
+        the dimensions of z, y, and x for the original image that the intensity table was generated
+        from
 
     Returns
     -------
     ImageStack :
         ImageStack containing Intensity information
-
 
     """
     # reverses the process used to produce the intensity table in to_pixel_intensities


### PR DESCRIPTION
Add methods to:
- reshape ImageStack directly into an IntensityTable containing pixel intensities
- revert an IntensityTable containing pixel intensities back into an ImageStack

@ttung @dganguli There's a note at the bottom here questioning whether or not we want to support reshaping non-contiguous intensities (i.e. IntensityTables that contain _spots_) back into an ImageStack. My sense is no, since it would be a lossy reversion (we summarize spots as location, radius, intensity, not clear how to reconstruct original data). 

If we _don't_ support it, then I think having the method here is a bit weird, since it only works on one type of IntensityTable. Open to thoughts. 