### PR TITLE
TST: add stronger assertions to the MERFISH and ISS_Pipeline notebooks

### DIFF
--- a/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.ipynb
+++ b/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.ipynb
@@ -211,6 +211,28 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# assert on a small piece of the image to verify that the filters and registration have not changed\n",
+    "expected = np.array(\n",
+    "    [[ 67,  95, 117, 112, 171, 248, 229, 254, 314, 405],\n",
+    "     [ 79,  62,  92, 110, 270, 224, 194, 187, 331, 391],\n",
+    "     [ 62, 153, 179, 178, 366, 305, 282, 195, 370, 552],\n",
+    "     [148,  92, 239, 151, 149, 143, 207, 325, 351, 676],\n",
+    "     [115, 131,  75, 152, 163, 148, 203, 236, 509, 803],\n",
+    "     [ 94, 170, 145, 130,  69, 167,  73, 242, 623, 877],\n",
+    "     [ 71, 165, 158, 191,  61,  77, 257, 341, 619, 799],\n",
+    "     [111, 131, 223, 195, 124, 134, 293, 480, 556, 820],\n",
+    "     [166, 167, 342, 235, 144, 133, 265, 447, 592, 941],\n",
+    "     [126, 140, 420, 340, 150, 212, 349, 481, 634, 897]],\n",
+    "    dtype=np.uint16)\n",
+    "assert np.array_equal(primary_image.numpy_array[3, 2, 0, 500:510, 400:410], expected)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -262,10 +284,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Verify the spot count is reasonable.\n",
+    "# Verify the spot count is reasonable and has not changed between starfish builds\n",
     "spot_count = intensities.shape[0]\n",
