### PR TITLE
added mean high pass filter

### DIFF
--- a/starfish/pipeline/filter/__init__.py
+++ b/starfish/pipeline/filter/__init__.py
@@ -10,6 +10,7 @@ from . import gaussian_high_pass
 from . import gaussian_low_pass
 from . import richardson_lucy_deconvolution
 from . import white_tophat
+from . import mean_high_pass
 
 
 class Filter(PipelineComponent):

--- a/starfish/pipeline/filter/mean_high_pass.py
+++ b/starfish/pipeline/filter/mean_high_pass.py
@@ -17,15 +17,15 @@ class MeanHighPass(FilterAlgorithmBase):
     def __init__(
             self, size: Union[Number, Tuple[Number]], is_volume: bool=False, verbose: bool=False, **kwargs
     ) -> None:
-        """Mean high pass filter. 
+        """Mean high pass filter.
 
-        The mean high pass filter reduces low spatial frequency features by subtracting a 
-        mean filtered image from the original image. The mean filter smooths an image by replacing 
-        each pixel's value with an average of the pixel values of the surrounding neighborhood. 
+        The mean high pass filter reduces low spatial frequency features by subtracting a
+        mean filtered image from the original image. The mean filter smooths an image by replacing
+        each pixel's value with an average of the pixel values of the surrounding neighborhood.
 
         The mean filter is also known as a uniform or box filter.
 
-        This is a pass through for the scipy.ndimage.filters.uniform_filter: 
+        This is a pass through for the scipy.ndimage.filters.uniform_filter:
         https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.ndimage.uniform_filter.html
 
         Parameters

--- a/starfish/pipeline/filter/mean_high_pass.py
+++ b/starfish/pipeline/filter/mean_high_pass.py
@@ -1,27 +1,27 @@
 import argparse
 from functools import partial
 from numbers import Number
-from typing import Callable, Union, Tuple, Optional
+from typing import Callable, Optional, Union, Tuple
 
 import numpy as np
+from scipy.ndimage.filters import uniform_filter
 from skimage import img_as_uint
 
 from starfish.errors import DataFormatWarning
 from starfish.image import ImageStack
-from scipy.ndimage.filters import uniform_filter
 from ._base import FilterAlgorithmBase
 
 
 class MeanHighPass(FilterAlgorithmBase):
 
     def __init__(
-            self, size: Number, is_volume: bool=False, verbose: bool=False, **kwargs
+            self, size: Union[Number, Tuple[Number]], is_volume: bool=False, verbose: bool=False, **kwargs
     ) -> None:
         """Mean high pass filter
 
         Parameters
         ----------
-        size : Number
+        size : Union[Number, Tuple[Number]]
             width of the kernel
         is_volume : bool
             If True, 3d (z, y, x) volumes will be filtered, otherwise, filter 2d tiles independently.
@@ -29,6 +29,14 @@ class MeanHighPass(FilterAlgorithmBase):
             if True, report on filtering progress (default = False)
 
         """
+
+        if isinstance(size, tuple):
+            message = ("if passing an anisotropic kernel, the dimensionality must match the data shape ({shape}), not "
+                       "{passed_shape}")
+            if is_volume and len(sigma) != 3:
+                raise ValueError(message.format(shape=3, passed_shape=len(sigma)))
+            if not is_volume and len(sigma) != 2:
+                raise ValueError(message.format(shape=2, passed_shape=len(sigma)))
 
         self.size = size
         self.is_volume = is_volume

--- a/starfish/pipeline/filter/mean_high_pass.py
+++ b/starfish/pipeline/filter/mean_high_pass.py
@@ -42,10 +42,10 @@ class MeanHighPass(FilterAlgorithmBase):
         if isinstance(size, tuple):
             message = ("if passing an anisotropic kernel, the dimensionality must match the data shape ({shape}), not "
                        "{passed_shape}")
-            if is_volume and len(sigma) != 3:
-                raise ValueError(message.format(shape=3, passed_shape=len(sigma)))
-            if not is_volume and len(sigma) != 2:
-                raise ValueError(message.format(shape=2, passed_shape=len(sigma)))
+            if is_volume and len(size) != 3:
+                raise ValueError(message.format(shape=3, passed_shape=len(size)))
+            if not is_volume and len(size) != 2:
+                raise ValueError(message.format(shape=2, passed_shape=len(size)))
 
         self.size = size
         self.is_volume = is_volume

