### PR TITLE
Add example of raw->spacetx format conversion for ISS Breast Data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ starfish.egg-info/
 .coverage
 .mypy_cache/
 .pytest_cache/
+build/
+dist/

--- a/examples/get_iss_breast_data.py
+++ b/examples/get_iss_breast_data.py
@@ -44,19 +44,20 @@ class ISSCroppedBreastPrimaryTileFetcher(TileFetcher):
 
     @property
     def ch_dict(self):
-        ch_str = ['Cy3 5', 'Cy3', 'Cy5', 'FITC']
-        ch = [2, 1, 3, 0]
-        ch_dict = dict(zip(ch, ch_str))
+        ch_dict = {0: 'FITC', 1: 'Cy3', 2: 'Cy3 5', 3: 'Cy5'}
         return ch_dict
 
     @property
     def hyb_dict(self):
         hyb_str = ['1st', '2nd', '3rd', '4th']
-        return dict(zip(range(4), hyb_str))
+        hyb_dict = dict(enumerate(hyb_str))
+        return hyb_dict
 
     def get_tile(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
-        filename = 'slideA_' + str(fov + 1) + '_' + \
-                   self.hyb_dict[hyb] + '_' + self.ch_dict[ch] + '.TIF'
+        filename = 'slideA_{}_{}_{}.TIF'.format(str(fov + 1),
+                                                self.hyb_dict[hyb],
+                                                self.ch_dict[ch]
+                                                )
         file_path = os.path.join(self.input_dir, filename)
         return IssCroppedBreastTile(file_path)
 
@@ -68,9 +69,9 @@ class ISSCroppedBreastAuxTileFetcher(TileFetcher):
 
     def get_tile(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
         if self.aux_type == 'nuclei':
-            filename = 'slideA_' + str(fov + 1) + '_DO_' + 'DAPI.TIF'
+            filename = 'slideA_{}_DO_DAPI.TIF'.format(str(fov + 1))
         elif self.aux_type == 'dots':
-            filename = 'slideA_' + str(fov + 1) + '_DO_' + 'Cy3.TIF'
+            filename = 'slideA_{}_DO_Cy3.TIF'.format(str(fov + 1))
         else:
             msg = 'invalid aux type: {}'.format(self.aux_type)
             msg += ' expected either nuclei or dots'
@@ -82,12 +83,6 @@ class ISSCroppedBreastAuxTileFetcher(TileFetcher):
 
 
 def format_data(input_dir, output_dir):
-    if not input_dir.endswith("/"):
-        input_dir += "/"
-
-    if not output_dir.endswith("/"):
-        output_dir += "/"
-
     def add_codebook(experiment_json_doc):
         experiment_json_doc['codebook'] = "codebook.json"
         return experiment_json_doc

--- a/examples/get_iss_breast_data.py
+++ b/examples/get_iss_breast_data.py
@@ -83,6 +83,23 @@ class AuxImageFetcherDots(ImageFetcher):
 
 
 def format_data(input_dir, output_dir):
+
+    if not input_dir.endswith("/"):
+        input_dir += "/"
+
+    if not output_dir.endswith("/"):
+        output_dir += "/"
+
+    def add_codebook(experiment_json_doc):
+        experiment_json_doc['codebook'] = "codebook.json"
+
+        # TODO: (ttung) remove the following unholy hacks.  this is because we want to point at a
+        # tileset rather than a collection.
+        experiment_json_doc['hybridization_images'] = "hybridization-fov_000.json"
+        experiment_json_doc['auxiliary_images']['nuclei'] = "nuclei-fov_000.json"
+        experiment_json_doc['auxiliary_images']['dots'] = "dots-fov_000.json"
+        return experiment_json_doc
+
     num_fovs = 16
 
     hyb_dimensions = {
@@ -117,6 +134,7 @@ def format_data(input_dir, output_dir):
                           aux_name_to_dimensions,
                           hyb_image_fetcher=hfetch,
                           aux_image_fetcher=auxfetch,
+                          postprocess_func=add_codebook,
                           default_shape=SHAPE
                           )
 

--- a/examples/get_iss_breast_data.py
+++ b/examples/get_iss_breast_data.py
@@ -56,7 +56,8 @@ class HybridizationImageFetcher(ImageFetcher):
         return dict(zip(range(4), hyb_str))
 
     def get_image(self, fov: int, hyb: int, ch: int, z: int) -> FetchedImage:
-        filename = 'slideA_' + str(fov + 1) + '_' + self.hyb_dict[hyb] + '_' + self.ch_dict[ch] + '.TIF'
+        filename = 'slideA_' + str(fov + 1) + '_' + \
+                   self.hyb_dict[hyb] + '_' + self.ch_dict[ch] + '.TIF'
         file_path = os.path.join(self.input_dir, filename)
         return CroppedISSImage(file_path)
 

--- a/examples/get_iss_breast_data.py
+++ b/examples/get_iss_breast_data.py
@@ -30,6 +30,7 @@ class IssCroppedBreastTile(FetchedTile):
         crp = img[40:1084, 20:1410]
         return crp
 
+    @property
     def tile_data_handle(self) -> IO:
         im = self.crop(imread(self.file_path))
         fh = io.BytesIO()
@@ -123,12 +124,13 @@ def format_data(input_dir, output_dir):
 
 
 if __name__ == "__main__":
+
+    s3_bucket = "s3://czi.starfish.data.public/browse/raw/20180820/iss_breast/"
+    input_help_msg = "Path to raw data. Raw data can be downloaded from: {}".format(s3_bucket)
+    output_help_msg = "Path to output experment.json and all formatted images it references"
     parser = argparse.ArgumentParser()
-    parser.add_argument("input_dir", type=FsExistsType())
-    parser.add_argument("output_dir", type=FsExistsType())
+    parser.add_argument("input_dir", type=FsExistsType(), help=input_help_msg)
+    parser.add_argument("output_dir", type=FsExistsType(), help=output_help_msg)
 
     args = parser.parse_args()
-    s3_bucket = "s3://czi.starfish.data.public/browse/raw/20180820/iss_breast/"
-    print("Raw data live at: {}".format(s3_bucket))
-
     format_data(args.input_dir, args.output_dir)

--- a/examples/get_iss_breast_data.py
+++ b/examples/get_iss_breast_data.py
@@ -113,19 +113,15 @@ def format_data(input_dir, output_dir):
         }
     }
 
