### PR TITLE
[4/8] ENH: update euclidean codebook with MERFISH filters and NearestNeighbor search

### DIFF
--- a/notebooks/ISS_Simple_tutorial_-_Mouse_vs._Human_Fibroblasts.ipynb
+++ b/notebooks/ISS_Simple_tutorial_-_Mouse_vs._Human_Fibroblasts.ipynb
@@ -234,7 +234,7 @@
     "\n",
     "decoder = IssDecoder(pd.DataFrame({'barcode': ['AAGC', 'AGGC'], 'gene': ['ACTB_human', 'ACTB_mouse']}), \n",
     "                     letters=['T', 'G', 'C', 'A'])\n",
-    "dec = decoder.decode_euclidean(spots_df_tidy)\n",
+    "dec = decoder.metric_decode(spots_df_tidy)\n",
     "dec.qual.hist(bins=20)\n",
     "top_barcode = dec.barcode.value_counts()[0:10]\n",
     "top_barcode"

--- a/notebooks/ISS_Simple_tutorial_-_Mouse_vs._Human_Fibroblasts.py
+++ b/notebooks/ISS_Simple_tutorial_-_Mouse_vs._Human_Fibroblasts.py
@@ -158,7 +158,7 @@ from starfish.decoders.iss import IssDecoder
 
 decoder = IssDecoder(pd.DataFrame({'barcode': ['AAGC', 'AGGC'], 'gene': ['ACTB_human', 'ACTB_mouse']}), 
                      letters=['T', 'G', 'C', 'A'])
-dec = decoder.decode_euclidean(spots_df_tidy)
+dec = decoder.metric_decode(spots_df_tidy)
 dec.qual.hist(bins=20)
 top_barcode = dec.barcode.value_counts()[0:10]
 top_barcode

--- a/starfish/image/_stack.py
+++ b/starfish/image/_stack.py
@@ -584,16 +584,14 @@ class ImageStack:
         return pd.DataFrame(data)
 
     @property
-    def raw_shape(self) -> Tuple[int]:
+    def raw_shape(self) -> Tuple[int, int, int, int, int]:
         """
-        Returns the shape of the space that this image inhabits.  It does not include the dimensions of the image
-        itself.  For instance, if this is an X-Y image in a C-H-Y-X space, then the shape would include the dimensions C
-        and H.
+        Returns the shape of the 5-d image tensor stored as self.image
 
         Returns
         -------
-        Tuple[int] :
-            The sizes of the indices.
+        Tuple[int, int, int, int, int] :
+            The size of the image tensor
         """
         return self._data.shape
 

--- a/starfish/image/_stack.py
+++ b/starfish/image/_stack.py
@@ -8,18 +8,17 @@ from typing import Any, Callable, Iterable, Iterator, List, Mapping, MutableSequ
 
 import numpy as np
 import pandas as pd
+from scipy.ndimage.filters import gaussian_filter
 from scipy.stats import scoreatpercentile
 from skimage import exposure
-from scipy.ndimage.filters import gaussian_filter
 from slicedimage import Reader, Writer, TileSet, Tile
 from slicedimage.io import resolve_path_or_url
 from tqdm import tqdm
 
 from starfish.constants import Coordinates, Indices
 from starfish.errors import DataFormatWarning
-from starfish.pipeline.features.spot_attributes import SpotAttributes
 from starfish.intensity_table import IntensityTable
-from starfish.munge import dataframe_to_multiindex
+from starfish.pipeline.features.spot_attributes import SpotAttributes
 
 
 _DimensionMetadata = collections.namedtuple("_DimensionMetadata", ['order', 'required'])
@@ -969,91 +968,3 @@ class ImageStack:
                     empty.set_slice({Indices.HYB: h, Indices.CH: c, Indices.Z: z}, view)
 
         return empty
