### PR TITLE
BUG: fix skimage anisotropic kernel

### DIFF
--- a/starfish/image/_filter/gaussian_high_pass.py
+++ b/starfish/image/_filter/gaussian_high_pass.py
@@ -10,6 +10,7 @@ from starfish._stack import ImageStack
 from starfish.image._filter.gaussian_low_pass import GaussianLowPass
 from starfish.types import Number
 from ._base import FilterAlgorithmBase
+from .util import validate_and_broadcast_kernel_size
 
 
 class GaussianHighPass(FilterAlgorithmBase):
@@ -29,15 +30,7 @@ class GaussianHighPass(FilterAlgorithmBase):
             independently.
 
         """
-        if isinstance(sigma, tuple):
-            message = ("if passing an anisotropic kernel, the dimensionality must match the data "
-                       "shape ({shape}), not {passed_shape}")
-            if is_volume and len(sigma) != 3:
-                raise ValueError(message.format(shape=3, passed_shape=len(sigma)))
-            if not is_volume and len(sigma) != 2:
-                raise ValueError(message.format(shape=2, passed_shape=len(sigma)))
-
-        self.sigma = sigma
+        self.sigma = validate_and_broadcast_kernel_size(sigma, is_volume)
         self.is_volume = is_volume
         self.verbose = verbose
 

--- a/starfish/image/_filter/gaussian_low_pass.py
+++ b/starfish/image/_filter/gaussian_low_pass.py
@@ -10,6 +10,7 @@ from starfish.errors import DataFormatWarning
 from starfish._stack import ImageStack
 from starfish.types import Number
 from ._base import FilterAlgorithmBase
+from .util import validate_and_broadcast_kernel_size
 
 
 class GaussianLowPass(FilterAlgorithmBase):
@@ -30,15 +31,7 @@ class GaussianLowPass(FilterAlgorithmBase):
             If True, report on the percentage completed (default = False) during processing
 
         """
-        if isinstance(sigma, tuple):
-            message = ("if passing an anisotropic kernel, the dimensionality must match the data "
-                       "shape ({shape}), not {passed_shape}")
-            if is_volume and len(sigma) != 3:
-                raise ValueError(message.format(shape=3, passed_shape=len(sigma)))
-            if not is_volume and len(sigma) != 2:
-                raise ValueError(message.format(shape=2, passed_shape=len(sigma)))
-
-        self.sigma = sigma
+        self.sigma = validate_and_broadcast_kernel_size(sigma, is_volume)
         self.is_volume = is_volume
         self.verbose = verbose
 


### PR DESCRIPTION
There is an inconsistency in skimage's gaussian filter documentation which suggests that scalar kernel sizes are broadcast to the image depth. This is not true, and this PR fixes rectifies the inconsistency by broadcasting to full-size kernels in the starfish codebase. Since this code is used by multiple functions, it is factored out into `util.py`. 

