### PR TITLE
increase pandas version to ensure multiindex support

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,7 +1,7 @@
 click
 matplotlib
 numpy != 1.13.0
-pandas
+pandas >= 0.23.4
 pytest>=3.6.3
 regional
 requests


### PR DESCRIPTION
Old versions of pandas do not support `pd.MultiIndex.to_frame()`