### PR TITLE
[5/8] ENH: adapt connected-components pixel merging to IntensityTable

### DIFF
--- a/starfish/intensity_table.py
+++ b/starfish/intensity_table.py
@@ -1,12 +1,12 @@
-from typing import Union, Tuple
 from itertools import product
+from typing import Union, Tuple
 
 import numpy as np
 import pandas as pd
 import xarray as xr
 
-from starfish.munge import dataframe_to_multiindex
 from starfish.constants import Indices, AugmentedEnum
+from starfish.munge import dataframe_to_multiindex
 
 
 class IntensityTable(xr.DataArray):
@@ -345,3 +345,7 @@ class IntensityTable(xr.DataArray):
         mask = np.where(self.coords.features[self.SpotAttributes.RADIUS.value] < min_size)[0]
         mask |= np.where(self.coords.features[self.SpotAttributes.RADIUS.value] > max_size)[0]
         return mask
+
+    def _intensities_from_regions(self, props, reduce_op='max') -> "IntensityTable":
+        """turn regions back into intensities by reducing over the labeled area"""
+        raise NotImplementedError

--- a/starfish/pipeline/features/pixels/combine_adjacent_features.py
+++ b/starfish/pipeline/features/pixels/combine_adjacent_features.py
@@ -1,0 +1,129 @@
+from typing import List, Tuple, Union
+
+import numpy as np
+import pandas as pd
+from skimage.measure import regionprops, label
+
+from starfish.munge import dataframe_to_multiindex
+from starfish.constants import Indices
+from starfish.intensity_table import IntensityTable
+
+Number = Union[int, float]
+
+
+def combine_adjacent_features(
+        intensities: IntensityTable, min_area: Number, max_area: Number, connectivity: int=2,
+) -> Tuple[IntensityTable, List, np.ndarray, np.ndarray]:
+    """
+
+    Parameters
+    ----------
+    intensities : IntensityTable
+        pixel-valued IntensityTable
+    min_area : Number
+        discard spots whose total pixel area is less than this value
+    max_area : Number
+        discard spots whose total pixel area is greater than this value
+    connectivity : int
+        the connectivity allowed when constructing connected components. Intuitively it can be
+        thought of as the number of square steps allowed between pixels that are considered
+        connected. 1 enforces adjacent pixels. 2 (default) allows diagonal pixels in the same
+        plane. 3 allows diagonal pixels in 3d.
+
+    Returns
+    -------
+    IntensityTable :
+        spot intensities
+    List[Object] :
+        region properties for each spot (see skimage.measure.regionprops)
+    np.ndarray[int] :
+        label image wherein each connected component (spot) is coded with a different
+        integer
+    np.ndarray[int] :
+        decoded image wherein each target is coded as a different integer. Intended for visualization
+
+    """
+    # None needs to map to zero, non-none needs to map to something else.
+    int_to_gene = dict(
+        zip(range(1, np.iinfo(np.int).max),
+            set(intensities.gene_name.values) - {'None'}))
+    int_to_gene[0] = 'None'
+    gene_to_int = {v: k for (k, v) in int_to_gene.items()}
+
+    # map genes to ints
+    gene_list = [gene_to_int[g] for g in intensities.coords[intensities.Constants.GENE.value].values]
+    gene_array = np.array(gene_list)
+
+    # reverses the linearization that was used to construct the IntensityTable from the ImageStack
+    decoded_image: np.ndarray = gene_array.reshape(intensities.attrs['image_shape'])
+
+    # label each pixel according to its component
+    label_image: np.ndarray = label(decoded_image, connectivity=connectivity)
+
+    # calculate the mean value grouped by (ch, round) across all pixels of a connected component
+    pixel_labels = label_image.reshape(-1)
+    intensities['spot_id'] = (IntensityTable.Constants.FEATURES.value, pixel_labels)
+    mean_pixel_traces = intensities.groupby('spot_id').mean(IntensityTable.Constants.FEATURES.value)
+    mean_distances = intensities[IntensityTable.Constants.DISTANCE.value].groupby('spot_id').mean(
+        IntensityTable.Constants.FEATURES.value)
+    mean_pixel_traces[IntensityTable.Constants.DISTANCE.value] = (
+        'spot_id',
+        np.ravel(mean_distances)
+    )
+
+    # "Zero" spot id is background in the label_image. Remove it.
+    # TODO ambrosejcarr: can we replace zero with nan above to get around this?
+    mean_pixel_traces = mean_pixel_traces.loc[mean_pixel_traces['spot_id'] > 0]
+    props: List = regionprops(np.squeeze(label_image))
+
+    # calculate spots and drop ones that fail the area threshold
+    spots = []
+    passes_filter = np.ones_like(props, dtype=np.bool)  # default is passing (ones)
+    for i, spot_property in enumerate(props):
+        # TODO ambrosejcarr: add tests for min/max area when fixing masking
+        if min_area <= spot_property.area < max_area:
+
+            # because of the above skimage issue, we need to support both 2d and 3d properties
+            if len(spot_property.centroid) == 3:
+                spot_attrs = {
+                    'z': int(spot_property.centroid[0]),
+                    'y': int(spot_property.centroid[1]),
+                    'x': int(spot_property.centroid[2])
+                }
+            else:  # data is 2d
+                spot_attrs = {
+                    'z': 0,
+                    'y': int(spot_property.centroid[0]),
+                    'x': int(spot_property.centroid[1])
+                }
+
+            # we're back to 3d or fake-3d here
+            gene_index = decoded_image[spot_attrs['z'], spot_attrs['y'], spot_attrs['x']]
+            spot_attrs['gene_name'] = int_to_gene[gene_index]
+            spot_attrs['radius'] = spot_property.equivalent_diameter / 2
+            spots.append(spot_attrs)
+        else:
+            passes_filter[i] = 0  # did not pass radius filter
+
+    # filter intensities
+    mean_pixel_traces = mean_pixel_traces.loc[passes_filter]
+
+    # now I need to make an IntensityTable from this thing.
+    spots_df = pd.DataFrame(spots)
+    spots_df[IntensityTable.Constants.DISTANCE.value] = \
+        mean_pixel_traces[IntensityTable.Constants.DISTANCE.value]
+
+    # create new indexes for the output IntensityTable
+    spots_index = dataframe_to_multiindex(spots_df)
+    channel_index = mean_pixel_traces.indexes[Indices.CH]
+    round_index = mean_pixel_traces.indexes[Indices.HYB]
+
+    # create the output IntensityTable
+    dims = (IntensityTable.Constants.FEATURES.value, Indices.CH.value, Indices.HYB.value)
+    attrs = {'image_shape': intensities.attrs['image_shape']}
+    intensity_table = IntensityTable(
+        data=mean_pixel_traces, coords=(spots_index, channel_index, round_index), dims=dims,
+        attrs=attrs
+    )
+
+    return intensity_table, props, label_image, decoded_image