-    "assert 1000 < spot_count < 5000\n",
-    "spot_count"
+    "assert spot_count == 3767"
    ]
   },
   {
@@ -360,9 +381,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert table.index.get_loc('HER2') < 10\n",
-    "assert table.index.get_loc('VIM') < 10\n",
-    "table.head()"
+    "# verify that HER2 and VIM retain the correct expression order (by number of spots)\n",
+    "assert table.index.get_loc('HER2') == 3\n",
+    "assert table.index.get_loc('VIM') == 5 \n",
+    "table.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# verify that the number of blank spots and the top four genes have the expected values\n",
+    "expected = pd.Series([2626, 307, 142, 134, 123], index=['None', 'ACTB', 'CTSL2', 'HER2', 'GAPDH'])\n",
+    "assert np.array_equal(table.head(5), expected)\n",
+    "assert np.array_equal(table.head(5).index, expected.index)"
    ]
   },
   {
@@ -403,6 +437,16 @@
     ")\n",
     "seg.run(primary_image, nuclei)\n",
     "seg.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# verify that the correct number of cells are detected\n",
+    "assert seg.num_cells == 75"
    ]
   },
   {

--- a/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
+++ b/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
@@ -197,6 +197,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# assert a small portion of the tensor remains unchanged to check for modifications to the filters\n",
+    "expected = np.array(\n",
+    "    [[14, 18, 15,  9,  4,  2,  2,  3,  6, 14],\n",
+    "     [22, 25, 18,  8,  2,  0,  0,  1,  2,  6],\n",
+    "     [24, 26, 16,  6,  1,  0,  0,  0,  0,  2],\n",
+    "     [18, 18, 10,  3,  0,  0,  0,  0,  0,  1],\n",
+    "     [ 9,  8,  4,  1,  0,  0,  0,  0,  2,  3],\n",
+    "     [ 5,  4,  2,  0,  0,  0,  1,  4,  8, 11],\n",
+    "     [ 8,  6,  3,  1,  0,  1,  4, 11, 20, 26],\n",
+    "     [20, 17, 10,  4,  2,  2,  6, 16, 27, 34],\n",
+    "     [37, 33, 20,  9,  4,  4,  7, 13, 21, 25],\n",
+    "     [48, 44, 27, 13,  6,  5,  5,  7, 10, 11]], \n",
+    ")\n",
+    "assert np.array_equal(primary_image.numpy_array[5, 1, 0, 1000:1010, 1000:1010], expected)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "scale_factors = {\n",
     "    (t[Indices.ROUND], t[Indices.CH]): t['scale_factor'] \n",
     "    for index, t in primary_image.tile_metadata.iterrows()\n",
@@ -220,6 +242,28 @@
     "    data = primary_image.get_slice(indices)[0]\n",
     "    scaled = data / scale_factors[indices[Indices.ROUND.value], indices[Indices.CH.value]]\n",
     "    primary_image.set_slice(indices, scaled)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# assert on a small part of the scaled image to verify values\n",
+    "expected = np.array(\n",
+    "    [[0.33527313, 0.43106545, 0.35922121, 0.21553273, 0.09579232,\n",
+    "      0.04789616, 0.04789616, 0.07184424, 0.14368848, 0.33527313],\n",
+    "     [0.52685777, 0.59870201, 0.43106545, 0.19158464, 0.04789616,\n",
+    "      0.        , 0.        , 0.02394808, 0.04789616, 0.14368848],\n",
+    "     [0.57475393, 0.62265009, 0.38316929, 0.14368848, 0.02394808,\n",
+    "      0.        , 0.        , 0.        , 0.        , 0.04789616],\n",
+    "     [0.43106545, 0.43106545, 0.23948081, 0.07184424, 0.        ,\n",
+    "      0.        , 0.        , 0.        , 0.        , 0.02394808],\n",
+    "     [0.21553273, 0.19158464, 0.09579232, 0.02394808, 0.        ,\n",
+    "      0.        , 0.        , 0.        , 0.04789616, 0.07184424]]\n",
+    ")\n",
+    "assert np.allclose(primary_image.numpy_array[5, 1, 0, 1000:1005, 1000:1010], expected)"
    ]
   },
   {
@@ -305,6 +349,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# verify detected number of spots\n",
+    "assert spot_intensities.shape == (37742, 2, 8)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -341,6 +395,16 @@
     "plt.xscale('log')\n",
     "plt.yscale('log')\n",
     "plt.title(f'r = {r}');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# assert that notebook results match published ones. \n",
+    "assert r > 0.99"
    ]
   },
   {

--- a/notebooks/allen_smFISH.ipynb
+++ b/notebooks/allen_smFISH.ipynb
@@ -288,6 +288,15 @@
     "    figure_size=(20, 20), p_min=60, p_max=99.9\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO ambrosejcarr: assert that the number of spots detected does not change"
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/py/ISS_Pipeline_-_Breast_-_1_FOV.py
+++ b/notebooks/py/ISS_Pipeline_-_Breast_-_1_FOV.py
@@ -130,6 +130,23 @@ registration = Registration.FourierShiftRegistration(
 registration.run(primary_image)
 # EPY: END code
 
+# EPY: START code
+# assert on a small piece of the image to verify that the filters and registration have not changed
+expected = np.array(
+    [[ 67,  95, 117, 112, 171, 248, 229, 254, 314, 405],
+     [ 79,  62,  92, 110, 270, 224, 194, 187, 331, 391],
+     [ 62, 153, 179, 178, 366, 305, 282, 195, 370, 552],
+     [148,  92, 239, 151, 149, 143, 207, 325, 351, 676],
+     [115, 131,  75, 152, 163, 148, 203, 236, 509, 803],
+     [ 94, 170, 145, 130,  69, 167,  73, 242, 623, 877],
+     [ 71, 165, 158, 191,  61,  77, 257, 341, 619, 799],
+     [111, 131, 223, 195, 124, 134, 293, 480, 556, 820],
+     [166, 167, 342, 235, 144, 133, 265, 447, 592, 941],
+     [126, 140, 420, 340, 150, 212, 349, 481, 634, 897]],
+    dtype=np.uint16)
+assert np.array_equal(primary_image.numpy_array[3, 2, 0, 500:510, 400:410], expected)
+# EPY: END code
+
 # EPY: START markdown
 # ## Use spot-detector to create 'encoder' table  for standardized input  to decoder
 # EPY: END markdown
@@ -166,10 +183,9 @@ with warnings.catch_warnings():
 # EPY: END code
 
 # EPY: START code
-# Verify the spot count is reasonable.
+# Verify the spot count is reasonable and has not changed between starfish builds
 spot_count = intensities.shape[0]
-assert 1000 < spot_count < 5000
-spot_count
+assert spot_count == 3767
 # EPY: END code
 
 # EPY: START markdown
@@ -220,9 +236,17 @@ table = pd.Series(counts, index=genes).sort_values(ascending=False)
 # EPY: END code
 
 # EPY: START code
-assert table.index.get_loc('HER2') < 10
-assert table.index.get_loc('VIM') < 10
-table.head()
+# verify that HER2 and VIM retain the correct expression order (by number of spots)
+assert table.index.get_loc('HER2') == 3
+assert table.index.get_loc('VIM') == 5 
+table.head(5)
+# EPY: END code
+
+# EPY: START code
+# verify that the number of blank spots and the top four genes have the expected values
+expected = pd.Series([2626, 307, 142, 134, 123], index=['None', 'ACTB', 'CTSL2', 'HER2', 'GAPDH'])
+assert np.array_equal(table.head(5), expected)
+assert np.array_equal(table.head(5).index, expected.index)
 # EPY: END code
 
 # EPY: START markdown
@@ -252,6 +276,11 @@ seg = Segmentation.Watershed(
 )
 seg.run(primary_image, nuclei)
 seg.show()
+# EPY: END code
+
+# EPY: START code
+# verify that the correct number of cells are detected
+assert seg.num_cells == 75
 # EPY: END code
 
 # EPY: START markdown

--- a/notebooks/py/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
+++ b/notebooks/py/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
@@ -115,6 +115,23 @@ glp.run(primary_image)
 # EPY: END markdown
 
 # EPY: START code
+# assert a small portion of the tensor remains unchanged to check for modifications to the filters
+expected = np.array(
+    [[14, 18, 15,  9,  4,  2,  2,  3,  6, 14],
+     [22, 25, 18,  8,  2,  0,  0,  1,  2,  6],
+     [24, 26, 16,  6,  1,  0,  0,  0,  0,  2],
+     [18, 18, 10,  3,  0,  0,  0,  0,  0,  1],
+     [ 9,  8,  4,  1,  0,  0,  0,  0,  2,  3],
+     [ 5,  4,  2,  0,  0,  0,  1,  4,  8, 11],
+     [ 8,  6,  3,  1,  0,  1,  4, 11, 20, 26],
+     [20, 17, 10,  4,  2,  2,  6, 16, 27, 34],
+     [37, 33, 20,  9,  4,  4,  7, 13, 21, 25],
+     [48, 44, 27, 13,  6,  5,  5,  7, 10, 11]], 
+)
+assert np.array_equal(primary_image.numpy_array[5, 1, 0, 1000:1010, 1000:1010], expected)
+# EPY: END code
+
+# EPY: START code
 scale_factors = {
     (t[Indices.ROUND], t[Indices.CH]): t['scale_factor'] 
     for index, t in primary_image.tile_metadata.iterrows()
@@ -133,6 +150,23 @@ for indices in primary_image._iter_indices():
     data = primary_image.get_slice(indices)[0]
     scaled = data / scale_factors[indices[Indices.ROUND.value], indices[Indices.CH.value]]
     primary_image.set_slice(indices, scaled)
+# EPY: END code
+
+# EPY: START code
+# assert on a small part of the scaled image to verify values
+expected = np.array(
+    [[0.33527313, 0.43106545, 0.35922121, 0.21553273, 0.09579232,
+      0.04789616, 0.04789616, 0.07184424, 0.14368848, 0.33527313],
+     [0.52685777, 0.59870201, 0.43106545, 0.19158464, 0.04789616,
+      0.        , 0.        , 0.02394808, 0.04789616, 0.14368848],
+     [0.57475393, 0.62265009, 0.38316929, 0.14368848, 0.02394808,
+      0.        , 0.        , 0.        , 0.        , 0.04789616],
+     [0.43106545, 0.43106545, 0.23948081, 0.07184424, 0.        ,
+      0.        , 0.        , 0.        , 0.        , 0.02394808],
+     [0.21553273, 0.19158464, 0.09579232, 0.02394808, 0.        ,
+      0.        , 0.        , 0.        , 0.04789616, 0.07184424]]
+)
+assert np.allclose(primary_image.numpy_array[5, 1, 0, 1000:1005, 1000:1010], expected)
 # EPY: END code
 
 # EPY: START code
@@ -196,6 +230,11 @@ spot_intensities, prop_results = psd.find(primary_image)
 spot_intensities
 # EPY: END code
 
+# EPY: START code
+# verify detected number of spots
+assert spot_intensities.shape == (37742, 2, 8)
+# EPY: END code
+
 # EPY: START markdown
 # ## Compare to results from paper 
 # 
@@ -225,6 +264,11 @@ plt.ylabel('Gene copy number Starfish')
 plt.xscale('log')
 plt.yscale('log')
 plt.title(f'r = {r}');
+# EPY: END code
+
+# EPY: START code
+# assert that notebook results match published ones. 
+assert r > 0.99
 # EPY: END code
 
 # EPY: START markdown

--- a/notebooks/py/allen_smFISH.py
+++ b/notebooks/py/allen_smFISH.py
@@ -177,3 +177,7 @@ fig = primary_image.show_stack(
     figure_size=(20, 20), p_min=60, p_max=99.9
 )
 # EPY: END code
+
+# EPY: START code
+# TODO ambrosejcarr: assert that the number of spots detected does not change
+# EPY: END code


### PR DESCRIPTION
- Adds a series of strong assertions to the two notebooks that are currently run on master: MERFISH and ISS. 
- These will help diagnose the locations of any breakages until we can convert sub-selections of the image data to small unit tests. 