### PR TITLE
Experiment builder should write the current version number

### DIFF
--- a/starfish/experiment/__init__.py
+++ b/starfish/experiment/__init__.py
@@ -9,6 +9,7 @@ from starfish.stack import ImageStack
 
 
 class Experiment:
+    CURRENT_VERSION = Version("1.0.0")
     MIN_SUPPORTED_VERSION = Version("1.0.0")
     MAX_SUPPORTED_VERSION = Version("1.0.0")
 

--- a/starfish/experiment/builder/__init__.py
+++ b/starfish/experiment/builder/__init__.py
@@ -10,6 +10,7 @@ from slicedimage import (
     Writer,
 )
 
+from starfish.experiment import Experiment
 from starfish.types import Coordinates, Indices
 from .imagedata import FetchedImage, ImageFetcher, RandomNoiseImage, RandomNoiseImageFetcher
 
@@ -150,7 +151,7 @@ def write_experiment_json(
         postprocess_func = lambda doc: doc
 
     experiment_doc = {
-        'version': "0.0.0",
+        'version': str(Experiment.CURRENT_VERSION),
         'auxiliary_images': {},
         'extras': {},
     }


### PR DESCRIPTION
It's currently hardcoded to 0.0.0; it should be 1.0.0.