### PR TITLE
[Easy] fix imagestack.write so that it correct appends a prefix

### DIFF
--- a/starfish/stack.py
+++ b/starfish/stack.py
@@ -761,12 +761,12 @@ class ImageStack:
         return self._tile_shape
 
     def write(self, filepath: str, tile_opener=None) -> None:
-        """write the image tensor to disk
+        """write the image tensor to disk in spaceTx format
 
         Parameters
         ----------
         filepath : str
-            path + prefix for writing the image tensor
+            Path + prefix for the images and hybridization_images.json written by this function
         tile_opener : TODO ttung: doc me.
 
         """
@@ -825,7 +825,7 @@ class ImageStack:
 
         Writer.write_to_path(
             self._image_partition,
-            filepath,
+            filepath + '.json',
             pretty=True,
             tile_opener=tile_opener)
 

--- a/starfish/stack.py
+++ b/starfish/stack.py
@@ -823,9 +823,11 @@ class ImageStack:
                     ),
                     "wb")
 
+        if not filepath.endswith('.json'):
+            filepath += '.json'
         Writer.write_to_path(
             self._image_partition,
-            filepath + '.json',
+            filepath,
             pretty=True,
             tile_opener=tile_opener)
 


### PR DESCRIPTION
- Makes the outcome (`hybridization_images.json` has `.json`) as one would expect from the request for path+prefix. 