-    hfetch = ISSCroppedBreastPrimaryTileFetcher(input_dir)
-
-    auxfetch = {
-        'nuclei': ISSCroppedBreastAuxTileFetcher(input_dir, 'nuclei'),
-        'dots': ISSCroppedBreastAuxTileFetcher(input_dir, 'dots'),
-    }
-
     write_experiment_json(output_dir,
                           num_fovs,
                           hyb_dimensions,
                           aux_name_to_dimensions,
-                          hyb_image_fetcher=hfetch,
-                          aux_image_fetcher=auxfetch,
+                          primary_image_fetcher=ISSCroppedBreastPrimaryTileFetcher(input_dir),
+                          aux_image_fetcher={
+                              'nuclei': ISSCroppedBreastAuxTileFetcher(input_dir, 'nuclei'),
+                              'dots': ISSCroppedBreastAuxTileFetcher(input_dir, 'dots'),
+                          },
                           postprocess_func=add_codebook,
                           default_shape=SHAPE
                           )

--- a/examples/get_iss_breast_data.py
+++ b/examples/get_iss_breast_data.py
@@ -30,7 +30,7 @@ class IssCroppedBreastTile(FetchedTile):
         crp = img[40:1084, 20:1410]
         return crp
 
-    def image_data_handle(self) -> IO:
+    def tile_data_handle(self) -> IO:
         im = self.crop(imread(self.file_path))
         fh = io.BytesIO()
         imsave(fh, im, plugin='tifffile')
