### PR TITLE
ENH: change filter.filter to filter.run, Update bandpass

### DIFF
--- a/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.ipynb
+++ b/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.ipynb
@@ -161,9 +161,9 @@
     "# filter raw data\n",
     "disk_size = 15  # disk as in circle\n",
     "filt = Filter.WhiteTophat(disk_size, verbose=True)\n",
-    "filt.filter(s.image)\n",
+    "filt.run(s.image)\n",
     "for img in s.auxiliary_images.values():\n",
-    "    filt.filter(img)"
+    "    filt.run(img)"
    ]
   },
   {

--- a/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.py
+++ b/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.py
@@ -97,9 +97,9 @@ from starfish.pipeline.filter import Filter
 # filter raw data
 disk_size = 15  # disk as in circle
 filt = Filter.WhiteTophat(disk_size, verbose=True)
-filt.filter(s.image)
+filt.run(s.image)
 for img in s.auxiliary_images.values():
-    filt.filter(img)
+    filt.run(img)
 # EPY: END code
 
 # EPY: START markdown

--- a/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
+++ b/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
@@ -1824,7 +1824,7 @@
    "source": [
     "from starfish.pipeline.filter.gaussian_high_pass import GaussianHighPass\n",
     "ghp = GaussianHighPass(sigma=3, verbose=True)\n",
-    "ghp.filter(s.image)"
+    "ghp.run(s.image)"
    ]
   },
   {
@@ -1850,7 +1850,7 @@
    "source": [
     "from starfish.pipeline.filter.richardson_lucy_deconvolution import DeconvolvePSF\n",
     "dpsf = DeconvolvePSF(num_iter=15, sigma=2, verbose=True)\n",
-    "dpsf.filter(s.image)"
+    "dpsf.run(s.image)"
    ]
   },
   {
@@ -1878,7 +1878,7 @@
    "source": [
     "from starfish.pipeline.filter.gaussian_low_pass import GaussianLowPass\n",
     "glp = GaussianLowPass(sigma=1, verbose=True)\n",
-    "glp.filter(s.image)"
+    "glp.run(s.image)"
    ]
   },
   {

--- a/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
+++ b/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
@@ -100,7 +100,7 @@ from starfish.viz import tile_lims
 # EPY: START code
 from starfish.pipeline.filter.gaussian_high_pass import GaussianHighPass
 ghp = GaussianHighPass(sigma=3, verbose=True)
-ghp.filter(s.image)
+ghp.run(s.image)
 # EPY: END code
 
 # EPY: START markdown
@@ -110,7 +110,7 @@ ghp.filter(s.image)
 # EPY: START code
 from starfish.pipeline.filter.richardson_lucy_deconvolution import DeconvolvePSF
 dpsf = DeconvolvePSF(num_iter=15, sigma=2, verbose=True)
-dpsf.filter(s.image)
+dpsf.run(s.image)
 # EPY: END code
 
 # EPY: START markdown
@@ -122,7 +122,7 @@ dpsf.filter(s.image)
 # EPY: START code
 from starfish.pipeline.filter.gaussian_low_pass import GaussianLowPass
 glp = GaussianLowPass(sigma=1, verbose=True)
-glp.filter(s.image)
+glp.run(s.image)
 # EPY: END code
 
 # EPY: START markdown

--- a/notebooks/allen_smFISH.ipynb
+++ b/notebooks/allen_smFISH.ipynb
@@ -110,7 +110,7 @@
    "source": [
     "from starfish.pipeline.filter import Filter\n",
     "s_clip = Filter.Clip(p_min=10, p_max=100, verbose=True)\n",
-    "s_clip.filter(s.image)"
+    "s_clip.run(s.image)"
    ]
   },
   {
@@ -154,7 +154,7 @@
    "outputs": [],
    "source": [
     "s_bandpass = Filter.Bandpass(lshort=0.5, llong=7, threshold=None, truncate=4, verbose=True)\n",
-    "s_bandpass.filter(s.image)"
+    "s_bandpass.run(s.image)"
    ]
   },
   {
@@ -173,7 +173,7 @@
     "# I wasn't sure if this clipping was supposed to be by volume or tile. I've done tile here, but it can be easily\n",
     "# switched to volume. \n",
     "s_clip = Filter.Clip(p_min=10, p_max=100, is_volume=False, verbose=True)\n",
-    "s_clip.filter(s.image)"
+    "s_clip.run(s.image)"
    ]
   },
   {
@@ -184,7 +184,7 @@
    "source": [
     "sigma=(1, 0, 0)  # filter only in z, do nothing in x, y\n",
     "glp = Filter.GaussianLowPass(sigma=sigma, is_volume=True, verbose=True)\n",
-    "glp.filter(s.image)"
+    "glp.run(s.image)"
    ]
   },
   {

--- a/notebooks/allen_smFISH.py
+++ b/notebooks/allen_smFISH.py
@@ -71,7 +71,7 @@ s = Stack.from_experiment_json(experiment_json)
 # EPY: START code
 from starfish.pipeline.filter import Filter
 s_clip = Filter.Clip(p_min=10, p_max=100, verbose=True)
-s_clip.filter(s.image)
+s_clip.run(s.image)
 # EPY: END code
 
 # EPY: START markdown
@@ -94,7 +94,7 @@ s.image.show_stack({Indices.CH.value: 0});
 
 # EPY: START code
 s_bandpass = Filter.Bandpass(lshort=0.5, llong=7, threshold=None, truncate=4, verbose=True)
-s_bandpass.filter(s.image)
+s_bandpass.run(s.image)
 # EPY: END code
 
 # EPY: START markdown
@@ -105,13 +105,13 @@ s_bandpass.filter(s.image)
 # I wasn't sure if this clipping was supposed to be by volume or tile. I've done tile here, but it can be easily
 # switched to volume. 
 s_clip = Filter.Clip(p_min=10, p_max=100, is_volume=False, verbose=True)
-s_clip.filter(s.image)
+s_clip.run(s.image)
 # EPY: END code
 
 # EPY: START code
 sigma=(1, 0, 0)  # filter only in z, do nothing in x, y
 glp = Filter.GaussianLowPass(sigma=sigma, is_volume=True, verbose=True)
-glp.filter(s.image)
+glp.run(s.image)
 # EPY: END code
 
 # EPY: START markdown

--- a/starfish/pipeline/filter/__init__.py
+++ b/starfish/pipeline/filter/__init__.py
@@ -48,6 +48,6 @@ class Filter(PipelineComponent):
         print('Filtering images ...')
         stack = ImageStack.from_path_or_url(args.input)
         instance = args.filter_algorithm_class(**vars(args))
-        instance.filter(stack)
+        instance.run(stack)
 
         stack.write(args.output)

--- a/starfish/pipeline/filter/_base.py
+++ b/starfish/pipeline/filter/_base.py
@@ -5,6 +5,6 @@ from starfish.pipeline.algorithmbase import AlgorithmBase
 
 
 class FilterAlgorithmBase(AlgorithmBase):
-    def filter(self, stack: ImageStack) -> Optional[ImageStack]:
-        """Performs in-place filtering on an ImageStack."""
+    def run(self, stack: ImageStack) -> Optional[ImageStack]:
+        """Performs filtering on an ImageStack."""
         raise NotImplementedError()

--- a/starfish/pipeline/filter/clip.py
+++ b/starfish/pipeline/filter/clip.py
@@ -65,7 +65,7 @@ class Clip(FilterAlgorithmBase):
         image = image.clip(min=v_min, max=v_max)
         return image.astype(dtype)
 
-    def filter(self, stack: ImageStack, in_place: bool=True) -> Optional[ImageStack]:
+    def run(self, stack: ImageStack, in_place: bool=True) -> Optional[ImageStack]:
         """Perform filtering of an image stack
 
         Parameters

--- a/starfish/pipeline/filter/gaussian_high_pass.py
+++ b/starfish/pipeline/filter/gaussian_high_pass.py
@@ -78,7 +78,7 @@ class GaussianHighPass(FilterAlgorithmBase):
 
         return filtered
 
-    def filter(self, stack: ImageStack, in_place: bool=True) -> Optional[ImageStack]:
+    def run(self, stack: ImageStack, in_place: bool=True) -> Optional[ImageStack]:
         """Perform filtering of an image stack
 
         Parameters

--- a/starfish/pipeline/filter/gaussian_low_pass.py
+++ b/starfish/pipeline/filter/gaussian_low_pass.py
@@ -80,7 +80,7 @@ class GaussianLowPass(FilterAlgorithmBase):
 
         return blurred
 
-    def filter(self, stack: ImageStack, in_place: bool=True) -> Optional[ImageStack]:
+    def run(self, stack: ImageStack, in_place: bool=True) -> Optional[ImageStack]:
         """Perform filtering of an image stack
 
         Parameters

--- a/starfish/pipeline/filter/mean_high_pass.py
+++ b/starfish/pipeline/filter/mean_high_pass.py
@@ -88,7 +88,7 @@ class MeanHighPass(FilterAlgorithmBase):
 
         return filtered
 
-    def filter(self, stack: ImageStack, in_place: bool=True) -> Optional[ImageStack]:
+    def run(self, stack: ImageStack, in_place: bool=True) -> Optional[ImageStack]:
         """Perform filtering of an image stack
 
         Parameters

--- a/starfish/pipeline/filter/richardson_lucy_deconvolution.py
+++ b/starfish/pipeline/filter/richardson_lucy_deconvolution.py
@@ -81,7 +81,7 @@ class DeconvolvePSF(FilterAlgorithmBase):
         img_deconv = img_deconv.astype(np.uint16)
         return img_deconv
 
-    def filter(self, stack: ImageStack, in_place: bool=True) -> Optional[ImageStack]:
+    def run(self, stack: ImageStack, in_place: bool=True) -> Optional[ImageStack]:
         """Perform filtering of an image stack
 
         Parameters

--- a/starfish/pipeline/filter/white_tophat.py
+++ b/starfish/pipeline/filter/white_tophat.py
@@ -32,7 +32,7 @@ class WhiteTophat(FilterAlgorithmBase):
         group_parser.add_argument(
             "--disk-size", default=15, type=int, help="diameter of morphological masking disk in pixels")
 
-    def filter(self, stack: ImageStack, in_place: bool=True) -> Optional[ImageStack]:
+    def run(self, stack: ImageStack, in_place: bool=True) -> Optional[ImageStack]:
         """Perform filtering of an image stack
 
         Parameters

--- a/starfish/test/dataset_fixtures.py
+++ b/starfish/test/dataset_fixtures.py
@@ -165,7 +165,7 @@ def synthetic_dataset_with_truth_values_and_called_spots(
     codebook, true_intensities, image = synthetic_dataset_with_truth_values
 
     wth = WhiteTophat(disk_size=15)
-    filtered = wth.filter(image, in_place=False)
+    filtered = wth.run(image, in_place=False)
 
     min_sigma = 1.5
     max_sigma = 4

--- a/starfish/test/full_pipelines/api/test_iss_api.py
+++ b/starfish/test/full_pipelines/api/test_iss_api.py
@@ -18,8 +18,8 @@ def test_iss_pipeline():
     dots = ImageStack.from_numpy_array(dots_data.reshape((1, 1, 1, *dots_data.shape)))
 
     wth = WhiteTophat(disk_size=15)
-    wth.filter(image)
-    wth.filter(dots)
+    wth.run(image)
+    wth.run(dots)
 
     fsr = FourierShiftRegistration(upsampling=1000, reference_stack=dots)
     fsr.run(image)

--- a/starfish/test/full_pipelines/api/test_merfish.py
+++ b/starfish/test/full_pipelines/api/test_merfish.py
@@ -14,15 +14,15 @@ def test_merfish_pipeline(merfish_stack):
 
     # high pass filter
     ghp = GaussianHighPass(sigma=3)
-    ghp.filter(s)
+    ghp.run(s)
 
     # deconvolve the point spread function
     dpsf = DeconvolvePSF(num_iter=15, sigma=2)
-    dpsf.filter(s)
+    dpsf.run(s)
 
     # low pass filter
     glp = GaussianLowPass(sigma=1)
-    glp.filter(s)
+    glp.run(s)
 
     # scale the data by the scale factors
     scale_factors = {(t[Indices.ROUND], t[Indices.CH]): t['scale_factor'] for index, t in s.tile_metadata.iterrows()}

--- a/starfish/test/pipeline/test_filter.py
+++ b/starfish/test/pipeline/test_filter.py
@@ -22,7 +22,7 @@ def test_gaussian_high_pass(merfish_stack: Stack, sigma: Union[Number, Tuple[Num
     """
     ghp = gaussian_high_pass.GaussianHighPass(sigma=sigma)
     sum_before = np.sum(merfish_stack.image.numpy_array)
-    ghp.filter(merfish_stack.image)
+    ghp.run(merfish_stack.image)
     assert np.sum(merfish_stack.image.numpy_array) < sum_before
 
 
@@ -31,7 +31,7 @@ def test_gaussian_high_pass_apply(merfish_stack: Stack, sigma: Union[Number, Tup
     """same as test_gaussian_high_pass, but tests apply loop functionality"""
     sum_before = np.sum(merfish_stack.image.numpy_array)
     ghp = gaussian_high_pass.GaussianHighPass(sigma=sigma)
-    ghp.filter(merfish_stack.image)
+    ghp.run(merfish_stack.image)
     assert np.sum(merfish_stack.image.numpy_array) < sum_before
 
 
@@ -40,5 +40,5 @@ def test_gaussian_high_pass_apply_3d(merfish_stack: Stack, sigma: Union[Number, 
     """same as test_gaussian_high_pass, but tests apply loop functionality"""
     sum_before = np.sum(merfish_stack.image.numpy_array)
     ghp = gaussian_high_pass.GaussianHighPass(sigma=sigma, is_volume=True)
-    ghp.filter(merfish_stack.image)
+    ghp.run(merfish_stack.image)
     assert np.sum(merfish_stack.image.numpy_array) < sum_before


### PR DESCRIPTION
- change `<filter_name>.filter` -> filter.run to improve ease of use of the package (all algorithms will be `<name>.run()`)
- update `bandpass.py` to adhere to various code standards
  - line length 100
  - typed return values
  - typed parameters
  - runtime parameters in run, algorithm parameters in constructor (`verbose` from `__init__` -> `run`)
  - remove default arguments, except for `truncate` which I don't understand
  - assign @dganguli to doc that method (not doc'd in trackpy)
  - add 3d volume support

Notes:
- a bunch of notebooks got brought along for the ride due to the refactor. 
- Further PRs will address the other algorithms in filter. 