-
-    def to_pixel_intensities(self, crop: Tuple[int, int, int]=(0, 0, 0)) -> IntensityTable:
-        """Generate an IntensityTable from all the pixels in the ImageStack
-
-        Parameters
-        ----------
-        crop : Tuple[int, int, int]
-            number of pixels from the image borders (z, y, x) to ignore
-
-        Returns
-        -------
-
-        """
-        zmin, ymin, xmin = crop
-        zmax = self.shape['z'] - zmin
-        ymax = self.shape['y'] - ymin
-        xmax = self.shape['x'] - xmin
-        data = self.numpy_array.transpose(2, 3, 4, 1, 0)  # (z, y, x, ch, hyb)
-        cropped_data = data[zmin:zmax, ymin:ymax, xmin:xmax, :, :]
-        intensity_data = cropped_data.reshape(-1, self.num_chs, self.num_hybs)  # (pixels, ch, hyb)
-        z = np.arange(zmin, zmax)
-        y = np.arange(ymin, ymax)
-        x = np.arange(xmin, xmax)
-
-        pixel_coordinates = pd.DataFrame(
-            data=np.array(list(product(z, y, x))),
-            columns=['z', 'y', 'x']
-        )
-        pixel_coordinates['r'] = np.full(pixel_coordinates.shape[0], fill_value=np.nan)
-
-        spot_attributes = dataframe_to_multiindex(pixel_coordinates)
-        image_size = cropped_data.shape[:3]
-
-        return IntensityTable.from_spot_data(intensity_data, spot_attributes, image_size)
-
-    @classmethod
-    def from_pixel_intensities(
-            cls, intensities: IntensityTable, assume_contiguous: bool=True
-    ) -> "ImageStack":
-        """
-
-        Parameters
-        ----------
-        intensities : IntensityTable
-            intensities to transform into an ImageStack
-        assume_contiguous : bool
-            if True, indicates that every pixel is present in the intensity_table. In this case,
-            the IntensityTable can simply be reshaped back into an ImageStack reversing
-            ImageStack.to_intensities()
-
-        Notes
-        -----
-        assume_contiguous == False is not implemented
-
-        Returns
-        -------
-        ImageStack :
-            ImageStack containing Intensity information
-
-
-        """
-        # if assume_contiguous is True, we can just reshape the original array
-        if assume_contiguous:
-
-            # reverses the process used to produce the intensity table in to_pixel_intensities
-            data = intensities.values.reshape([
-                *intensities.attrs['image_shape'],
-                intensities.sizes[Indices.CH],
-                intensities.sizes[Indices.HYB]])
-            data = data.transpose(4, 3, 0, 1, 2)
-            return ImageStack.from_numpy_array(data)
-
-        else:
-
-            raise NotImplementedError
-
-            # not implementing this right now, not clear it makes sense to.
-
-            # # construct an empty (z, y, x) image
-            # decoded_image = np.zeros(self.attrs['image_shape'], dtype=int)
-            #
-            # # fill it with features
-            # coordinates = self.indexes['features'].to_frame()[['z', 'y', 'x']]
-            # genes = self.gene_name.values
-            #
-            # for i in np.arange(self.sizes[self.Constants.FEATURES.value]):
-            #     z, y, x = coordinates.iloc[i]
-            #     decoded_image[z, y, x] = self._gene_to_int[genes[i]]

--- a/starfish/image/_stack.py
+++ b/starfish/image/_stack.py
@@ -19,6 +19,7 @@ from starfish.constants import Coordinates, Indices
 from starfish.errors import DataFormatWarning
 from starfish.pipeline.features.spot_attributes import SpotAttributes
 from starfish.intensity_table import IntensityTable
+from starfish.munge import dataframe_to_multiindex
 
 
 _DimensionMetadata = collections.namedtuple("_DimensionMetadata", ['order', 'required'])
@@ -968,3 +969,91 @@ class ImageStack:
                     empty.set_slice({Indices.HYB: h, Indices.CH: c, Indices.Z: z}, view)
 
         return empty
