### PR TITLE
ENH: refactor gaussian spot detection to enable per-(round, channel) detection

### DIFF
--- a/starfish/pipeline/features/spot_attributes.py
+++ b/starfish/pipeline/features/spot_attributes.py
@@ -11,7 +11,7 @@ class SpotAttributes(ValidatedTable):
     required_fields = {
         'x',  # spot x-coordinate
         'y',  # spot y-coordinate
-        'r',  # spot radius
+        'radius',  # spot radius
         'intensity',  # intensity of spot (commonly max or average)
         'spot_id'  # integer spot id
     }

--- a/starfish/pipeline/features/spots/detector/detect.py
+++ b/starfish/pipeline/features/spots/detector/detect.py
@@ -1,0 +1,211 @@
+from functools import partial
+from itertools import product
+from typing import Callable, Dict, Tuple, Union, Sequence
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from starfish.constants import Indices
+from starfish.image import ImageStack
+from starfish.intensity_table import IntensityTable
+from starfish.munge import dataframe_to_multiindex
+from starfish.pipeline.features.spot_attributes import SpotAttributes
+from starfish.typing import Number
+
+
+def measure_spot_intensity(
+        image: Union[np.ndarray, xr.DataArray],
+        spots: pd.DataFrame,
+        measurement_function: Callable[[Sequence], Number]) \
+        -> pd.Series:
+    """measure the intensity of each spot in spots in the corresponding image
+
+    Parameters
+    ----------
+    image : Union[np.ndarray, xr.DataArray],
+        3-d volume in which to measure intensities
+    spots : pd.DataFrame
+        SpotAttributes table containing coordinates and radii of spots
+    measurement_function : Callable[[Sequence], Number]) \
+        Function to apply over the spot volumes to identify the intensity (e.g. max, mean, ...)
+
+    Returns
+    -------
+    pd.Series :
+        Intensities for each spot in SpotAttributes
+
+    """
+
+    def fn(row: pd.Series) -> Number:
+        int_row: pd.Series = row.astype(int)
+        result = measurement_function(
+            image[
+                int_row['z_min']:int_row['z_max'],
+                int_row['y_min']:int_row['y_max'],
+                int_row['x_min']:int_row['x_max']
+            ]
+        )
+        return result
+
+    return spots.apply(
+        fn,
+        axis=1
+    )
+
+
+def measure_spot_intensities(
+        data_image: ImageStack,
+        spot_attributes: pd.DataFrame,
+        measurement_function: Callable[[Sequence], Number], ) \
+        -> IntensityTable:
+    """given spots found from a reference image, find those spots across a data_image
+
+    Parameters
+    ----------
+    data_image : ImageStack
+        ImageStack containing multiple volumes for which spots' intensities must be calculated
+    spot_attributes : pd.Dataframe
+        Locations and radii of spots
+    measurement_function : Callable[[Sequence], Number]) \
+        Function to apply over the spot volumes to identify the intensity (e.g. max, mean, ...)
+
+    Returns
+    -------
+    IntensityTable :
+        3d tensor of (spot, channel, round) information for each coded spot
+
+    """
+
+    n_ch = data_image.shape[Indices.CH]
+    n_round = data_image.shape[Indices.ROUND]
+    spot_attribute_index = dataframe_to_multiindex(spot_attributes)
+    image_shape: Tuple[int, int, int] = data_image.raw_shape[2:]
+    intensity_table = IntensityTable.empty_intensity_table(
+        spot_attribute_index, n_ch, n_round, image_shape)
+
+    indices = product(range(n_ch), range(n_round))
+    for c, r in indices:
+        image, _ = data_image.get_slice({Indices.CH: c, Indices.ROUND: r})
+        blob_intensities: pd.Series = measure_spot_intensity(
+            image, spot_attributes, measurement_function)
+        intensity_table[:, c, r] = blob_intensities
+
+    return intensity_table
+
+
+def concatenate_spot_attributes_to_intensities(
+        spot_attributes: Sequence[Tuple[SpotAttributes, Dict[Indices, int]]]) \
+        -> IntensityTable:
+    """
+    Merge multiple spot attributes frames into a single IntensityTable without merging across
+    channels and imaging rounds
+
+    Parameters
+    ----------
+    spot_attributes : Sequence[Tuple[SpotAttributes, Dict[Indices, int]]]
+        A sequence of SpotAttribute objects and the Indices (channel, round) that each object is
+        associated with.
+
+    Returns
+    -------
+    IntensityTable :
+        concatenated input SpotAttributes, converted to an IntensityTable object
+
+    """
+    n_ch: int = max(inds[Indices.CH] for _, inds in spot_attributes) + 1
+    n_round: int = max(inds[Indices.ROUND] for _, inds in spot_attributes) + 1
+
+    all_spots = pd.concat([sa.data for sa, inds in spot_attributes])
+    spot_attribute_index = dataframe_to_multiindex(all_spots.drop(['spot_id', 'intensity'], axis=1))
+
+    # TODO ambrosejcarr: remove image_shape
+    z_max = max(max(sa.data['z']) for sa, inds in spot_attributes)
+    y_max = max(max(sa.data['y']) for sa, inds in spot_attributes)
+    x_max = max(max(sa.data['x']) for sa, inds in spot_attributes)
+    image_shape = (z_max, y_max, x_max)
+
+    intensity_table = IntensityTable.empty_intensity_table(
+        spot_attribute_index, n_ch, n_round, image_shape
+    )
+
+    i = 0
+    for attrs, inds in spot_attributes:
+        for _, row in attrs.data.iterrows():
+            intensity_table[i, inds[Indices.CH], inds[Indices.ROUND]] = row['intensity']
+            i += 1
+
+    return intensity_table
+
+
+def detect_spots(
+        data_image: ImageStack,
+        spot_finding_method: Callable[..., SpotAttributes],
+        spot_finding_kwargs: Dict=None,
+        reference_image: Union[xr.DataArray, np.ndarray]=None,
+        reference_from_max_projection: bool=False,
+        measurement_function: Callable[[Sequence], Number]=np.max,
+) -> IntensityTable:
+    """Apply a spot_finding_method to a ImageStack
+
+    Parameters
+    ----------
+    data_image : ImageStack
+        The ImageStack containing spots
+    spot_finding_method : Callable[[Any], IntensityTable]
+        The method to identify spots
+    spot_finding_kwargs : Dict
+        additional keyword arguments to pass to spot_finding_method
+    reference_image : xr.DataArray
+        (Optional) a reference image. If provided, spots will be found in this image, and then
+        the locations that correspond to these spots will be measured across each channel and hyb,
+        filling in the values in the IntensityTable
+    reference_from_max_projection : Tuple[Indices]
+        (Optional) if True, create a reference image by max-projecting the channels and imaging
+        rounds found in data_image.
+    measurement_function : Callable
+        the function to apply over the spot area to extract the intensity value (default 'np.max')
+
+    Notes
+    -----
+    - This class will always detect spots in 3d. If 2d spot detection is desired, the data should
+      be projected down to "fake 3d" prior to submission to this function
+    - If neither reference_image nor reference_from_max_projection are passed, spots will be
+      detected _independently_ in each channel. This assumes a non-multiplex imaging experiment,
+      as only one (ch, round) will be measured for each spot.
+
+    Returns
+    -------
+    IntensityTable :
+        IntensityTable containing the intensity of each spot, its radius, and location in pixel
+        coordinates
+
+    """
+
+    if spot_finding_kwargs is None:
+        spot_finding_kwargs = {}
+
+    if reference_image is not None and reference_from_max_projection:
+        raise ValueError(
+            'Please pass only one of reference_image and reference_from_max_projection'
+        )
+
+    if reference_from_max_projection:
+        reference_image = data_image.max_proj(Indices.CH, Indices.ROUND)
+
+    if reference_image is not None:
+        reference_spot_locations = spot_finding_method(reference_image, **spot_finding_kwargs)
+        intensity_table = measure_spot_intensities(
+            data_image=data_image,
+            spot_attributes=reference_spot_locations.data,
+            measurement_function=measurement_function
+        )
+    else:
+        spot_finding_method = partial(spot_finding_method, **spot_finding_kwargs)
+        spot_attributes_list = data_image.transform(
+            func=spot_finding_method,
+            is_volume=True  # always use volumetric or pseudo-3d (1, n, m) data
+        )
+        intensity_table = concatenate_spot_attributes_to_intensities(spot_attributes_list)
+
+    return intensity_table

