### PR TITLE
RFC: update target assignment API

### DIFF
--- a/starfish/munge.py
+++ b/starfish/munge.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable
+from typing import Any, Dict, Iterable
 
 import numpy as np
 import pandas as pd
@@ -113,7 +113,7 @@ def spots_to_geojson(spots_viz):
     return [make_dict(row) for row in spots_viz.iterrows()]
 
 
-def geojson_to_region(geojson):
+def geojson_to_region(geojson: Dict[Any, Any]) -> regional.many:
     """
     Convert geojson data to region geometrical data.
     """

--- a/starfish/pipeline/target_assignment/__init__.py
+++ b/starfish/pipeline/target_assignment/__init__.py
@@ -1,11 +1,12 @@
 import argparse
 import json
+from typing import List, Type
 
+from starfish.intensity_table import IntensityTable
 from starfish.pipeline.pipelinecomponent import PipelineComponent
 from starfish.util.argparse import FsExistsType
-from starfish.intensity_table import IntensityTable
-from . import _base
 from . import point_in_poly
+from ._base import TargetAssignmentAlgorithm
 
 
 class TargetAssignment(PipelineComponent):
@@ -13,11 +14,11 @@ class TargetAssignment(PipelineComponent):
     target_assignment_group: argparse.ArgumentParser
 
     @classmethod
-    def implementing_algorithms(cls):
-        return _base.TargetAssignmentAlgorithm.__subclasses__()
+    def implementing_algorithms(cls) -> List[Type[TargetAssignmentAlgorithm]]:
+        return TargetAssignmentAlgorithm.__subclasses__()
 
     @classmethod
-    def add_to_parser(cls, subparsers):
+    def add_to_parser(cls, subparsers) -> None:
         """Adds the target_assignment component to the CLI argument parser."""
         target_assignment_group = subparsers.add_parser("target_assignment")
         target_assignment_group.add_argument(
@@ -36,7 +37,7 @@ class TargetAssignment(PipelineComponent):
         cls.target_assignment_group = target_assignment_group
 
     @classmethod
-    def _cli(cls, args, print_help=False):
+    def _cli(cls, args, print_help=False) -> None:
         """Runs the target_assignment component based on parsed arguments."""
         from starfish import munge
 
@@ -53,7 +54,7 @@ class TargetAssignment(PipelineComponent):
 
         instance = args.target_assignment_algorithm_class(**vars(args))
 
-        result = instance.assign_targets(intensity_table, regions)
+        result = instance.run(intensity_table, regions)
 
         print("Writing | cell_id | spot_id to: {}".format(args.output))
         result.to_json(args.output, orient="records")

--- a/starfish/pipeline/target_assignment/_base.py
+++ b/starfish/pipeline/target_assignment/_base.py
@@ -1,7 +1,11 @@
+import pandas as pd
+import regional
+
+from starfish.intensity_table import IntensityTable
 from starfish.pipeline.algorithmbase import AlgorithmBase
 
 
 class TargetAssignmentAlgorithm(AlgorithmBase):
-    def assign_targets(self, spots, regions):
+    def run(self, spots: IntensityTable, regions: regional.many) -> pd.DataFrame:
         """Performs target (e.g. gene) assignment given the spots and the regions."""
         raise NotImplementedError()

--- a/starfish/pipeline/target_assignment/point_in_poly.py
+++ b/starfish/pipeline/target_assignment/point_in_poly.py
@@ -9,9 +9,9 @@ from starfish.intensity_table import IntensityTable
 from ._base import TargetAssignmentAlgorithm
 
 
-class PointInPoly(TargetAssignmentAlgorithm):
+class PointInPoly2D(TargetAssignmentAlgorithm):
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         """
         PointInPoly accepts no parameters, but all pipeline components must accept arbitrary kwargs
         """
@@ -22,8 +22,9 @@ class PointInPoly(TargetAssignmentAlgorithm):
 
     @staticmethod
     def _assign(
-            cells_region: regional.many, spots: pd.DataFrame, use_hull=True, verbose=False) \
-            -> pd.DataFrame:
+            cells_region: regional.many, spots: pd.DataFrame, use_hull: bool=True, verbose:
+            bool=False
+    ) -> pd.DataFrame:
 
         results = pd.DataFrame({'spot_id': range(0, spots.shape[0])})
         results['cell_id'] = None
@@ -45,8 +46,8 @@ class PointInPoly(TargetAssignmentAlgorithm):
         return results
 
     def run(
-            self, intensity_table: IntensityTable, regions: regional.many, verbose: bool=False) \
-            -> pd.DataFrame:
+            self, intensity_table: IntensityTable, regions: regional.many, verbose: bool=False
+    ) -> pd.DataFrame:
         """Assign spots with target assignments to cells
 
         Parameters
@@ -55,8 +56,7 @@ class PointInPoly(TargetAssignmentAlgorithm):
         regions : regional.many
             # TODO dganguli can you add an explanation? I'll fix during PR.
         verbose : bool
-            (default False) report on the progress of gene assignment
-
+            If True, report on the progress of gene assignment (default False)
 
         Returns
         -------

--- a/starfish/test/full_pipelines/cli/test_iss.py
+++ b/starfish/test/full_pipelines/cli/test_iss.py
@@ -118,7 +118,7 @@ class TestWithIssData(unittest.TestCase):
             lambda tempdir, *args, **kwargs: os.path.join(tempdir, "results", "regions.geojson"),
             "--intensities", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "results", "spots.nc"),
             "--output", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "results", "regions.json"),
-            "PointInPoly",
+            "PointInPoly2D",
         ],
         [
             "starfish", "decode",


### PR DESCRIPTION
In attempting to modernize the target assignment API a few questions came up: 

1. Currently, target assignment emits a 2-column `Dataframe` that maps spot ids to cells. We no longer have an explicit representation of spot ids in the IntensityTable, and I wonder if the IntensityTable should just gain a column of "cell id" 

2. As far as I can tell, segmentation in starfish is purely 2d at the moment. This means that our assignment method is also 2d, however we assume but don't test this and I have a feeling that as a result, this method may not work for approaches that don't follow the ISS pipeline. 

Proposal: 
- If we store cell information in the `IntensityTable`, we can simply assign spots to cells using x/y coordinates (ignore z) until such a time as we support 3d segmentation. 
- Storing as an IntensityTable also lets us punt on filtering (since future-starfish is storing a `passes_filter` mask), allowing us to keep "cell" associations for both properly coded and noise spots, which could be nice for downstream QC. 