+
+    def to_pixel_intensities(self, crop: Tuple[int, int, int]=(0, 0, 0)) -> IntensityTable:
+        """Generate an IntensityTable from all the pixels in the ImageStack
+
+        Parameters
+        ----------
+        crop : Tuple[int, int, int]
+            number of pixels from the image borders (z, y, x) to ignore
+
+        Returns
+        -------
+
+        """
+        zmin, ymin, xmin = crop
+        zmax = self.shape['z'] - zmin
+        ymax = self.shape['y'] - ymin
+        xmax = self.shape['x'] - xmin
+        data = self.numpy_array.transpose(2, 3, 4, 1, 0)  # (z, y, x, ch, hyb)
+        cropped_data = data[zmin:zmax, ymin:ymax, xmin:xmax, :, :]
+        intensity_data = cropped_data.reshape(-1, self.num_chs, self.num_hybs)  # (pixels, ch, hyb)
+        z = np.arange(zmin, zmax)
+        y = np.arange(ymin, ymax)
+        x = np.arange(xmin, xmax)
+
+        pixel_coordinates = pd.DataFrame(
+            data=np.array(list(product(z, y, x))),
+            columns=['z', 'y', 'x']
+        )
+        pixel_coordinates['r'] = np.full(pixel_coordinates.shape[0], fill_value=np.nan)
+
+        spot_attributes = dataframe_to_multiindex(pixel_coordinates)
+        image_size = cropped_data.shape[:3]
+
+        return IntensityTable.from_spot_data(intensity_data, spot_attributes, image_size)
+
+    @classmethod
+    def from_pixel_intensities(
+            cls, intensities: IntensityTable, assume_contiguous: bool=True
+    ) -> "ImageStack":
+        """
+
+        Parameters
+        ----------
+        intensities : IntensityTable
+            intensities to transform into an ImageStack
+        assume_contiguous : bool
+            if True, indicates that every pixel is present in the intensity_table. In this case,
+            the IntensityTable can simply be reshaped back into an ImageStack reversing
+            ImageStack.to_intensities()
+
+        Notes
+        -----
+        assume_contiguous == False is not implemented
+
+        Returns
+        -------
+        ImageStack :
+            ImageStack containing Intensity information
+
+
+        """
+        # if assume_contiguous is True, we can just reshape the original array
+        if assume_contiguous:
+
+            # reverses the process used to produce the intensity table in to_pixel_intensities
+            data = intensities.values.reshape([
+                *intensities.attrs['image_shape'],
+                intensities.sizes[Indices.CH],
+                intensities.sizes[Indices.HYB]])
+            data = data.transpose(4, 3, 0, 1, 2)
+            return ImageStack.from_numpy_array(data)
+
+        else:
+
+            raise NotImplementedError
+
+            # not implementing this right now, not clear it makes sense to.
+
+            # # construct an empty (z, y, x) image
+            # decoded_image = np.zeros(self.attrs['image_shape'], dtype=int)
+            #
+            # # fill it with features
+            # coordinates = self.indexes['features'].to_frame()[['z', 'y', 'x']]
+            # genes = self.gene_name.values
+            #
+            # for i in np.arange(self.sizes[self.Constants.FEATURES.value]):
+            #     z, y, x = coordinates.iloc[i]
+            #     decoded_image[z, y, x] = self._gene_to_int[genes[i]]

--- a/starfish/intensity_table.py
+++ b/starfish/intensity_table.py
@@ -280,21 +280,26 @@ class IntensityTable(xr.DataArray):
         return intensities
 
     @classmethod
-    def from_image_stack(cls, image_stack, crop: Tuple[int, int, int]=(0, 0, 0)) -> "IntensityTable":
+    def from_image_stack(cls, image_stack, crop_x: int=0, crop_y: int=0, crop_z: int=0) -> "IntensityTable":
         """Generate an IntensityTable from all the pixels in the ImageStack
 
         Parameters
         ----------
+        crop_x : int
+            number of pixels to crop from both top and bottom of x
+        crop_y : int
+            number of pixels to crop from both top and bottom of y
+        crop_z : int
+            number of pixels to crop from both top and bottom of z
         image_stack : ImageStack
-
-        crop : Tuple[int, int, int]
-            number of pixels from the image borders (z, y, x) to ignore
+            ImageStack containing pixels to be treated as intensities
 
         Returns
         -------
+        IntensityTable
+            IntensityTable containing one intensity per pixel (across channels and rounds)
 
         """
-        crop_z, crop_y, crop_x = crop
 
         # verify the image is large enough to crop
         assert crop_z * 2 < image_stack.shape['z']
@@ -328,4 +333,3 @@ class IntensityTable(xr.DataArray):
         image_size = cropped_data.shape[:3]
 
         return IntensityTable.from_spot_data(intensity_data, spot_attributes, image_size)
-

--- a/starfish/pipeline/features/spots/detector/gaussian.py
+++ b/starfish/pipeline/features/spots/detector/gaussian.py
@@ -1,5 +1,6 @@
 from itertools import product
 from numbers import Number
+from typing import Tuple
 
 import numpy as np
 import pandas as pd