--- a/starfish/pipeline/features/spots/detector/gaussian.py
+++ b/starfish/pipeline/features/spots/detector/gaussian.py
@@ -1,8 +1,9 @@
-from typing import Callable, Sequence
+from typing import Callable, Sequence, Union
 
 import numpy as np
 import pandas as pd
 from skimage.feature import blob_log
+import xarray as xr
 
 from starfish.constants import Indices, Features
 from starfish.image import ImageStack
@@ -129,15 +130,16 @@ class GaussianSpotDetector(SpotFinderAlgorithmBase):
 
 # TODO ambrosejcarr: make this return IntensityTable instead of SpotAttributes
 def gaussian_spot_detector(
-        data_image: ImageStack, min_sigma: Number, max_sigma: Number, num_sigma: int,
-        threshold: Number, overlap=0.5, measurement_function: Callable[[Sequence], Number]=np.max) \
+        data_image: Union[np.ndarray, xr.DataArray], min_sigma: Number, max_sigma: Number,
+        num_sigma: int, threshold: Number, overlap=0.5,
+        measurement_function: Callable[[Sequence], Number]=np.max) \
         -> SpotAttributes:
     """
     Find gaussian blobs in an data image
 
     Parameters
     ----------
-    data_image : ImageStack
+    data_image : Union[np.ndarray, xr.DataArray]
         ImageStack containing blobs to be detected
     min_sigma : float
         The minimum standard deviation for Gaussian Kernel. Keep this low to

--- a/starfish/pipeline/features/spots/detector/gaussian.py
+++ b/starfish/pipeline/features/spots/detector/gaussian.py
@@ -1,6 +1,4 @@
-from itertools import product
-from numbers import Number
-from typing import Tuple
+from typing import Callable, Sequence
 
 import numpy as np
 import pandas as pd
@@ -8,18 +6,24 @@ from skimage.feature import blob_log
 
 from starfish.constants import Indices, Features
 from starfish.image import ImageStack
-from starfish.munge import dataframe_to_multiindex
 from starfish.intensity_table import IntensityTable
+from starfish.pipeline.features.spot_attributes import SpotAttributes
+from starfish.pipeline.features.spots.detector.detect import (
+    measure_spot_intensity,
+    detect_spots,
+)
 from starfish.util.argparse import FsExistsType
+from starfish.typing import Number
 from ._base import SpotFinderAlgorithmBase
 
 
 class GaussianSpotDetector(SpotFinderAlgorithmBase):
 
     def __init__(
-            self, min_sigma, max_sigma, num_sigma, threshold,
-            blobs_stack, overlap=0.5, measurement_type='max', is_volume: bool=True, **kwargs
-    ) -> None:
+            self, min_sigma: Number, max_sigma: Number, num_sigma: int, threshold: Number,
+            blobs_stack: ImageStack, overlap=0.5, measurement_type='max', is_volume: bool=True,
+            **kwargs) \
+            -> None:
         """Multi-dimensional gaussian spot detector
 
         Parameters
