### PR TITLE
ENH: enable 3d white tophat, harmonize API

### DIFF
--- a/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.ipynb
+++ b/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.ipynb
@@ -159,7 +159,7 @@
     "from starfish.pipeline.filter import Filter\n",
     "\n",
     "# filter raw data\n",
-    "masking_radius = 15  # disk as in circle\n",
+    "masking_radius = 15\n",
     "filt = Filter.WhiteTophat(masking_radius, verbose=True, is_volume=False)\n",
     "filt.run(s.image)\n",
     "for img in s.auxiliary_images.values():\n",

--- a/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.ipynb
+++ b/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.ipynb
@@ -159,8 +159,8 @@
     "from starfish.pipeline.filter import Filter\n",
     "\n",
     "# filter raw data\n",
-    "disk_size = 15  # disk as in circle\n",
-    "filt = Filter.WhiteTophat(disk_size, verbose=True)\n",
+    "masking_radius = 15  # disk as in circle\n",
+    "filt = Filter.WhiteTophat(masking_radius, verbose=True, is_volume=False)\n",
     "filt.run(s.image)\n",
     "for img in s.auxiliary_images.values():\n",
     "    filt.run(img)"

--- a/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.py
+++ b/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.py
@@ -95,8 +95,8 @@ codebook
 from starfish.pipeline.filter import Filter
 
 # filter raw data
-disk_size = 15  # disk as in circle
-filt = Filter.WhiteTophat(disk_size, verbose=True)
+masking_radius = 15  # disk as in circle
+filt = Filter.WhiteTophat(masking_radius, verbose=True, is_volume=False)
 filt.run(s.image)
 for img in s.auxiliary_images.values():
     filt.run(img)

--- a/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.py
+++ b/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.py
@@ -95,7 +95,7 @@ codebook
 from starfish.pipeline.filter import Filter
 
 # filter raw data
-masking_radius = 15  # disk as in circle
+masking_radius = 15
 filt = Filter.WhiteTophat(masking_radius, verbose=True, is_volume=False)
 filt.run(s.image)
 for img in s.auxiliary_images.values():

--- a/starfish/pipeline/filter/util.py
+++ b/starfish/pipeline/filter/util.py
@@ -31,7 +31,7 @@ def bin_open(img: np.ndarray, disk_size: int) -> np.ndarray:
 
     img : np.ndarray
         Image to filter.
-    disk_size : int
+    masking_radius : int
         Radius of the disk-shaped structuring element.
 
     Returns

--- a/starfish/pipeline/filter/white_tophat.py
+++ b/starfish/pipeline/filter/white_tophat.py
@@ -27,6 +27,9 @@ class WhiteTophat(FilterAlgorithmBase):
         ----------
         masking_radius : int
             radius of the morphological masking structure in pixels
+        is_volume : int
+            If True, 3d (z, y, x) volumes will be filtered, otherwise, filter 2d tiles
+            independently.
 
         """
         self.masking_radius = masking_radius

--- a/starfish/pipeline/filter/white_tophat.py
+++ b/starfish/pipeline/filter/white_tophat.py
@@ -1,6 +1,8 @@
 from typing import Optional
 
 import numpy as np
+from scipy.ndimage.filters import maximum_filter, minimum_filter
+from skimage.morphology import disk, ball
 
 from starfish.image import ImageStack
 from ._base import FilterAlgorithmBase
@@ -8,31 +10,70 @@ from ._base import FilterAlgorithmBase
 
 class WhiteTophat(FilterAlgorithmBase):
     """
-    Performs "white top hat" filtering of an image to enhance spots. "White top hat filtering" finds spots that are both
-    smaller and brighter than their surroundings.
+    Performs "white top hat" filtering of an image to enhance spots. "White top hat filtering"
+    finds spots that are both smaller and brighter than their surroundings.
 
     See Also
     --------
     https://en.wikipedia.org/wiki/Top-hat_transform
     """
 
-    def __init__(self, disk_size, **kwargs):
-        """Instance of a white top hat morphological masking filter which masks objects larger than `disk_size`
+    def __init__(self, masking_radius: int, is_volume: bool=False, **kwargs) -> None:
+        """
+        Instance of a white top hat morphological masking filter which masks objects larger
+        than `masking_radius`
 
         Parameters
         ----------
-        disk_size : int
-            diameter of the morphological masking disk in pixels
+        masking_radius : int
+            radius of the morphological masking structure in pixels
 
         """