@@ -95,7 +96,9 @@ class GaussianSpotDetector(SpotFinderAlgorithmBase):
         n_ch = stack.shape[Indices.CH]
         n_hyb = stack.shape[Indices.HYB]
         spot_attribute_index = dataframe_to_multiindex(spot_attributes)
-        intensity_table = IntensityTable.empty_intensity_table(spot_attribute_index, n_ch, n_hyb)
+        image_shape: Tuple[int, int, int] = stack.raw_shape[2:]
+        intensity_table = IntensityTable.empty_intensity_table(
+            spot_attribute_index, n_ch, n_hyb, image_shape)
 
         indices = product(range(n_ch), range(n_hyb))
         for c, h in indices:

--- a/starfish/test/dataset_fixtures.py
+++ b/starfish/test/dataset_fixtures.py
@@ -61,7 +61,7 @@ def small_intensity_table():
         [[1, 0],
          [0, 1]],
         [[0, 0],
-         [1, 1]]
+         [1, 1]],
     ])
 
     spot_attributes = dataframe_to_multiindex(pd.DataFrame(
@@ -72,8 +72,9 @@ def small_intensity_table():
             IntensityTable.SpotAttributes.RADIUS: [0.1, 0.2, 0.3]
         }
     ))
+    image_shape = (3, 2, 2)
 
-    return IntensityTable.from_spot_data(intensities, spot_attributes)
+    return IntensityTable.from_spot_data(intensities, spot_attributes, image_shape)
 
 
 @pytest.fixture(scope='module')

--- a/starfish/test/dataset_fixtures.py
+++ b/starfish/test/dataset_fixtures.py
@@ -238,3 +238,14 @@ def synthetic_spot_pass_through_stack(synthetic_dataset_with_truth_values):
         point_spread_function=(0, 0, 0), camera_detection_efficiency=1.0,
         background_electrons=0, graylevel=1)
     return codebook, true_intensities, img_stack
+
+
+@pytest.fixture()
+def single_synthetic_spot():
+    sd = synthesize.SyntheticData(
+        n_hyb=2, n_ch=2, n_z=2, height=20, width=30, n_codes=1, n_spots=1
+    )
+    codebook = sd.codebook()
+    intensities = sd.intensities(codebook)
+    image = sd.spots(intensities)
+    return codebook, intensities, image

--- a/starfish/test/dataset_fixtures.py
+++ b/starfish/test/dataset_fixtures.py
@@ -62,14 +62,18 @@ def small_intensity_table():
          [0, 1]],
         [[0, 0],
          [1, 1]],
+        [[0.5, 0.5],  # this one should fail decoding
+         [0.5, 0.5]],
+        [[0.1, 0],
+         [0, 0.1]],  # this one is a candidate for intensity filtering
     ])
 
     spot_attributes = dataframe_to_multiindex(pd.DataFrame(
         data={
-            IntensityTable.SpotAttributes.X: [0, 1, 2],
-            IntensityTable.SpotAttributes.Y: [3, 4, 5],
-            IntensityTable.SpotAttributes.Z: [0, 0, 0],
-            IntensityTable.SpotAttributes.RADIUS: [0.1, 0.2, 0.3]
+            IntensityTable.SpotAttributes.X: [0, 1, 2, 3, 4],
+            IntensityTable.SpotAttributes.Y: [3, 4, 5, 6, 7],
+            IntensityTable.SpotAttributes.Z: [0, 0, 0, 0, 0],
+            IntensityTable.SpotAttributes.RADIUS: [0.1, 2, 3, 2, 1]
         }
     ))
     image_shape = (3, 2, 2)
@@ -123,7 +127,9 @@ def loaded_codebook(simple_codebook_json):
 
 @pytest.fixture(scope='function')
 def euclidean_decoded_intensities(small_intensity_table, loaded_codebook):
-    decoded_intensities = loaded_codebook.decode_euclidean(small_intensity_table)
+    decoded_intensities = loaded_codebook.metric_decode(
+        small_intensity_table, max_distance=0, norm=2, min_intensity=0)
+    assert decoded_intensities.shape == (5, 2, 2)
     return decoded_intensities
 
 
