### PR TITLE
ENH: Remove IntensityTable's image_shape

### DIFF
--- a/starfish/intensity_table.py
+++ b/starfish/intensity_table.py
@@ -72,7 +72,6 @@ class IntensityTable(xr.DataArray):
     @classmethod
     def empty_intensity_table(
             cls, spot_attributes: pd.DataFrame, n_ch: int, n_round: int,
-            image_shape: Tuple[int, int, int]
     ) -> "IntensityTable":
         """Create an empty intensity table with pre-set axis whose values are zero
 
@@ -85,8 +84,6 @@ class IntensityTable(xr.DataArray):
             number of channels measured in the imaging experiment
         n_round : int
             number of imaging rounds measured in the imaging experiment
-        image_shape : Tuple[int, int, int]
-            the shape (z, y, x) of the image from which features will be extracted
 
         Returns
         -------
@@ -99,12 +96,10 @@ class IntensityTable(xr.DataArray):
         round_index = np.arange(n_round)
         data = np.zeros((spot_attributes.shape[0], n_ch, n_round))
         dims = (Features.AXIS, Indices.CH.value, Indices.ROUND.value)
-        attrs = {cls.IMAGE_SHAPE: image_shape}
         coords = cls._build_xarray_coords(spot_attributes, channel_index, round_index)
 
         intensity_table = cls(
             data=data, coords=coords, dims=dims,
-            attrs=attrs
         )
 
         return intensity_table
@@ -126,7 +121,6 @@ class IntensityTable(xr.DataArray):
     @classmethod
     def from_spot_data(
             cls, intensities: Union[xr.DataArray, np.ndarray], spot_attributes: pd.DataFrame,
-            image_shape: Tuple[int, int, int],
             *args, **kwargs) -> "IntensityTable":
         """Table to store image feature intensities and associated metadata
 
@@ -140,8 +134,6 @@ class IntensityTable(xr.DataArray):
             number of dimensions. If this argument is omitted, dimension names
             are taken from ``coords`` (if possible) and otherwise default to
             ``['dim_0', ... 'dim_n']``.
-        image_shape : Tuple[int, int, int]
-            the shape of the image (z, y, x) from which the features were extracted
         args :
             additional arguments to pass to the xarray constructor
         kwargs :
@@ -167,9 +159,7 @@ class IntensityTable(xr.DataArray):
 
         dims = (Features.AXIS, Indices.CH.value, Indices.ROUND.value)
 
-        attrs = {cls.IMAGE_SHAPE: image_shape}
-
-        intensities = cls(intensities, coords, dims, attrs=attrs, *args, **kwargs)
+        intensities = cls(intensities, coords, dims, *args, **kwargs)
         return intensities
 
     def save(self, filename: str) -> None:
@@ -266,9 +256,7 @@ class IntensityTable(xr.DataArray):
         data *= np.random.poisson(mean_photons_per_fluor, size=data.shape)
         data *= np.random.poisson(mean_fluor_per_spot, size=data.shape)
 
-        image_shape = (num_z, height, width)
-
-        intensities = cls.from_spot_data(data, spot_attributes, image_shape=image_shape)
+        intensities = cls.from_spot_data(data, spot_attributes)
         intensities[Features.TARGET] = (Features.AXIS, targets)
 
         return intensities