-        self.disk_size = disk_size
+        self.masking_radius = masking_radius
+        self.is_volume = is_volume
 
     @classmethod
-    def add_arguments(cls, group_parser):
+    def add_arguments(cls, group_parser) -> None:
         group_parser.add_argument(
-            "--disk-size", default=15, type=int, help="diameter of morphological masking disk in pixels")
+            "--masking-radius", default=15, type=int,
+            help="diameter of morphological masking disk in pixels")
 
-    def run(self, stack: ImageStack, in_place: bool=True) -> Optional[ImageStack]:
+    # TODO dganguli: any reason we're not using the white_tophat method?
+    # https://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.ndimage.\
+    # morphology.white_tophat.html
+    def white_tophat(self, image: np.ndarray) -> np.ndarray:
+        """
+        run a white top hat morphological masking filter which detects peaks that are smaller
+        and brighter than their surroundings
+
+        Parameters
+        ----------
+        image: np.ndarray
+            2 or 3-d image
+
+        Returns
+        -------
+        np.ndarray:
+            filtered image
+
+        """
+
+        if image.dtype.kind != "u":
+            raise TypeError("images should be stored in an unsigned integer array")
+
+        if self.is_volume:
+            structuring_element = ball(self.masking_radius)
+        else:
+            structuring_element = disk(self.masking_radius)
+
+        min_filtered = minimum_filter(image, footprint=structuring_element)
+        max_filtered = maximum_filter(min_filtered, footprint=structuring_element)
+        filtered_image = image - np.minimum(image, max_filtered)
+        return filtered_image
+
+    def run(
+            self, stack: ImageStack, in_place: bool=True, verbose: bool=False) \
+            -> Optional[ImageStack]:
         """Perform filtering of an image stack
 
         Parameters
@@ -41,6 +82,8 @@ class WhiteTophat(FilterAlgorithmBase):
             Stack to be filtered.
         in_place : bool
             if True, process ImageStack in-place, otherwise return a new stack
+        verbose : bool
+            If True, report on the percentage completed (default = False) during processing
 
         Returns
         -------
@@ -48,19 +91,8 @@ class WhiteTophat(FilterAlgorithmBase):
             if in-place is False, return the results of filter as a new stack
 
         """
-        from scipy.ndimage.filters import maximum_filter, minimum_filter
-        from skimage.morphology import disk
-
-        def white_tophat(image):
-            if image.dtype.kind != "u":
-                raise TypeError("images should be stored in an unsigned integer array")
-            structuring_element = disk(self.disk_size)
-            min_filtered = minimum_filter(image, footprint=structuring_element)
-            max_filtered = maximum_filter(min_filtered, footprint=structuring_element)
-            filtered_image = image - np.minimum(image, max_filtered)
-            return filtered_image
-
-        result = stack.apply(white_tophat)
+        result = stack.apply(
+            self.white_tophat, is_volume=self.is_volume, verbose=verbose, in_place=in_place)
         if not in_place:
             return result
         return None