@@ -177,7 +183,7 @@ def synthetic_dataset_with_truth_values_and_called_spots(
     intensities = gsd.find(hybridization_image=filtered)
     assert intensities.shape[0] == 5
 
-    codebook.decode_euclidean(intensities)
+    codebook.metric_decode(intensities, max_distance=1, min_intensity=0, norm=2)
 
     return codebook, true_intensities, image, intensities
 

--- a/starfish/test/full_pipelines/api/test_iss_api.py
+++ b/starfish/test/full_pipelines/api/test_iss_api.py
@@ -40,4 +40,4 @@ def test_iss_pipeline():
     intensities = gsd.find(hybridization_image=image)
     assert intensities.shape[0] == 5
 
-    codebook.decode_euclidean(intensities)
+    codebook.metric_decode(intensities, max_distance=1, min_intensity=0, norm=2)

--- a/starfish/test/image/test_imagestack.py
+++ b/starfish/test/image/test_imagestack.py
@@ -3,11 +3,14 @@ import pytest
 
 from starfish.constants import Indices
 from starfish.image import ImageStack
+from starfish.intensity_table import IntensityTable
 # don't inspect pytest fixtures in pycharm
 # noinspection PyUnresolvedReferences
 from starfish.test.dataset_fixtures import (
     synthetic_intensity_table, synthetic_spot_pass_through_stack, loaded_codebook,
-    synthetic_dataset_with_truth_values, simple_codebook_json, simple_codebook_array)
+    synthetic_dataset_with_truth_values, simple_codebook_json, simple_codebook_array,
+    single_synthetic_spot
+)
 
 
 def test_get_slice_simple_index():
@@ -207,3 +210,20 @@ def test_synthetic_spot_creation_produces_an_imagestack_with_correct_spot_locati
     assert np.array_equal(
         image.numpy_array[h, c, z, y, x],
         true_intensities.values[np.where(true_intensities)])
+
+
+# TODO ambrosejcarr: improve the tests here.
+def test_imagestack_to_intensity_table(single_synthetic_spot):
+    codebook, intensity_table, image = single_synthetic_spot
+    pixel_intensities = image.to_pixel_intensities()
+    pixel_intensities = codebook.decode_euclidean(
+        pixel_intensities)
+    assert isinstance(pixel_intensities, IntensityTable)
+
+
+def test_imagestack_to_intensity_table_no_noise(synthetic_spot_pass_through_stack):
+    codebook, intensity_table, image = synthetic_spot_pass_through_stack
+    pixel_intensities = image.to_pixel_intensities()
+    pixel_intensities = codebook.decode_euclidean(
+        pixel_intensities)
+    assert isinstance(pixel_intensities, IntensityTable)

--- a/starfish/test/image/test_imagestack.py
+++ b/starfish/test/image/test_imagestack.py
@@ -7,8 +7,12 @@ from starfish.intensity_table import IntensityTable
 # don't inspect pytest fixtures in pycharm
 # noinspection PyUnresolvedReferences
 from starfish.test.dataset_fixtures import (
-    synthetic_intensity_table, synthetic_spot_pass_through_stack, loaded_codebook,
-    synthetic_dataset_with_truth_values, simple_codebook_json, simple_codebook_array,
+    synthetic_intensity_table,
+    synthetic_spot_pass_through_stack,
+    loaded_codebook,
+    synthetic_dataset_with_truth_values,
+    simple_codebook_json,
+    simple_codebook_array,
     single_synthetic_spot
 )
 
@@ -215,7 +219,7 @@ def test_synthetic_spot_creation_produces_an_imagestack_with_correct_spot_locati
 # TODO ambrosejcarr: improve the tests here.
 def test_imagestack_to_intensity_table(single_synthetic_spot):
     codebook, intensity_table, image = single_synthetic_spot
-    pixel_intensities = image.to_pixel_intensities()
+    pixel_intensities = IntensityTable.from_image_stack(image)
     pixel_intensities = codebook.decode_euclidean(
         pixel_intensities)
     assert isinstance(pixel_intensities, IntensityTable)
@@ -223,7 +227,7 @@ def test_imagestack_to_intensity_table(single_synthetic_spot):
 
 def test_imagestack_to_intensity_table_no_noise(synthetic_spot_pass_through_stack):
     codebook, intensity_table, image = synthetic_spot_pass_through_stack
-    pixel_intensities = image.to_pixel_intensities()
+    pixel_intensities = IntensityTable.from_image_stack(image)
     pixel_intensities = codebook.decode_euclidean(
         pixel_intensities)
     assert isinstance(pixel_intensities, IntensityTable)