--- a/starfish/spots/_detector/combine_adjacent_features.py
+++ b/starfish/spots/_detector/combine_adjacent_features.py
@@ -57,7 +57,10 @@ def combine_adjacent_features(
     target_array = np.array(target_list)
 
     # reverses the linearization that was used to construct the IntensityTable from the ImageStack
-    decoded_image: np.ndarray = target_array.reshape(intensities.attrs[IntensityTable.IMAGE_SHAPE])
+    max_x = intensities[Features.X].values.max() + 1
+    max_y = intensities[Features.Y].values.max() + 1
+    max_z = intensities[Features.Z].values.max() + 1
+    decoded_image: np.ndarray = target_array.reshape((max_z, max_y, max_x))
 
     # label each pixel according to its component
     label_image: np.ndarray = label(decoded_image, connectivity=connectivity)
@@ -122,9 +125,8 @@ def combine_adjacent_features(
 
     # create the output IntensityTable
     dims = (Features.AXIS, Indices.CH.value, Indices.ROUND.value)
-    attrs = {IntensityTable.IMAGE_SHAPE: intensities.attrs[IntensityTable.IMAGE_SHAPE]}
     intensity_table = IntensityTable(
-        data=mean_pixel_traces, coords=coords, dims=dims, attrs=attrs
+        data=mean_pixel_traces, coords=coords, dims=dims
     )
 
     ccdr = ConnectedComponentDecodingResult(props, label_image, decoded_image)

--- a/starfish/spots/_detector/detect.py
+++ b/starfish/spots/_detector/detect.py
@@ -94,14 +94,12 @@ def measure_spot_intensities(
     # determine the shape of the intensity table
     n_ch = data_image.shape[Indices.CH]
     n_round = data_image.shape[Indices.ROUND]
-    image_shape: Tuple[int, int, int] = data_image.raw_shape[2:]
 
     # construct the empty intensity table
     intensity_table = IntensityTable.empty_intensity_table(
         spot_attributes=spot_attributes,
         n_ch=n_ch,
         n_round=n_round,
-        image_shape=image_shape
     )
 
     # fill the intensity table
@@ -145,14 +143,8 @@ def concatenate_spot_attributes_to_intensities(
     # this drop call ensures only x, y, z, radius, and quality, are passed to the IntensityTable
     features_coordinates = all_spots.drop(['spot_id', 'intensity'], axis=1)
 
-    # TODO ambrosejcarr: remove image_shape from intensity_table
-    z_max = max(max(sa.data['z']) for sa, inds in spot_attributes)
-    y_max = max(max(sa.data['y']) for sa, inds in spot_attributes)
-    x_max = max(max(sa.data['x']) for sa, inds in spot_attributes)
-    image_shape = (z_max, y_max, x_max)
-
     intensity_table = IntensityTable.empty_intensity_table(
-        features_coordinates, n_ch, n_round, image_shape
+        features_coordinates, n_ch, n_round,
     )
 
     i = 0

--- a/starfish/test/dataset_fixtures.py
+++ b/starfish/test/dataset_fixtures.py
@@ -79,9 +79,8 @@ def small_intensity_table():
             Features.SPOT_RADIUS: [0.1, 2, 3, 2, 1]
         }
     )
-    image_shape = (3, 2, 2)
 
-    return IntensityTable.from_spot_data(intensities, spot_attributes, image_shape)
+    return IntensityTable.from_spot_data(intensities, spot_attributes)
 
 
 @pytest.fixture(scope='module')

--- a/starfish/test/pipeline/test_intensity_table.py
+++ b/starfish/test/pipeline/test_intensity_table.py
@@ -18,7 +18,7 @@ from starfish.test.dataset_fixtures import (
 from starfish.types import Features, Indices
 
 
-def make_empty_intensity_table(image_shape=(2, 4, 3)):
+def make_empty_intensity_table():
     x = [1, 2]
     y = [2, 3]
     z = [1, 1]
@@ -26,14 +26,13 @@ def make_empty_intensity_table(image_shape=(2, 4, 3)):
     spot_attributes = pd.DataFrame(
         {Features.X: x, Features.Y: y, Features.Z: z, Features.SPOT_RADIUS: r}
     )
-    empty = IntensityTable.empty_intensity_table(spot_attributes, 2, 2, image_shape)
+    empty = IntensityTable.empty_intensity_table(spot_attributes, 2, 2)
     return empty, spot_attributes
 
 
 def test_empty_intensity_table():
-    image_shape = (2, 4, 3)
-    empty, spot_attributes = make_empty_intensity_table(image_shape=image_shape)
-    empty = IntensityTable.empty_intensity_table(spot_attributes, 2, 2, image_shape)
+    empty, spot_attributes = make_empty_intensity_table()
+    empty = IntensityTable.empty_intensity_table(spot_attributes, 2, 2)
     assert empty.shape == (2, 2, 2)
     assert np.sum(empty.values) == 0
 


### PR DESCRIPTION
* not necessary if we are not supporting reversion from IntensityTable to ImageStack
* adds flexibility to IntensityTable, as now we don't need to pass along an attr. 