--- a/starfish/test/dataset_fixtures.py
+++ b/starfish/test/dataset_fixtures.py
@@ -164,7 +164,7 @@ def synthetic_dataset_with_truth_values_and_called_spots(
 
     codebook, true_intensities, image = synthetic_dataset_with_truth_values
 
-    wth = WhiteTophat(disk_size=15)
+    wth = WhiteTophat(masking_radius=15)
     filtered = wth.run(image, in_place=False)
 
     min_sigma = 1.5

--- a/starfish/test/full_pipelines/api/test_iss_api.py
+++ b/starfish/test/full_pipelines/api/test_iss_api.py
@@ -17,7 +17,7 @@ def test_iss_pipeline():
     dots_data = image.max_proj(Indices.ROUND, Indices.CH, Indices.Z)
     dots = ImageStack.from_numpy_array(dots_data.reshape((1, 1, 1, *dots_data.shape)))
 
-    wth = WhiteTophat(disk_size=15)
+    wth = WhiteTophat(masking_radius=15)
     wth.run(image)
     wth.run(dots)
 

--- a/starfish/test/full_pipelines/cli/test_iss.py
+++ b/starfish/test/full_pipelines/cli/test_iss.py
@@ -68,7 +68,7 @@ class TestWithIssData(unittest.TestCase):
             "--input", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "registered", "hybridization.json"),
             "--output", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "filtered", "hybridization.json"),
             "WhiteTophat",
-            "--disk-size", "15",
+            "--masking-radius", "15",
         ],
         [
             "starfish", "filter",
@@ -78,7 +78,7 @@ class TestWithIssData(unittest.TestCase):
             ),
             "--output", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "filtered", "nuclei.json"),
             "WhiteTophat",
-            "--disk-size", "15",
+            "--masking-radius", "15",
         ],
         [
             "starfish", "filter",
@@ -88,7 +88,7 @@ class TestWithIssData(unittest.TestCase):
             ),
             "--output", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "filtered", "dots.json"),
             "WhiteTophat",
-            "--disk-size", "15",
+            "--masking-radius", "15",
         ],
         [
             "starfish", "detect_spots",

--- a/starfish/test/pipeline/test_white_tophat.py
+++ b/starfish/test/pipeline/test_white_tophat.py
@@ -1,0 +1,54 @@
+import numpy as np
+from skimage.filters import gaussian
+import pytest
+
+from starfish.pipeline.filter.white_tophat import WhiteTophat
+
+
+def simple_spot_3d():
+
+    big_spot = np.zeros((100, 100, 100), dtype=np.uint16)
+    big_spot[20, 20, 20] = 10000
+    big_spot = gaussian(big_spot, sigma=(4, 4, 4), preserve_range=True).astype(np.uint16)
+
+    small_spot = np.zeros((100, 100, 100), dtype=np.uint16)
+    small_spot[80, 80, 80] = 10000
+    small_spot = gaussian(small_spot, sigma=(1, 1, 1), preserve_range=True).astype(np.uint16)
+
+    return big_spot + small_spot
+
+
+@pytest.mark.parametrize('is_volume', [True, False])
+def test_white_tophat(is_volume: bool):
+    """
+    white tophat filters should reduce the intensity of spots that are larger than the masking
+    radius much more than those that are smaller. Here we have a 4-diameter spot and a 2-diameter
+    spot. We expect the large spot to be filtered more substantially.
+
+    Verify this functionality in both 2d and 3d images
+    """
+    if is_volume:
+
+        image = simple_spot_3d()
+        small_spot_intensity = image[80, 80, 80]
+        big_spot_intensity = image[20, 20, 20]
+
+        wth = WhiteTophat(masking_radius=2, is_volume=True)
+        filtered = wth.white_tophat(image)
+
+        large_ratio = filtered[20, 20, 20] / big_spot_intensity
+        small_ratio = filtered[80, 80, 80] / small_spot_intensity
+
+    else:
+
+        image = simple_spot_3d().max(axis=0)
+        small_spot_intensity = image[80, 80]
+        big_spot_intensity = image[20, 20]
+
+        wth = WhiteTophat(masking_radius=2, is_volume=False)
+        filtered = wth.white_tophat(image)
+
+        large_ratio = filtered[20, 20] / big_spot_intensity
+        small_ratio = filtered[80, 80] / small_spot_intensity
+
+    assert large_ratio < small_ratio


### PR DESCRIPTION
- Update `white_tophat` with API changes similar to #364 
- Add 3d support
  - change `disk_size` to `masking_radius` to make compatible with 3d. 
- Add tests
- Update notebooks
- Move the code that filters the numpy array out of `run` to make it consistent with other filters
- Fixes a bug where in_place wasn't being passed to `apply`
- Adds verbose option