### PR TITLE
[6/5] Rename experiment.org

### DIFF
--- a/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.ipynb
+++ b/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.ipynb
@@ -57,7 +57,7 @@
    "outputs": [],
    "source": [
     "pp = pprint.PrettyPrinter(indent=2)\n",
-    "pp.pprint(experiment.org)"
+    "pp.pprint(experiment.format_metadata)"
    ]
   },
   {

--- a/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.py
+++ b/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.py
@@ -39,7 +39,7 @@ experiment.read('https://dmf0bdeheu4zf.cloudfront.net/20180802/ISS/fov_001/exper
 
 # EPY: START code
 pp = pprint.PrettyPrinter(indent=2)
-pp.pprint(experiment.org)
+pp.pprint(experiment.format_metadata)
 # EPY: END code
 
 # EPY: START markdown

--- a/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
+++ b/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
@@ -55,7 +55,7 @@ experiment.image.show_stack({Indices.CH: 0})
 
 # EPY: START code
 pp = pprint.PrettyPrinter(indent=2)
-pp.pprint(experiment.org)
+pp.pprint(experiment.format_metadata)
 # EPY: END code
 
 # EPY: START markdown

--- a/starfish/experiment.py
+++ b/starfish/experiment.py
@@ -14,7 +14,7 @@ class Experiment:
 
     def __init__(self):
         # data organization
-        self.org = None
+        self.format_metadata = None
         self.image = None
 
         # auxiliary images
@@ -56,11 +56,11 @@ class Experiment:
     def read(self, in_json_path_or_url):
         self.backend, name, self.baseurl = resolve_path_or_url(in_json_path_or_url)
         with self.backend.read_file_handle(name) as fh:
-            self.org = json.load(fh)
+            self.format_metadata = json.load(fh)
 
-        self.verify_version(self.org['version'])
-        self.image = ImageStack.from_url(self.org['hybridization_images'], self.baseurl)
-        for aux_key, aux_data in self.org['auxiliary_images'].items():
+        self.verify_version(self.format_metadata['version'])
+        self.image = ImageStack.from_url(self.format_metadata['hybridization_images'], self.baseurl)
+        for aux_key, aux_data in self.format_metadata['auxiliary_images'].items():
             self.auxiliary_images[aux_key] = ImageStack.from_url(aux_data, self.baseurl)
 
     @classmethod


### PR DESCRIPTION
Per request, this PR renames `experiment.org` to `experiment.format_metadata`