### PR TITLE
__str__ for AugmentedEnum

### DIFF
--- a/starfish/constants.py
+++ b/starfish/constants.py
@@ -10,6 +10,9 @@ class AugmentedEnum(Enum):
             return self.value == other
         return False
 
+    def __str__(self) -> str:
+        return self.value
+
 
 class Coordinates(AugmentedEnum):
     X = 'x'


### PR DESCRIPTION
This allows for easier formatting without requiring a call to `.value`.  Only downside is that it's not obvious when one is dealing with an AugmentedEnum or a string.