@@ -54,7 +54,7 @@ class ISSCroppedBreastPrimaryTileFetcher(TileFetcher):
         hyb_str = ['1st', '2nd', '3rd', '4th']
         return dict(zip(range(4), hyb_str))
 
-    def get_image(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
+    def get_tile(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
         filename = 'slideA_' + str(fov + 1) + '_' + \
                    self.hyb_dict[hyb] + '_' + self.ch_dict[ch] + '.TIF'
         file_path = os.path.join(self.input_dir, filename)
@@ -66,7 +66,7 @@ class ISSCroppedBreastAuxTileFetcher(TileFetcher):
         self.input_dir = input_dir
         self.aux_type = aux_type
 
-    def get_image(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
+    def get_tile(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
         if self.aux_type == 'nuclei':
             filename = 'slideA_' + str(fov + 1) + '_DO_' + 'DAPI.TIF'
         elif self.aux_type == 'dots':
@@ -117,8 +117,8 @@ def format_data(input_dir, output_dir):
                           num_fovs,
                           hyb_dimensions,
                           aux_name_to_dimensions,
-                          primary_image_fetcher=ISSCroppedBreastPrimaryTileFetcher(input_dir),
-                          aux_image_fetcher={
+                          primary_tile_fetcher=ISSCroppedBreastPrimaryTileFetcher(input_dir),
+                          aux_tile_fetcher={
                               'nuclei': ISSCroppedBreastAuxTileFetcher(input_dir, 'nuclei'),
                               'dots': ISSCroppedBreastAuxTileFetcher(input_dir, 'dots'),
                           },

--- a/examples/get_iss_data.py
+++ b/examples/get_iss_data.py
@@ -28,7 +28,7 @@ class ISSTile(FetchedTile):
     def format(self) -> ImageFormat:
         return ImageFormat.TIFF
 
-    def image_data_handle(self) -> IO:
+    def tile_data_handle(self) -> IO:
         return open(self.file_path, "rb")
 
 
@@ -36,7 +36,7 @@ class ISSPrimaryTileFetcher(TileFetcher):
     def __init__(self, input_dir):
         self.input_dir = input_dir
 
-    def get_image(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
+    def get_tile(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
         return ISSTile(os.path.join(self.input_dir, str(hyb + 1), "c{}.TIF".format(ch + 2)))
 
 
@@ -44,7 +44,7 @@ class ISSAuxTileFetcher(TileFetcher):
     def __init__(self, path):
         self.path = path
 
-    def get_image(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
+    def get_tile(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
         return ISSTile(self.path)
 
 
@@ -110,8 +110,8 @@ def format_data(input_dir, output_dir, d):
                 Indices.Z: 1,
             }
         },
-        primary_image_fetcher=ISSPrimaryTileFetcher(input_dir),
-        aux_image_fetcher={
+        primary_tile_fetcher=ISSPrimaryTileFetcher(input_dir),
+        aux_tile_fetcher={
             'nuclei': ISSAuxTileFetcher(os.path.join(input_dir, "DO", "c1.TIF")),
             'dots': ISSAuxTileFetcher(os.path.join(input_dir, "DO", "c2.TIF")),
         },

--- a/examples/get_iss_data.py
+++ b/examples/get_iss_data.py
@@ -8,7 +8,7 @@ from typing import IO, Tuple
 import requests
 from slicedimage import ImageFormat
 
-from starfish.experiment.builder import TileFetcher, FetchedTile
+from starfish.experiment.builder import FetchedTile, TileFetcher
 from starfish.experiment.builder import write_experiment_json
 from starfish.types import Features, Indices
 from starfish.util.argparse import FsExistsType

--- a/examples/get_iss_data.py
+++ b/examples/get_iss_data.py
@@ -110,7 +110,7 @@ def format_data(input_dir, output_dir, d):
                 Indices.Z: 1,
             }
         },
-        hyb_image_fetcher=ISSPrimaryTileFetcher(input_dir),
+        primary_image_fetcher=ISSPrimaryTileFetcher(input_dir),
         aux_image_fetcher={
             'nuclei': ISSAuxTileFetcher(os.path.join(input_dir, "DO", "c1.TIF")),
             'dots': ISSAuxTileFetcher(os.path.join(input_dir, "DO", "c2.TIF")),

--- a/examples/get_iss_data.py
+++ b/examples/get_iss_data.py
@@ -8,21 +8,15 @@ from typing import IO, Tuple
 import requests
 from slicedimage import ImageFormat
 
-from starfish.experiment.builder import FetchedImage, ImageFetcher, write_experiment_json
+from starfish.experiment.builder import TileFetcher, FetchedTile
+from starfish.experiment.builder import write_experiment_json
 from starfish.types import Features, Indices
 from starfish.util.argparse import FsExistsType
 
-SHAPE = (980, 1330)
+SHAPE = 980, 1330
 
 
-def download(input_dir, url):
-    print("Downloading data ...")
-    r = requests.get(url)
-    z = zipfile.ZipFile(io.BytesIO(r.content))
-    z.extractall(input_dir)
-
-
-class ISSImage(FetchedImage):
+class ISSTile(FetchedTile):
     def __init__(self, file_path):
         self.file_path = file_path
 
@@ -38,20 +32,27 @@ class ISSImage(FetchedImage):
         return open(self.file_path, "rb")
 
 
-class HybridizationImageFetcher(ImageFetcher):
+class ISSPrimaryTileFetcher(TileFetcher):
     def __init__(self, input_dir):
         self.input_dir = input_dir
 
-    def get_image(self, fov: int, hyb: int, ch: int, z: int) -> FetchedImage:
-        return ISSImage(os.path.join(self.input_dir, str(hyb + 1), "c{}.TIF".format(ch + 2)))
+    def get_image(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
+        return ISSTile(os.path.join(self.input_dir, str(hyb + 1), "c{}.TIF".format(ch + 2)))
 
 
-class AuxImageFetcher(ImageFetcher):
+class ISSAuxTileFetcher(TileFetcher):
     def __init__(self, path):
         self.path = path
 
-    def get_image(self, fov: int, hyb: int, ch: int, z: int) -> FetchedImage:
-        return ISSImage(self.path)
+    def get_image(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
+        return ISSTile(self.path)
+
+
+def download(input_dir, url):
+    print("Downloading data ...")
+    r = requests.get(url)
+    z = zipfile.ZipFile(io.BytesIO(r.content))
+    z.extractall(input_dir)
 
 
 def write_json(res, output_path):
@@ -109,13 +110,13 @@ def format_data(input_dir, output_dir, d):
                 Indices.Z: 1,
             }
         },
-        hyb_image_fetcher=HybridizationImageFetcher(input_dir),
+        hyb_image_fetcher=ISSPrimaryTileFetcher(input_dir),
         aux_image_fetcher={
-            'nuclei': AuxImageFetcher(os.path.join(input_dir, "DO", "c1.TIF")),
-            'dots': AuxImageFetcher(os.path.join(input_dir, "DO", "c2.TIF")),
+            'nuclei': ISSAuxTileFetcher(os.path.join(input_dir, "DO", "c1.TIF")),
+            'dots': ISSAuxTileFetcher(os.path.join(input_dir, "DO", "c2.TIF")),
         },
         postprocess_func=add_codebook,
-        default_shape=SHAPE,
+        default_shape=SHAPE
     )
 
     codebook = [

--- a/starfish/experiment/builder/__init__.py
+++ b/starfish/experiment/builder/__init__.py
@@ -12,7 +12,7 @@ from slicedimage import (
 
 from starfish.experiment import Experiment
 from starfish.types import Coordinates, Indices
-from .imagedata import FetchedTile, TileFetcher, RandomNoiseTile, RandomNoiseTileFetcher
+from .imagedata import FetchedTile, RandomNoiseTile, RandomNoiseTileFetcher, TileFetcher
 
 
 AUX_IMAGE_NAMES = {

--- a/starfish/experiment/builder/__init__.py
+++ b/starfish/experiment/builder/__init__.py
@@ -84,7 +84,7 @@ def build_image(
         for z_ix in range(z_count):
             for hyb_ix in range(hyb_count):
                 for ch_ix in range(ch_count):
-                    image = image_fetcher.get_image(fov_ix, hyb_ix, ch_ix, z_ix)
+                    image = image_fetcher.get_tile(fov_ix, hyb_ix, ch_ix, z_ix)
                     tile = Tile(
                         {
                             Coordinates.X: (0.0, 0.0001),
@@ -98,7 +98,7 @@ def build_image(
                         },
                         image.shape,
                     )
-                    tile.set_source_fh_contextmanager(image.image_data_handle, image.format)
+                    tile.set_source_fh_contextmanager(image.tile_data_handle, image.format)
                     fov_images.add_tile(tile)
         collection.add_partition("fov_{:03}".format(fov_ix), fov_images)
     return collection
@@ -109,8 +109,8 @@ def write_experiment_json(
         fov_count,
         hyb_dimensions,
         aux_name_to_dimensions,
-        primary_image_fetcher=None,
-        aux_image_fetcher=None,
+        primary_tile_fetcher=None,
+        aux_tile_fetcher=None,
         postprocess_func=None,
         default_shape=(1536, 1024),
 ):
@@ -128,11 +128,11 @@ def write_experiment_json(
     aux_name_to_dimensions : Mapping[str, Mapping[str, int]]
         Dictionary mapping the auxiliary image type to dictionaries, which map from dimension name
         to dimension size.
-    primary_image_fetcher : Optional[ImageFetcher]
+    primary_tile_fetcher : Optional[ImageFetcher]
         ImageFetcher for hybridization images.  Set this if you want specific image data to be set
         for the hybridization images.  If not provided, the image data is set to random noise via
         :class:`RandomNoiseImageFetcher`.
-    aux_image_fetcher : Optional[Mapping[str, ImageFetcher]]
+    aux_tile_fetcher : Optional[Mapping[str, ImageFetcher]]
         ImageFetchers for auxiliary images.  Set this if you want specific image data to be set for
         one or more aux image types.  If not provided for any given aux image, the image data is
         set to random noise via :class:`RandomNoiseImageFetcher`.
@@ -143,10 +143,10 @@ def write_experiment_json(
     default_shape : Tuple[int, int] (default = (1536, 1024))
         Default shape for the tiles in this experiment.
     """
-    if primary_image_fetcher is None:
-        primary_image_fetcher = RandomNoiseTileFetcher()
-    if aux_image_fetcher is None:
-        aux_image_fetcher = {}
+    if primary_tile_fetcher is None:
+        primary_tile_fetcher = RandomNoiseTileFetcher()
+    if aux_tile_fetcher is None:
+        aux_tile_fetcher = {}
     if postprocess_func is None:
         postprocess_func = lambda doc: doc
 
@@ -158,7 +158,7 @@ def write_experiment_json(
     hybridization_image = build_image(
         fov_count,
         hyb_dimensions[Indices.ROUND], hyb_dimensions[Indices.CH], hyb_dimensions[Indices.Z],
-        primary_image_fetcher,
+        primary_tile_fetcher,
         default_shape=default_shape,
     )
     Writer.write_to_path(
@@ -177,7 +177,7 @@ def write_experiment_json(
         auxiliary_image = build_image(
             fov_count,
             aux_dimensions[Indices.ROUND], aux_dimensions[Indices.CH], aux_dimensions[Indices.Z],
-            aux_image_fetcher.get(aux_name, RandomNoiseTileFetcher()),
+            aux_tile_fetcher.get(aux_name, RandomNoiseTileFetcher()),
             default_shape=default_shape,
         )
         Writer.write_to_path(

--- a/starfish/experiment/builder/__init__.py
+++ b/starfish/experiment/builder/__init__.py
@@ -12,7 +12,7 @@ from slicedimage import (
 
 from starfish.experiment import Experiment
 from starfish.types import Coordinates, Indices
-from .imagedata import FetchedImage, ImageFetcher, RandomNoiseImage, RandomNoiseImageFetcher
+from .imagedata import FetchedTile, TileFetcher, RandomNoiseTile, RandomNoiseTileFetcher
 
 
 AUX_IMAGE_NAMES = {
@@ -49,7 +49,7 @@ def fov_path_generator(parent_toc_path, toc_name):
 
 def build_image(
         fov_count, hyb_count, ch_count, z_count,
-        image_fetcher: ImageFetcher,
+        image_fetcher: TileFetcher,
         default_shape: Tuple[int, int]
 ):
     """
@@ -144,7 +144,7 @@ def write_experiment_json(
         Default shape for the tiles in this experiment.
     """
     if hyb_image_fetcher is None:
-        hyb_image_fetcher = RandomNoiseImageFetcher()
+        hyb_image_fetcher = RandomNoiseTileFetcher()
     if aux_image_fetcher is None:
         aux_image_fetcher = {}
     if postprocess_func is None:
@@ -177,7 +177,7 @@ def write_experiment_json(
         auxiliary_image = build_image(
             fov_count,
             aux_dimensions[Indices.ROUND], aux_dimensions[Indices.CH], aux_dimensions[Indices.Z],
-            aux_image_fetcher.get(aux_name, RandomNoiseImageFetcher()),
+            aux_image_fetcher.get(aux_name, RandomNoiseTileFetcher()),
             default_shape=default_shape,
         )
         Writer.write_to_path(

--- a/starfish/experiment/builder/__init__.py
+++ b/starfish/experiment/builder/__init__.py
@@ -109,7 +109,7 @@ def write_experiment_json(
         fov_count,
         hyb_dimensions,
         aux_name_to_dimensions,
-        hyb_image_fetcher=None,
+        primary_image_fetcher=None,
         aux_image_fetcher=None,
         postprocess_func=None,
         default_shape=(1536, 1024),
@@ -128,7 +128,7 @@ def write_experiment_json(
     aux_name_to_dimensions : Mapping[str, Mapping[str, int]]
         Dictionary mapping the auxiliary image type to dictionaries, which map from dimension name
         to dimension size.
-    hyb_image_fetcher : Optional[ImageFetcher]
+    primary_image_fetcher : Optional[ImageFetcher]
         ImageFetcher for hybridization images.  Set this if you want specific image data to be set
         for the hybridization images.  If not provided, the image data is set to random noise via
         :class:`RandomNoiseImageFetcher`.
@@ -143,8 +143,8 @@ def write_experiment_json(
     default_shape : Tuple[int, int] (default = (1536, 1024))
         Default shape for the tiles in this experiment.
     """
-    if hyb_image_fetcher is None:
-        hyb_image_fetcher = RandomNoiseTileFetcher()
+    if primary_image_fetcher is None:
+        primary_image_fetcher = RandomNoiseTileFetcher()
     if aux_image_fetcher is None:
         aux_image_fetcher = {}
     if postprocess_func is None:
@@ -158,7 +158,7 @@ def write_experiment_json(
     hybridization_image = build_image(
         fov_count,
         hyb_dimensions[Indices.ROUND], hyb_dimensions[Indices.CH], hyb_dimensions[Indices.Z],
-        hyb_image_fetcher,
+        primary_image_fetcher,
         default_shape=default_shape,
     )
     Writer.write_to_path(

--- a/starfish/experiment/builder/imagedata.py
+++ b/starfish/experiment/builder/imagedata.py
@@ -21,7 +21,7 @@ class FetchedTile:
         raise NotImplementedError()
 
     @property
-    def image_data_handle(self) -> IO:
+    def tile_data_handle(self) -> IO:
         raise NotImplementedError()
 
 
@@ -30,7 +30,7 @@ class TileFetcher:
     This is the contract for providing the image data for constructing a
     :class:`slicedimage.Collection`.
     """
-    def get_image(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
+    def get_tile(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
         """
         Given fov, hyb, ch, and z, return an instance of a :class:`.FetchedImage` that can be
         queried for the image data.
@@ -51,7 +51,7 @@ class RandomNoiseTile(FetchedTile):
     def format(self) -> ImageFormat:
         return ImageFormat.TIFF
 
-    def image_data_handle(self) -> IO:
+    def tile_data_handle(self) -> IO:
         arr = np.random.randint(0, 256, size=self.shape, dtype=np.uint8)
         output = BytesIO()
         imsave(output, arr, plugin="tifffile")
@@ -64,5 +64,5 @@ class RandomNoiseTileFetcher(TileFetcher):
     This is a simple implementation of :class:`.ImageFetcher` that simply returns a
     :class:`.RandomNoiseImage` for every fov, hyb, ch, z combination.
     """
-    def get_image(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
+    def get_tile(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
         return RandomNoiseTile()

--- a/starfish/experiment/builder/imagedata.py
+++ b/starfish/experiment/builder/imagedata.py
@@ -8,7 +8,7 @@ from slicedimage import (
 )
 
 
-class FetchedImage:
+class FetchedTile:
     """
     This is the contract for providing the data for constructing a :class:`slicedimage.Tile`.
     """
@@ -25,12 +25,12 @@ class FetchedImage:
         raise NotImplementedError()
 
 
-class ImageFetcher:
+class TileFetcher:
     """
     This is the contract for providing the image data for constructing a
     :class:`slicedimage.Collection`.
     """
-    def get_image(self, fov: int, hyb: int, ch: int, z: int) -> FetchedImage:
+    def get_image(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
         """
         Given fov, hyb, ch, and z, return an instance of a :class:`.FetchedImage` that can be
         queried for the image data.
@@ -38,7 +38,7 @@ class ImageFetcher:
         raise NotImplementedError()
 
 
-class RandomNoiseImage(FetchedImage):
+class RandomNoiseTile(FetchedTile):
     """
     This is a simple implementation of :class:`.FetchedImage` that simply regenerates random data
     for the image.
@@ -59,10 +59,10 @@ class RandomNoiseImage(FetchedImage):
         return output
 
 
-class RandomNoiseImageFetcher(ImageFetcher):
+class RandomNoiseTileFetcher(TileFetcher):
     """
     This is a simple implementation of :class:`.ImageFetcher` that simply returns a
     :class:`.RandomNoiseImage` for every fov, hyb, ch, z combination.
     """
-    def get_image(self, fov: int, hyb: int, ch: int, z: int) -> FetchedImage:
-        return RandomNoiseImage()
+    def get_image(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
+        return RandomNoiseTile()


### PR DESCRIPTION
This PR:
1. Introduces get_iss_breast_data.py, which converts raw data from s3://czi.starfish.data.public/browse/raw/20180820/iss_breast/ to spaceTx formatted data. This will be our first real multi-fov dataset. 

2. re-names things. image -> tile, image_fetcher -> tile_fetcher

I tested this PR in a notebook locally. I downloaded the 1 FOV from he breast data formatter and ran the ISS breast notebook against it. It worked.

Remaining work for @ambrosejcarr :
1. Run this tool.
2. Upload formatted data to s3 browsable.
3. Copy codebook.json from 1 FOV dataset over to latter bucket.

Remaining work for @ttung :
1. Get cracking on experiment API so that...

Remaining work for Deep:
1. Use experiment API to analyze this entire dataset (blocked by @ttung )
2. Generate copy number plot for call 2 (high priority @ttung )
3. Start spec'ing out what multi-fov experiment processing will require (blocked by @ttung )