@@ -38,7 +42,8 @@ class GaussianSpotDetector(SpotFinderAlgorithmBase):
             than thresh are ignored. Reduce this to detect blobs with less
             intensities.
         overlap : float [0, 1]
-            If two spots have more than this fraction of overlap, the spots are combined (default = 0.5)
+            If two spots have more than this fraction of overlap, the spots are combined
+            (default = 0.5)
         blobs_stack : Union[ImageStack, str]
             ImageStack or the path or URL that references the ImageStack that contains the blobs.
         measurement_type : str ['max', 'mean']
@@ -46,8 +51,9 @@ class GaussianSpotDetector(SpotFinderAlgorithmBase):
 
         Notes
         -----
-        This spot detector is very sensitive to the threshold that is selected, and the threshold is defined as an
-        absolute value -- therefore it must be adjusted depending on the datatype of the passed image.
+        This spot detector is very sensitive to the threshold that is selected, and the threshold
+        is defined as an absolute value -- therefore it must be adjusted depending on the datatype
+        of the passed image.
 
 
         """
@@ -59,8 +65,11 @@ class GaussianSpotDetector(SpotFinderAlgorithmBase):
         self.is_volume = is_volume
         if isinstance(blobs_stack, ImageStack):
             self.blobs_stack = blobs_stack
-        else:
+        elif isinstance(blobs_stack, str):
             self.blobs_stack = ImageStack.from_path_or_url(blobs_stack)
+        else:
+            raise TypeError(f"blobs_stack must be a string url pointing to an experiment.json file "
+                            f"or an ImageStack, not {type(blobs_stack)}.")
         self.blobs_image: np.ndarray = self.blobs_stack.max_proj(Indices.ROUND, Indices.CH)
 
         try:
@@ -70,77 +79,8 @@ class GaussianSpotDetector(SpotFinderAlgorithmBase):
                 f'measurement_type must be a numpy reduce function such as "max" or "mean". {measurement_type} '
                 f'not found.')
 
-    @staticmethod
-    def _measure_blob_intensity(image, blobs, measurement_function) -> pd.Series:
-
-        def fn(row: pd.Series) -> Number:
-            row = row.astype(int)
-            result = measurement_function(
-                image[
-                    row['z_min']:row['z_max'],
-                    row['y_min']:row['y_max'],
-                    row['x_min']:row['x_max']
-                ]
-            )
-            return result
-
-        return blobs.apply(
-            fn,
-            axis=1
-        )
-
-    def _measure_spot_intensities(
-            self, stack: ImageStack, spot_attributes: pd.DataFrame
-    ) -> IntensityTable:
-
-        n_ch = stack.shape[Indices.CH]
-        n_round = stack.shape[Indices.ROUND]
-        spot_attribute_index = dataframe_to_multiindex(spot_attributes)
-        image_shape: Tuple[int, int, int] = stack.raw_shape[2:]
-        intensity_table = IntensityTable.empty_intensity_table(
-            spot_attribute_index, n_ch, n_round, image_shape)
-
-        indices = product(range(n_ch), range(n_round))
-        for c, h in indices:
-            image, _ = stack.get_slice({Indices.CH: c, Indices.ROUND: h})
-            blob_intensities: pd.Series = self._measure_blob_intensity(
-                image, spot_attributes, self.measurement_function)
-            intensity_table[:, c, h] = blob_intensities
-
-        return intensity_table
-
-    def _find_spot_locations(self) -> pd.DataFrame:
-        fitted_blobs_array: np.ndarray = blob_log(
-            self.blobs_image, self.min_sigma, self.max_sigma, self.num_sigma, self.threshold,
-            self.overlap)
-
-        if fitted_blobs_array.shape[0] == 0:
-            raise ValueError('No spots detected with provided parameters')
-
-        columns = [Features.Z, Features.Y, Features.X, Features.SPOT_RADIUS]
-        fitted_blobs = pd.DataFrame(data=fitted_blobs_array, columns=columns)
-
-        # convert standard deviation of gaussian kernel used to identify spot to radius of spot
-        converted_radius = np.round(fitted_blobs[Features.SPOT_RADIUS] * np.sqrt(3))
-        fitted_blobs[Features.SPOT_RADIUS] = converted_radius
-
-        # convert the array to int so it can be used to index
-        fitted_blobs = fitted_blobs.astype(int)
-
-        for v, max_size in zip(['z', 'y', 'x'], self.blobs_image.shape):
-            fitted_blobs[f'{v}_min'] = np.clip(
-                fitted_blobs[v] - fitted_blobs[Features.SPOT_RADIUS], 0, None)
-            fitted_blobs[f'{v}_max'] = np.clip(
-                fitted_blobs[v] + fitted_blobs[Features.SPOT_RADIUS], None, max_size)
-
-        fitted_blobs['intensity'] = self._measure_blob_intensity(
-            self.blobs_image, fitted_blobs, self.measurement_function)
-        fitted_blobs['spot_id'] = np.arange(fitted_blobs.shape[0])
-
-        return fitted_blobs
-
     def find(self, image_stack: ImageStack) -> IntensityTable:
-        """find spots
+        """find spots in an ImageStack
 
         Parameters
         ----------
@@ -153,8 +93,23 @@ class GaussianSpotDetector(SpotFinderAlgorithmBase):
             3d tensor containing the intensity of spots across channels and imaging rounds
 
         """