--- a/starfish/pipeline/filter/mean_high_pass.py
+++ b/starfish/pipeline/filter/mean_high_pass.py
@@ -1,0 +1,94 @@
+import argparse
+from functools import partial
+from numbers import Number
+from typing import Callable, Union, Tuple, Optional
+
+import numpy as np
+from skimage import img_as_uint
+
+from starfish.errors import DataFormatWarning
+from starfish.image import ImageStack
+from scipy.ndimage.filters import uniform_filter
+from ._base import FilterAlgorithmBase
+
+
+class MeanHighPass(FilterAlgorithmBase):
+
+    def __init__(
+            self, size: Number, is_volume: bool=False, verbose: bool=False, **kwargs
+    ) -> None:
+        """Mean high pass filter
+
+        Parameters
+        ----------
+        size : Number
+            width of the kernel
+        is_volume : bool
+            If True, 3d (z, y, x) volumes will be filtered, otherwise, filter 2d tiles independently.
+        verbose : bool
+            if True, report on filtering progress (default = False)
+
+        """
+
+        self.size = size
+        self.is_volume = is_volume
+        self.verbose = verbose
+
+    @classmethod
+    def add_arguments(cls, group_parser: argparse.ArgumentParser) -> None:
+        group_parser.add_argument(
+            "--size", type=float, help="width of the kernel")
+        group_parser.add_argument(
+            "--is-volume", action="store_true", help="indicates that the image stack should be filtered in 3d")
+
+    @staticmethod
+    def high_pass(image: np.ndarray, size: Number) -> np.ndarray:
+        """
+        Applies a gaussian high pass filter to an image
+
+        Parameters
+        ----------
+        image : numpy.ndarray[np.uint16]
+            2-d or 3-d image data
+        size : Number
+            width of the kernel
+
+        Returns
+        -------
+        np.ndarray :
+            Filtered image, same shape as input
+
+        """
+        if image.dtype != np.uint16:
+            DataFormatWarning('mean filters currently only support uint16 images. Image data will be converted.')
+            image = img_as_uint(image)
+
+        blurred: np.ndarray = uniform_filter(image, size)
+
+        over_flow_ind: np.ndarray[bool] = image < blurred
+        filtered: np.ndarray = image - blurred
+        filtered[over_flow_ind] = 0
+
+        return filtered
+
+    def filter(self, stack: ImageStack, in_place: bool=True) -> Optional[ImageStack]:
+        """Perform filtering of an image stack
+
+        Parameters
+        ----------
+        stack : ImageStack
+            Stack to be filtered.
+        in_place : bool
+            if True, process ImageStack in-place, otherwise return a new stack
+
+        Returns
+        -------
+        Optional[ImageStack] :
+            if in_place is False, return the results of filter as a new stack
+
+        """
+        high_pass: Callable = partial(self.high_pass, size=self.size)
+        result = stack.apply(high_pass, is_volume=self.is_volume, verbose=self.verbose, in_place=in_place)
+        if not in_place:
+            return result
+        return None

--- a/starfish/pipeline/filter/mean_high_pass.py
+++ b/starfish/pipeline/filter/mean_high_pass.py
@@ -17,7 +17,16 @@ class MeanHighPass(FilterAlgorithmBase):
     def __init__(
             self, size: Union[Number, Tuple[Number]], is_volume: bool=False, verbose: bool=False, **kwargs
     ) -> None:
-        """Mean high pass filter
+        """Mean high pass filter. 
+
+        The mean high pass filter reduces low spatial frequency features by subtracting a 
+        mean filtered image from the original image. The mean filter smooths an image by replacing 
+        each pixel's value with an average of the pixel values of the surrounding neighborhood. 
+
+        The mean filter is also known as a uniform or box filter.
+
+        This is a pass through for the scipy.ndimage.filters.uniform_filter: 
+        https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.ndimage.uniform_filter.html
 
         Parameters
         ----------


### PR DESCRIPTION
I added a mean high pass filter following the same pattern as the Gaussian high pass filter. The image typing is handled in the same manner as the Gaussian high pass filter (uses img_as_uint to convert) and will likely need to be updated when issue #316 is resolved. 

I did not add a test, as only some of the filters have tests. However, if the current test style for the Gaussian High Pass filter (just checking that the total intensity is reduced) is sufficient, I can add that.