--- a/starfish/test/image/test_imagestack.py
+++ b/starfish/test/image/test_imagestack.py
@@ -220,14 +220,14 @@ def test_synthetic_spot_creation_produces_an_imagestack_with_correct_spot_locati
 def test_imagestack_to_intensity_table(single_synthetic_spot):
     codebook, intensity_table, image = single_synthetic_spot
     pixel_intensities = IntensityTable.from_image_stack(image)
-    pixel_intensities = codebook.decode_euclidean(
-        pixel_intensities)
+    pixel_intensities = codebook.metric_decode(
+        pixel_intensities, max_distance=0, min_intensity=1000, norm=2)
     assert isinstance(pixel_intensities, IntensityTable)
 
 
 def test_imagestack_to_intensity_table_no_noise(synthetic_spot_pass_through_stack):
     codebook, intensity_table, image = synthetic_spot_pass_through_stack
     pixel_intensities = IntensityTable.from_image_stack(image)
-    pixel_intensities = codebook.decode_euclidean(
-        pixel_intensities)
+    pixel_intensities = codebook.metric_decode(
+        pixel_intensities, max_distance=0, min_intensity=1000, norm=2)
     assert isinstance(pixel_intensities, IntensityTable)

--- a/starfish/test/pipeline/test_intensity_table.py
+++ b/starfish/test/pipeline/test_intensity_table.py
@@ -15,7 +15,8 @@ def test_empty_intensity_table():
     z = [1, 1]
     r = [1, 1]
     spot_attributes = pd.MultiIndex.from_arrays([x, y, z, r], names=('x', 'y', 'z', 'r'))
-    empty = IntensityTable.empty_intensity_table(spot_attributes, 2, 2)
+    image_shape = (2, 4, 4)
+    empty = IntensityTable.empty_intensity_table(spot_attributes, 2, 2, image_shape)
     assert empty.shape == (2, 2, 2)
     assert np.sum(empty.values) == 0
 

--- a/starfish/test/test_stack_intensity_table_reshaping.py
+++ b/starfish/test/test_stack_intensity_table_reshaping.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+# don't inspect pytest fixtures in pycharm
+# noinspection PyUnresolvedReferences
+from starfish.test.dataset_fixtures import single_synthetic_spot
+from starfish.image import ImageStack
+
+
+def test_reshaping_between_stack_and_intensities(single_synthetic_spot):
+    """
+    transform an pixels of an ImageStack into an IntensityTable and back again, then verify that
+    the created Imagestack is the same as the original
+    """
+    codebook, intensities, image = single_synthetic_spot
+    pixel_intensities = image.to_pixel_intensities()
+    image_from_pixels = ImageStack.from_pixel_intensities(pixel_intensities, assume_contiguous=True)
+    assert np.array_equal(image.numpy_array, image_from_pixels.numpy_array)

--- a/starfish/test/test_stack_intensity_table_reshaping.py
+++ b/starfish/test/test_stack_intensity_table_reshaping.py
@@ -1,9 +1,12 @@
 import numpy as np
+from typing import Tuple
 
+from starfish.constants import Indices
+from starfish.image import ImageStack
+from starfish.intensity_table import IntensityTable
 # don't inspect pytest fixtures in pycharm
 # noinspection PyUnresolvedReferences
 from starfish.test.dataset_fixtures import single_synthetic_spot
-from starfish.image import ImageStack
 
 
 def test_reshaping_between_stack_and_intensities(single_synthetic_spot):