-        spot_attributes = self._find_spot_locations()
-        intensity_table = self._measure_spot_intensities(image_stack, spot_attributes)
+        spot_finding_kwargs = {
+            'min_sigma': self.min_sigma,
+            'max_sigma': self.max_sigma,
+            'num_sigma': self.num_sigma,
+            'threshold': self.threshold,
+            'overlap': self.overlap,
+            'measurement_function': self.measurement_function,
+        }
+
+        intensity_table = detect_spots(
+            data_image=image_stack,
+            spot_finding_method=gaussian_spot_detector,
+            spot_finding_kwargs=spot_finding_kwargs,
+            reference_image=self.blobs_image,  # todo should be xarray with tony's PR
+            measurement_function=self.measurement_function
+        )
+
         return intensity_table
 
     @classmethod
@@ -170,3 +125,77 @@ class GaussianSpotDetector(SpotFinderAlgorithmBase):
             "--overlap", default=0.5, type=float, help="dots with overlap of greater than this fraction are combined")
         group_parser.add_argument(
             "--show", default=False, action='store_true', help="display results visually")
+
+
+# TODO ambrosejcarr: make this return IntensityTable instead of SpotAttributes
+def gaussian_spot_detector(
+        data_image: ImageStack, min_sigma: Number, max_sigma: Number, num_sigma: int,
+        threshold: Number, overlap=0.5, measurement_function: Callable[[Sequence], Number]=np.max) \
+        -> SpotAttributes:
+    """
+    Find gaussian blobs in an data image
+
+    Parameters
+    ----------
+    data_image : ImageStack
+        ImageStack containing blobs to be detected
+    min_sigma : float
+        The minimum standard deviation for Gaussian Kernel. Keep this low to
+        detect smaller blobs.
+    max_sigma : float
+        The maximum standard deviation for Gaussian Kernel. Keep this high to
+        detect larger blobs.
+    num_sigma : int
+        The number of intermediate values of standard deviations to consider
+        between `min_sigma` and `max_sigma`.
+    threshold : float
+        The absolute lower bound for scale space maxima. Local maxima smaller
+        than thresh are ignored. Reduce this to detect blobs with less
+        intensities.
+    overlap : float [0, 1]
+        If two spots have more than this fraction of overlap, the spots are combined (default = 0.5)
+    measurement_function : Callable
+        The function used to calculate the intensity for each identified spot area
+
+    Returns
+    -------
+    SpotAttributes :
+        DataFrame of metadata containing the coordinates, intensity and radius of each spot
+
+    """
+
+    fitted_blobs_array: np.ndarray = blob_log(
+        data_image,
+        min_sigma,
+        max_sigma,
+        num_sigma,
+        threshold,
+        overlap
+    )
+
+    # TODO this needs to be a warning, there are codebooks that could trigger this
+    if fitted_blobs_array.shape[0] == 0:
+        raise ValueError('No spots detected with provided parameters')
+
+    # create the SpotAttributes Table
+    columns = [Features.Z, Features.Y, Features.X, Features.SPOT_RADIUS]
+    fitted_blobs = pd.DataFrame(data=fitted_blobs_array, columns=columns)
+
+    # convert standard deviation of gaussian kernel used to identify spot to radius of spot
+    converted_radius = np.round(fitted_blobs[Features.SPOT_RADIUS] * np.sqrt(3))
+    fitted_blobs[Features.SPOT_RADIUS] = converted_radius
+
+    # convert the array to int so it can be used to index
+    rounded_blobs: pd.DataFrame = fitted_blobs.astype(int)
+
+    for v, max_size in zip(['z', 'y', 'x'], data_image.shape):
+        rounded_blobs[f'{v}_min'] = np.clip(
+            rounded_blobs[v] - rounded_blobs[Features.SPOT_RADIUS], 0, None)
+        rounded_blobs[f'{v}_max'] = np.clip(
+            rounded_blobs[v] + rounded_blobs[Features.SPOT_RADIUS], None, max_size)
+
+    rounded_blobs['intensity'] = measure_spot_intensity(
+        data_image, rounded_blobs, measurement_function)
+    rounded_blobs['spot_id'] = np.arange(rounded_blobs.shape[0])
+
+    return SpotAttributes(rounded_blobs)

--- a/starfish/pipeline/features/spots/detector/local_max_peak_finder.py
+++ b/starfish/pipeline/features/spots/detector/local_max_peak_finder.py
@@ -5,6 +5,7 @@ from trackpy import locate
 
 from starfish.image import ImageStack
 from starfish.pipeline.features.spot_attributes import SpotAttributes
+from starfish.intensity_table import IntensityTable
 from ._base import SpotFinderAlgorithmBase
 
 


### PR DESCRIPTION
Per discussion in #305, it is desirable for spot-finding to be able to proceed either by measuring spots in a dots image and then examining the intensity of each location across channels and rounds, or by _independently finding spots in each (channel, round) pair_. 

This PR adds a method `starfish/pipeline/features/spots/detect/detect_spots` which takes a `spot_finder_algorithm` and enables both above approaches (and also adds the ability to _create_ a dots image from a max_projection). 

It then refactors GaussianSpotDetector to leverage `detect_spots`, adds appropriate tests for the three different spot finding approaches above, and removes tests that are no longer relevant. 

There are a few methods that are moved, which I will note in comments below. 

Follow-up PRs will refactor `LocalMaxPeakFinder` to leverage `detect_spots`, which will address the remaining issues in #305. 