### PR TITLE
ENH: require pytest>=3.6.3

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -2,7 +2,7 @@ click
 matplotlib
 numpy != 1.13.0
 pandas
-pytest
+pytest>=3.6.3
 regional
 requests
 scikit-image>=0.14.0


### PR DESCRIPTION
- Travis installs pytest 3.3 by default, which breaks a dependency on pytest-xdist. 