### PR TITLE
Unbreak the merfish notebook.

### DIFF
--- a/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
+++ b/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
@@ -1919,7 +1919,7 @@
     }
    ],
    "source": [
-    "mp = s.image.max_proj(Indices.ROUND.value, Indices.CH.value, Indices.Z.value)\n",
+    "mp = s.image.max_proj(Indices.ROUND, Indices.CH, Indices.Z)\n",
     "clim = scoreatpercentile(mp, [0.5, 99.5])\n",
     "image(mp, clim=clim)"
    ]

--- a/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
+++ b/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
@@ -141,7 +141,7 @@ from scipy.stats import scoreatpercentile
 # EPY: END code
 
 # EPY: START code
-mp = s.image.max_proj(Indices.ROUND.value, Indices.CH.value, Indices.Z.value)
+mp = s.image.max_proj(Indices.ROUND, Indices.CH, Indices.Z)
 clim = scoreatpercentile(mp, [0.5, 99.5])
 image(mp, clim=clim)
 # EPY: END code


### PR DESCRIPTION
max_proj is supposed to take Indices, but prior to #350, it also magically worked with their string equivalents, due to the `__eq__` hack in `AugmentedEnum`.  Switching to an `xarray` backend removed the indexing, so it doesn't work any more.