@@ -12,6 +15,32 @@ def test_reshaping_between_stack_and_intensities(single_synthetic_spot):
     the created Imagestack is the same as the original
     """
     codebook, intensities, image = single_synthetic_spot
-    pixel_intensities = image.to_pixel_intensities()
-    image_from_pixels = ImageStack.from_pixel_intensities(pixel_intensities, assume_contiguous=True)
+    pixel_intensities = IntensityTable.from_image_stack(image, crop=(0, 0, 0))
+    image_shape = (image.shape['z'], image.shape['y'], image.shape['x'])
+    image_from_pixels = from_pixel_intensities(pixel_intensities, image_shape)
     assert np.array_equal(image.numpy_array, image_from_pixels.numpy_array)
+
+
+def from_pixel_intensities(intensities: IntensityTable, image_shape: Tuple[int, int, int]) -> "ImageStack":
+    """Re-create the pixel intensities from an IntensityTable
+
+    Parameters
+    ----------
+    intensities : IntensityTable
+        intensities to transform into an ImageStack
+    image_shape : Tuple[int, int, int]
+
+    Returns
+    -------
+    ImageStack :
+        ImageStack containing Intensity information
+
+
+    """
+    # reverses the process used to produce the intensity table in to_pixel_intensities
+    data = intensities.values.reshape([
+        *image_shape,
+        intensities.sizes[Indices.CH],
+        intensities.sizes[Indices.HYB]])
+    data = data.transpose(4, 3, 0, 1, 2)
+    return ImageStack.from_numpy_array(data)

--- a/starfish/test/test_stack_intensity_table_reshaping.py
+++ b/starfish/test/test_stack_intensity_table_reshaping.py
@@ -15,13 +15,15 @@ def test_reshaping_between_stack_and_intensities(single_synthetic_spot):
     the created Imagestack is the same as the original
     """
     codebook, intensities, image = single_synthetic_spot
-    pixel_intensities = IntensityTable.from_image_stack(image, crop=(0, 0, 0))
+    pixel_intensities = IntensityTable.from_image_stack(image, 0, 0, 0)
     image_shape = (image.shape['z'], image.shape['y'], image.shape['x'])
-    image_from_pixels = from_pixel_intensities(pixel_intensities, image_shape)
+    image_from_pixels = pixel_intensities_to_imagestack(pixel_intensities, image_shape)
     assert np.array_equal(image.numpy_array, image_from_pixels.numpy_array)
 
 
-def from_pixel_intensities(intensities: IntensityTable, image_shape: Tuple[int, int, int]) -> "ImageStack":
+def pixel_intensities_to_imagestack(
+        intensities: IntensityTable, image_shape: Tuple[int, int, int]
+) -> ImageStack:
     """Re-create the pixel intensities from an IntensityTable
 
     Parameters
@@ -29,12 +31,13 @@ def from_pixel_intensities(intensities: IntensityTable, image_shape: Tuple[int, 
     intensities : IntensityTable
         intensities to transform into an ImageStack
     image_shape : Tuple[int, int, int]
+        the dimensions of z, y, and x for the original image that the intensity table was generated
+        from
 
     Returns
     -------
     ImageStack :
         ImageStack containing Intensity information
-
 
     """
     # reverses the process used to produce the intensity table in to_pixel_intensities

--- a/starfish/test/test_synthetic_data.py
+++ b/starfish/test/test_synthetic_data.py
@@ -26,7 +26,7 @@ def test_round_trip_synthetic_data():
     gsd = GaussianSpotDetector(
         min_sigma=1, max_sigma=4, num_sigma=5, threshold=0, blobs_stack=spots)
     calculated_intensities = gsd.find(spots)
-    codebook.decode_euclidean(calculated_intensities)
+    codebook.metric_decode(calculated_intensities, max_distance=1, min_intensity=0, norm=2)
 
     # applying the gaussian blur to the intensities causes them to be reduced in magnitude, so
     # they won't be the same size, but they should be in the same place, and decode the same
@@ -83,7 +83,7 @@ def test_medium_synthetic_stack():
 
     gsd = GaussianSpotDetector(min_sigma=1, max_sigma=4, num_sigma=5, threshold=1e-4, blobs_stack=spots)
     calculated_intensities = gsd.find(spots)
-    codebook.decode_euclidean(calculated_intensities)
+    codebook.metric_decode(calculated_intensities, max_distance=1, min_intensity=0, norm=2)
 
     # spots are detected in a different order that they're generated; sorting makes comparison easy
     sorted_intensities = intensities.sortby('features')

--- a/starfish/typing.py
+++ b/starfish/typing.py
@@ -1,0 +1,3 @@
+from typing import Union
+
+Number = Union[int, float]


### PR DESCRIPTION
- Updates euclidean decode to work with the MERFISH requirements
- Swap out brute force search for NearestNeighbors
- add `min_intensity`, `max_distance`
- swap `np.nan` gene_ids to `None`. Both approaches are gross, but `np.nan` was being implicitly converted to string, so I find setting it as a string `None` more explicit. How to deal with `object` coordinate indices is on my list of things to talk to the xarray people about. 