--- a/starfish/test/pipeline/test_intensity_table.py
+++ b/starfish/test/pipeline/test_intensity_table.py
@@ -1,12 +1,17 @@
+from typing import Tuple
+
 import numpy as np
 import pandas as pd
 
 from starfish.constants import Indices
 from starfish.intensity_table import IntensityTable
+from starfish.codebook import Codebook
+from starfish.image import ImageStack
+from starfish.pipeline.features.pixels.combine_adjacent_features import combine_adjacent_features
 # don't inspect pytest fixtures in pycharm
 # noinspection PyUnresolvedReferences
 from starfish.test.dataset_fixtures import (
-    loaded_codebook, simple_codebook_json, simple_codebook_array)
+    loaded_codebook, simple_codebook_json, simple_codebook_array, single_synthetic_spot)
 
 
 def test_empty_intensity_table():
@@ -15,7 +20,7 @@ def test_empty_intensity_table():
     z = [1, 1]
     r = [1, 1]
     spot_attributes = pd.MultiIndex.from_arrays([x, y, z, r], names=('x', 'y', 'z', 'r'))
-    image_shape = (2, 4, 4)
+    image_shape = (2, 4, 3)
     empty = IntensityTable.empty_intensity_table(spot_attributes, 2, 2, image_shape)
     assert empty.shape == (2, 2, 2)
     assert np.sum(empty.values) == 0
@@ -37,3 +42,66 @@ def test_synthetic_intensities_have_correct_number_of_on_features(loaded_codeboo
     # this asserts that the number of features "on" in intensities should be equal to the
     # number of "on" features in the codewords, times the total number of spots in intensities.
     assert on_features == loaded_codebook.sum((Indices.CH, Indices.HYB)).values.mean() * n_spots
+
+
+def feature_data() -> Tuple[Codebook, ImageStack]:
+    # This codebook has two codes: on/off and on/on
+    # This array has 3 spots: one on/off, one on/on, and one off/on
+    # They exist in the first and second z-slice, but not the third.
+    code_array = [
+        {
+            # on/off
+            Codebook.Constants.CODEWORD.value: [
+                {Indices.HYB.value: 0, Indices.CH.value: 0, Codebook.Constants.VALUE.value: 1},
+            ],
+            Codebook.Constants.GENE.value: "gene_1"
+        },
+        {
+            # on/on
+            Codebook.Constants.CODEWORD.value: [
+                {Indices.HYB.value: 0, Indices.CH.value: 0, Codebook.Constants.VALUE.value: 1},
+                {Indices.HYB.value: 1, Indices.CH.value: 0, Codebook.Constants.VALUE.value: 1},
+            ],
+            Codebook.Constants.GENE.value: "gene_2"
+        }
+    ]
+    codebook = Codebook.from_code_array(code_array)
+
+    data = np.array(
+        [[[[1, 1, 0, 1],  # hyb 0
+           [1, 1, 0, 1],
+           [0, 0, 0, 0]],
+
+          [[1, 1, 0, 1],
+           [1, 1, 0, 1],
+           [0, 0, 0, 0]],
+
+          [[0, 0, 0, 1],
+           [0, 0, 0, 1],
+           [0, 0, 0, 0]]],
+
+         [[[1, 1, 0, 0],  # hyb 1
+           [1, 1, 0, 0],
+           [0, 0, 0, 1]],
+
+          [[1, 1, 0, 0],
+           [1, 1, 0, 0],
+           [0, 0, 0, 1]],
+
+          [[0, 0, 0, 0],
+           [0, 0, 0, 0],
+           [0, 0, 0, 1]]]]
+    )
+    data = data.reshape(2, 1, 3, 3, 4)
+    image = ImageStack.from_numpy_array(data)
+    return codebook, image
+
+
+def test_combine_adjacent_features():
+    codebook, image = feature_data()
+    new_intensities = IntensityTable.from_image_stack(image)
+    new_intensities = codebook.metric_decode(new_intensities, max_distance=0.5, min_intensity=0.5, norm=2)
+    combined_intensities = combine_adjacent_features(new_intensities, min_area=0, max_area=10)[0]
+    # this is "working", with the caveat that the z-coord is a bit weird and potentially wrong.
+    assert np.array_equal(combined_intensities.shape, (2, 1, 2))
+    assert np.array_equal(combined_intensities.gene_name, ['gene_2', 'gene_1'])


### PR DESCRIPTION
- Adds connected components pixel merging to IntensityTable

I've left some notes in the method string that discuss how we might implement this for non-contiguous methods. If the decision is to not support this, I'll remove that text prior to merging. 