### PR TITLE
suppress harmless cython warning

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
 max-line-length=100
-ignore: E301, E302, E305, E401, E402, F401, E731, F811
+ignore: E301, E302, E305, E401, F401, E731, F811
 application-import-names = starfish, examples
 import-order-style = smarkets

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
 max-line-length=100
-ignore: E301, E302, E305, E401, F401, E731, F811
+ignore: E301, E302, E305, E401, E402, F401, E731, F811
 application-import-names = starfish, examples
 import-order-style = smarkets

--- a/starfish/__init__.py
+++ b/starfish/__init__.py
@@ -1,3 +1,10 @@
+# deal with numpy import warnings due to cython
+# See: https://stackoverflow.com/questions/40845304/
+#      runtimewarning-numpy-dtype-size-changed-may-indicate-binary-incompatibility)
+import warnings
+warnings.filterwarnings("ignore", message="numpy.dtype size changed")
+warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
+
 # image processing methods and objects
 from . import image
 # spot detection and manipulation

--- a/starfish/__init__.py
+++ b/starfish/__init__.py
@@ -2,8 +2,8 @@
 # See: https://stackoverflow.com/questions/40845304/
 #      runtimewarning-numpy-dtype-size-changed-may-indicate-binary-incompatibility)
 import warnings
-warnings.filterwarnings("ignore", message="numpy.dtype size changed")
-warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
+warnings.filterwarnings("ignore", message="numpy.dtype size changed")  # noqa
+warnings.filterwarnings("ignore", message="numpy.ufunc size changed")  # noqa
 
 # image processing methods and objects
 from . import image


### PR DESCRIPTION
Adds a warning filter to get rid of numpy x cython x scipy dtype warning (happens when versions of scipy and numpy don't match up, is apparently harmless. 

The warning: 
```python
/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/importlib/_bootstrap.py:219: 
RuntimeWarning: numpy.dtype size changed, may indicate binary incompatibility. Expected 96, got 88
  return f(*args, **kwds)
```

adds E402, "imports must be at top of file" to suppressed filters. Per our previous conversation, it's not easy to get file-specific granularity with flake. 

See e.g. 
https://github.com/ContextLab/supereeg/pull/176