### PR TITLE
ENH: change single_synthetic_spot to a factory function

### DIFF
--- a/starfish/test/dataset_fixtures.py
+++ b/starfish/test/dataset_fixtures.py
@@ -288,8 +288,7 @@ def synthetic_spot_pass_through_stack(synthetic_dataset_with_truth_values):
     return codebook, true_intensities, img_stack
 
 
-@pytest.fixture()
-def single_synthetic_spot():
+def codebook_intensities_image_for_single_synthetic_spot():
     sd = synthesize.SyntheticData(
         n_round=2, n_ch=2, n_z=2, height=20, width=30, n_codes=1, n_spots=1
     )

--- a/starfish/test/image/test_imagestack.py
+++ b/starfish/test/image/test_imagestack.py
@@ -6,10 +6,10 @@ from starfish.stack import ImageStack
 # don't inspect pytest fixtures in pycharm
 # noinspection PyUnresolvedReferences
 from starfish.test.dataset_fixtures import (
+    codebook_intensities_image_for_single_synthetic_spot,
     loaded_codebook,
     simple_codebook_array,
     simple_codebook_json,
-    single_synthetic_spot,
     synthetic_dataset_with_truth_values,
     synthetic_intensity_table,
     synthetic_spot_pass_through_stack,
@@ -217,8 +217,8 @@ def test_synthetic_spot_creation_produces_an_imagestack_with_correct_spot_locati
 
 
 # TODO ambrosejcarr: improve the tests here.
-def test_imagestack_to_intensity_table(single_synthetic_spot):
-    codebook, intensity_table, image = single_synthetic_spot
+def test_imagestack_to_intensity_table():
+    codebook, intensity_table, image = codebook_intensities_image_for_single_synthetic_spot()
     pixel_intensities = IntensityTable.from_image_stack(image)
     pixel_intensities = codebook.metric_decode(
         pixel_intensities, max_distance=0, min_intensity=1000, norm_order=2)

--- a/starfish/test/pipeline/test_intensity_table.py
+++ b/starfish/test/pipeline/test_intensity_table.py
@@ -13,7 +13,6 @@ from starfish.test.dataset_fixtures import (
     loaded_codebook,
     simple_codebook_array,
     simple_codebook_json,
-    single_synthetic_spot,
 )
 from starfish.types import Features, Indices
 

--- a/starfish/test/test_stack_intensity_table_reshaping.py
+++ b/starfish/test/test_stack_intensity_table_reshaping.py
@@ -4,18 +4,16 @@ import numpy as np
 
 from starfish.intensity_table import IntensityTable
 from starfish.stack import ImageStack
-# don't inspect pytest fixtures in pycharm
-# noinspection PyUnresolvedReferences
-from starfish.test.dataset_fixtures import single_synthetic_spot
+from starfish.test.dataset_fixtures import codebook_intensities_image_for_single_synthetic_spot
 from starfish.types import Indices
 
 
-def test_reshaping_between_stack_and_intensities(single_synthetic_spot):
+def test_reshaping_between_stack_and_intensities():
     """
     transform an pixels of an ImageStack into an IntensityTable and back again, then verify that
     the created Imagestack is the same as the original
     """
-    codebook, intensities, image = single_synthetic_spot
+    codebook, intensities, image = codebook_intensities_image_for_single_synthetic_spot()
     pixel_intensities = IntensityTable.from_image_stack(image, 0, 0, 0)
     image_shape = (image.shape['z'], image.shape['y'], image.shape['x'])
     image_from_pixels = pixel_intensities_to_imagestack(pixel_intensities, image_shape)


### PR DESCRIPTION
First of many, many PRs that change fixtures into factories. In this case, I also renamed it to have a more informative name. 