### PR TITLE
Fix python setup.py install

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -9,7 +9,7 @@ semantic_version
 scikit-image>=0.14.0
 scikit-learn
 scipy
-showit
+showit >= 1.1.4
 slicedimage == 0.0.0-dev21
 scikit-learn
 tqdm


### PR DESCRIPTION
Pin showit to >= 1.1.4, which has https://github.com/freeman-lab/showit/pull/5 and https://github.com/freeman-lab/showit/pull/6 merged.

Test plan: reran @csweaver's repro steps and successfully ran starfish.

Fixes #372 