### PR TITLE
Pass metric argument into PixelSpotDetector

### DIFF
--- a/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
+++ b/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
@@ -304,6 +304,7 @@
     "from starfish.pipeline.features.pixels.pixel_spot_detector import PixelSpotDetector\n",
     "psd = PixelSpotDetector(\n",
     "    codebook=codebook,\n",
+    "    metric='euclidean',\n",
     "    distance_threshold=0.5176,\n",
     "    magnitude_threshold=1,\n",
     "    min_area=2,\n",
@@ -394,7 +395,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.3"
   },
   "toc": {
    "nav_menu": {},

--- a/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
+++ b/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
@@ -191,6 +191,7 @@ image(mp, clim=clim)
 from starfish.pipeline.features.pixels.pixel_spot_detector import PixelSpotDetector
 psd = PixelSpotDetector(
     codebook=codebook,
+    metric='euclidean',
     distance_threshold=0.5176,
     magnitude_threshold=1,
     min_area=2,

--- a/starfish/pipeline/features/pixels/pixel_spot_detector.py
+++ b/starfish/pipeline/features/pixels/pixel_spot_detector.py
@@ -9,19 +9,20 @@ from ._base import PixelFinderAlgorithmBase
 
 
 class PixelSpotDetector(PixelFinderAlgorithmBase):
-
     def __init__(
-            self, codebook: Codebook, distance_threshold: float,
-            magnitude_threshold: int, min_area: int, max_area: int, norm_order: int=2,
-            crop_x: int=0, crop_y: int=0, crop_z: int=0, **kwargs) -> None:
+            self, codebook: Codebook, metric: str, distance_threshold: float,
+            magnitude_threshold: int, min_area: int, max_area: int, norm_order: int = 2,
+            crop_x: int = 0, crop_y: int = 0, crop_z: int = 0, **kwargs) -> None:
         """Decode an image by first coding each pixel, then combining the results into spots
 
         Parameters
         ----------
         codebook : Codebook
             Codebook object mapping codewords to the targets they are designed to detect
+        metric : str
+            the sklearn metric string to pass to NearestNeighbors
         distance_threshold : float
-            spots whose codewords are more than this distance from an expected code are filtered
+            spots whose codewords are more than this metric distance from an expected code are filtered
         magnitude_threshold : int
             spots with intensity less than this value are filtered
         min_area : int
@@ -37,6 +38,7 @@ class PixelSpotDetector(PixelFinderAlgorithmBase):
 
         """
         self.codebook = codebook
+        self.metric = metric
         self.distance_threshold = distance_threshold
         self.magnitude_threshold = magnitude_threshold
         self.min_area = min_area
@@ -69,7 +71,8 @@ class PixelSpotDetector(PixelFinderAlgorithmBase):
             pixel_intensities,
             max_distance=self.distance_threshold,
             min_intensity=self.magnitude_threshold,
-            norm_order=self.norm_order
+            norm_order=self.norm_order,
+            metric=self.metric
         )
         decoded_spots, image_decoding_results = combine_adjacent_features(
             decoded_intensities,
@@ -82,6 +85,7 @@ class PixelSpotDetector(PixelFinderAlgorithmBase):
     @classmethod
     def add_arguments(cls, group_parser):
         group_parser.add_argument("--codebook-input", help="csv file containing a codebook")
+        group_parser.add_argument("--metric", type='str', default='euclidean')
         group_parser.add_argument(
             "--distance-threshold", default=0.5176,
             help="maximum distance a pixel may be from a codeword before it is filtered")

--- a/starfish/test/full_pipelines/api/test_merfish.py
+++ b/starfish/test/full_pipelines/api/test_merfish.py
@@ -34,6 +34,7 @@ def test_merfish_pipeline(merfish_stack):
     # detect and decode spots
     psd = PixelSpotDetector(
         codebook='https://s3.amazonaws.com/czi.starfish.data.public/MERFISH/codebook.csv',
+        metric='euclidean',
         distance_threshold=0.5176,
         magnitude_threshold=1,
         area_threshold=2,


### PR DESCRIPTION
The PixelSpotDetector assigns each pixel in a stack (across C and R) to a barcode in the codebook via a distance function. Currently this distance function is hardcoded to be the euclidean distance. This PR generalizes the PixelSpotDetector to accept any distance function supported by sklearn.NearestNeighbors. 

FYI @kevinyamauchi 