### PR TITLE
TST: add notebook tests on cropped data for ISS_Pipeline, MERFISH, DARTFISH

### DIFF
--- a/starfish/test/full_pipelines/api/test_allen_smFISH.py
+++ b/starfish/test/full_pipelines/api/test_allen_smFISH.py
@@ -1,0 +1,53 @@
+import pytest
+
+from starfish import Codebook, Experiment
+from starfish.image._filter.bandpass import Bandpass
+from starfish.image._filter.clip import Clip
+from starfish.image._filter.gaussian_low_pass import GaussianLowPass
+from starfish.spots._detector.local_max_peak_finder import LocalMaxPeakFinder
+
+
+@pytest.mark.skip('issues with checksums prevent this data from working properly')
+def test_allen_smFISH_cropped_data():
+
+    # load the experiment
+    experiment_json = (
+        'https://dmf0bdeheu4zf.cloudfront.net/'
+        'TEST/20180821/allen_smFISH_TEST/fov_001/experiment.json'
+    )
+    experiment = Experiment.from_json(experiment_json)
+
+    # load the codebook
+    codebook = Codebook.from_json(  # noqa
+        'https://dmf0bdeheu4zf.cloudfront.net/20180813/allen_smFISH/'
+        'fov_001/codebook.json'
+    )
+
+    primary_image = experiment.image
+
+    clip = Clip(p_min=10, p_max=100)
+    clipped_image = clip.run(primary_image, in_place=False)
+
+    bandpass = Bandpass(lshort=0.5, llong=7, threshold=None, truncate=4)
+    bandpassed_image = bandpass.run(clipped_image, in_place=False)
+
+    clip = Clip(p_min=10, p_max=100, is_volume=False)
+    clipped_bandpassed_image = clip.run(bandpassed_image, in_place=False)
+
+    sigma = (1, 0, 0)  # filter only in z, do nothing in x, y
+    glp = GaussianLowPass(sigma=sigma, is_volume=True)
+    z_filtered_image = glp.run(clipped_bandpassed_image, in_place=False)
+
+    kwargs = dict(
+        spot_diameter=3,
+        min_mass=300,
+        max_size=3,
+        separation=5,
+        noise_size=0.65,
+        preprocess=False,
+        percentile=10,
+        verbose=True,
+        is_volume=True,
+    )
+    lmpf = LocalMaxPeakFinder(**kwargs)
+    intensities = lmpf.run(z_filtered_image)  # noqa

--- a/starfish/test/full_pipelines/api/test_allen_smFISH.py
+++ b/starfish/test/full_pipelines/api/test_allen_smFISH.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from starfish import Codebook, Experiment
@@ -9,6 +10,9 @@ from starfish.spots._detector.local_max_peak_finder import LocalMaxPeakFinder
 
 @pytest.mark.skip('issues with checksums prevent this data from working properly')
 def test_allen_smFISH_cropped_data():
+
+    # set random seed to errors provoked by optimization functions
+    np.random.seed(777)
 
     # load the experiment
     experiment_json = (
@@ -38,7 +42,7 @@ def test_allen_smFISH_cropped_data():
     glp = GaussianLowPass(sigma=sigma, is_volume=True)
     z_filtered_image = glp.run(clipped_bandpassed_image, in_place=False)
 
-    kwargs = dict(
+    lmpf = LocalMaxPeakFinder(
         spot_diameter=3,
         min_mass=300,
         max_size=3,
@@ -49,5 +53,4 @@ def test_allen_smFISH_cropped_data():
         verbose=True,
         is_volume=True,
     )
-    lmpf = LocalMaxPeakFinder(**kwargs)
     intensities = lmpf.run(z_filtered_image)  # noqa

--- a/starfish/test/full_pipelines/api/test_dartfish.py
+++ b/starfish/test/full_pipelines/api/test_dartfish.py
@@ -1,0 +1,156 @@
+import numpy as np
+import pandas as pd
+
+from starfish import Codebook, Experiment
+from starfish.image._filter.scale_by_percentile import ScaleByPercentile
+from starfish.image._filter.zero_by_channel_magnitude import ZeroByChannelMagnitude
+from starfish.spots._detector.pixel_spot_detector import PixelSpotDetector
+from starfish.types import Features
+
+
+def test_dartfish_pipeline_cropped_data():
+
+    # load the experiment
+    experiment_json = (
+        'https://dmf0bdeheu4zf.cloudfront.net/'
+        'TEST/20180821/DARTFISH_TEST/fov_001/experiment.json'
+    )
+    experiment = Experiment.from_json(experiment_json)
+
+    primary_image = experiment.image
+    primary_image._data = primary_image._data.astype(float)
+
+    expected_primary_image = np.array(
+        [[1., 0., 0., 0., 0., 0., 3., 0., 0., 2.],
+         [0., 0., 0., 0., 1., 0., 0., 0., 0., 0.],
+         [0., 0., 0., 0., 1., 0., 0., 0., 2., 0.],
+         [0., 0., 1., 0., 0., 1., 0., 1., 0., 0.],
+         [0., 0., 0., 0., 0., 0., 2., 0., 1., 0.],
+         [0., 0., 1., 0., 2., 0., 0., 0., 0., 1.],
+         [0., 0., 0., 0., 0., 1., 0., 0., 0., 0.],
+         [0., 1., 0., 0., 1., 0., 0., 0., 0., 0.],
+         [1., 1., 0., 0., 0., 0., 0., 0., 0., 0.],
+         [0., 0., 0., 0., 0., 1., 1., 0., 0., 0.]],
+        dtype=np.float
+    )
+
+    assert np.array_equal(
+        primary_image.numpy_array[0, 0, 0, 50:60, 60:70],
+        expected_primary_image
+    )
+
+    sc_filt = ScaleByPercentile(p=100)
+    normalized_image = sc_filt.run(primary_image, in_place=False)
+
+    expected_normalized_image = np.array(
+        [[0.01960784, 0., 0., 0., 0.,
+          0., 0.05882353, 0., 0., 0.03921569],
+         [0., 0., 0., 0., 0.01960784,
+          0., 0., 0., 0., 0.],
+         [0., 0., 0., 0., 0.01960784,
+          0., 0., 0., 0.03921569, 0.],
+         [0., 0., 0.01960784, 0., 0.,
+          0.01960784, 0., 0.01960784, 0., 0.],
+         [0., 0., 0., 0., 0.,
+          0., 0.03921569, 0., 0.01960784, 0.],
+         [0., 0., 0.01960784, 0., 0.03921569,
+          0., 0., 0., 0., 0.01960784],
+         [0., 0., 0., 0., 0.,
+          0.01960784, 0., 0., 0., 0.],
+         [0., 0.01960784, 0., 0., 0.01960784,
+          0., 0., 0., 0., 0.],
+         [0.01960784, 0.01960784, 0., 0., 0.,
+          0., 0., 0., 0., 0.],
+         [0., 0., 0., 0., 0.,
+          0.01960784, 0.01960784, 0., 0., 0.]])
+
+    assert np.allclose(
+        normalized_image.numpy_array[0, 0, 0, 50:60, 60:70],
+        expected_normalized_image
+    )
+
+    z_filt = ZeroByChannelMagnitude(thresh=.05, normalize=False)
+    zero_norm_stack = z_filt.run(normalized_image, in_place=False)
+
+    expected_zero_normalized_image = np.array(
+        [[0.01960784, 0., 0., 0., 0.,
+          0., 0.05882353, 0., 0., 0.03921569],
+         [0., 0., 0., 0., 0.01960784,
+          0., 0., 0., 0., 0.],
+         [0., 0., 0., 0., 0.01960784,
+          0., 0., 0., 0., 0.],
+         [0., 0., 0.01960784, 0., 0.,
+          0., 0., 0.01960784, 0., 0.],
+         [0., 0., 0., 0., 0.,
+          0., 0.03921569, 0., 0.01960784, 0.],
+         [0., 0., 0.01960784, 0., 0.,
+          0., 0., 0., 0., 0.01960784],
+         [0., 0., 0., 0., 0.,
+          0.01960784, 0., 0., 0., 0.],
+         [0., 0.01960784, 0., 0., 0.,
+          0., 0., 0., 0., 0.],
+         [0.01960784, 0., 0., 0., 0.,
+          0., 0., 0., 0., 0.],
+         [0., 0., 0., 0., 0.,
+          0., 0.01960784, 0., 0., 0.]])
+
+    assert np.allclose(
+        expected_zero_normalized_image,
+        zero_norm_stack.numpy_array[0, 0, 0, 50:60, 60:70]
+    )
+
+    magnitude_threshold = 0.5
+    area_threshold = (5, 30)
+    distance_threshold = 3
+
+    codebook = Codebook.from_json(
+        'https://dmf0bdeheu4zf.cloudfront.net/20180813/DARTFISH/fov_001/codebook.json'
+    )
+
+    psd = PixelSpotDetector(
+        codebook=codebook,
+        metric='euclidean',
+        distance_threshold=distance_threshold,
+        magnitude_threshold=magnitude_threshold,
+        min_area=area_threshold[0],
+        max_area=area_threshold[1]
+    )
+
+    spot_intensities, results = psd.run(zero_norm_stack)
+    spots_df = spot_intensities.to_features_dataframe()
+    spots_df['area'] = np.pi * spots_df['radius'] ** 2
+
+    # verify number of spots detected
+    assert spot_intensities.sizes[Features.AXIS] == 53
+
+    # compare to benchmark data -- note that this particular part of the dataset appears completely
+    # uncorrelated
+    cnts_benchmark = pd.read_csv(
+        'https://dmf0bdeheu4zf.cloudfront.net/20180813/DARTFISH/fov_001/counts.csv')
+
+    min_dist = 0.6
+    cnts_starfish = spots_df[spots_df.distance <= min_dist].groupby('target').count()['area']
+    cnts_starfish = cnts_starfish.reset_index(level=0)
+    cnts_starfish.rename(columns={'target': 'gene', 'area': 'cnt_starfish'}, inplace=True)
+
+    # get top 5 genes and verify they are correct
+    high_expression_genes = cnts_starfish.sort_values('cnt_starfish', ascending=False).head(5)
+    assert np.array_equal(
+        high_expression_genes['cnt_starfish'].values,
+        [7, 3, 2, 2, 2]
+    )
+    assert np.array_equal(
+        high_expression_genes['gene'].values,
+        ['MBP', 'MOBP', 'ADCY8', 'TRIM66', 'SYT6']
+    )
+
+    # verify correlation is accurate for this subset of the image
+    benchmark_comparison = pd.merge(cnts_benchmark, cnts_starfish, on='gene', how='left')
+    benchmark_comparison.head(20)
+
+    x = benchmark_comparison.dropna().cnt.values
+    y = benchmark_comparison.dropna().cnt_starfish.values
+    corrcoef = np.corrcoef(x, y)
+    corrcoef = corrcoef[0, 1]
+
+    assert np.round(corrcoef, 5) == -0.00992

--- a/starfish/test/full_pipelines/api/test_dartfish.py
+++ b/starfish/test/full_pipelines/api/test_dartfish.py
@@ -10,6 +10,9 @@ from starfish.types import Features
 
 def test_dartfish_pipeline_cropped_data():
 
+    # set random seed to errors provoked by optimization functions
+    np.random.seed(777)
+
     # load the experiment
     experiment_json = (
         'https://dmf0bdeheu4zf.cloudfront.net/'
@@ -62,7 +65,9 @@ def test_dartfish_pipeline_cropped_data():
          [0.01960784, 0.01960784, 0., 0., 0.,
           0., 0., 0., 0., 0.],
          [0., 0., 0., 0., 0.,
-          0.01960784, 0.01960784, 0., 0., 0.]])
+          0.01960784, 0.01960784, 0., 0., 0.]],
+        dtype=np.float,
+    )
 
     assert np.allclose(
         normalized_image.numpy_array[0, 0, 0, 50:60, 60:70],
@@ -92,7 +97,9 @@ def test_dartfish_pipeline_cropped_data():
          [0.01960784, 0., 0., 0., 0.,
           0., 0., 0., 0., 0.],
          [0., 0., 0., 0., 0.,
-          0., 0.01960784, 0., 0., 0.]])
+          0., 0.01960784, 0., 0., 0.]],
+        dtype=np.float
+    )
 
     assert np.allclose(
         expected_zero_normalized_image,

--- a/starfish/test/full_pipelines/api/test_iss_api.py
+++ b/starfish/test/full_pipelines/api/test_iss_api.py
@@ -1,43 +1,122 @@
+import warnings
+
 import numpy as np
 
+from starfish import Codebook, Experiment
 from starfish.image._filter.white_tophat import WhiteTophat
 from starfish.image._registration.fourier_shift import FourierShiftRegistration
+from starfish.image._segmentation.watershed import Watershed
 from starfish.spots._detector.gaussian import GaussianSpotDetector
-from starfish.stack import ImageStack
-from starfish.types import Indices
-from starfish.util.synthesize import SyntheticData
+from starfish.spots._target_assignment.point_in_poly import PointInPoly2D
+from starfish.types import Features, Indices
 
 
-def test_iss_pipeline():
-    np.random.seed(2)
-    synthesizer = SyntheticData(n_spots=5)
-    codebook = synthesizer.codebook()
-    true_intensities = synthesizer.intensities(codebook=codebook)
-    image = synthesizer.spots(intensities=true_intensities)
+def test_iss_pipeline_cropped_data():
 
-    dots_data = image.max_proj(Indices.ROUND, Indices.CH, Indices.Z)
-    dots = ImageStack.from_numpy_array(dots_data.reshape((1, 1, 1, *dots_data.shape)))
-
-    wth = WhiteTophat(masking_radius=15)
-    wth.run(image)
-    wth.run(dots)
-
-    fsr = FourierShiftRegistration(upsampling=1000, reference_stack=dots)
-    fsr.run(image)
-
-    min_sigma = 1.5
-    max_sigma = 5
-    num_sigma = 10
-    threshold = 1e-4
-    gsd = GaussianSpotDetector(
-        min_sigma=min_sigma,
-        max_sigma=max_sigma,
-        num_sigma=num_sigma,
-        threshold=threshold,
-        measurement_type='max',
+    # load the experiment
+    experiment_json = (
+        'https://dmf0bdeheu4zf.cloudfront.net/'
+        'TEST/20180821/ISS_TEST/fov_001/experiment.json'
     )
-    blobs_image = dots.numpy_array.reshape(1, *dots_data.shape)
-    intensities = gsd.run(data_stack=image, blobs_image=blobs_image)
-    assert intensities.shape[0] == 5
+    experiment = Experiment.from_json(experiment_json)
+    dots = experiment.auxiliary_images['dots']
+    nuclei = experiment.auxiliary_images['nuclei']
+    primary_image = experiment.image
 
-    codebook.metric_decode(intensities, max_distance=1, min_intensity=0, norm_order=2)
+    # register the data
+    fsr = FourierShiftRegistration(upsampling=1000, reference_stack=dots)
+    registered_primary_image = fsr.run(primary_image, in_place=False)
+
+    # pick a random part of the registered image and assert on it
+    expected_registration_values = np.array(
+        [[5887, 5846, 5900, 5891, 5857, 6047, 6393, 6435, 6636, 7476],
+         [6334, 6197, 6229, 6266, 6195, 6295, 6490, 6575, 6796, 6866],
+         [7110, 6704, 6610, 6511, 6408, 6512, 6665, 6718, 7004, 7247],
+         [7862, 7172, 7143, 6824, 6746, 6778, 6902, 6905, 6955, 7497],
+         [9192, 8233, 7913, 7654, 7501, 7140, 7160, 6966, 7154, 7250],
+         [9637, 9302, 9007, 8592, 8018, 7750, 7666, 7339, 7112, 7134],
+         [9638, 9787, 9840, 9181, 8638, 8505, 7921, 7454, 7455, 7334],
+         [8773, 9603, 9924, 9536, 9047, 8472, 8299, 7704, 7647, 7362],
+         [8267, 8829, 9444, 9826, 9362, 8898, 8331, 7970, 7670, 7607],
+         [8145, 8300, 8797, 9532, 9877, 9304, 8451, 8141, 7881, 7919]],
+        dtype=np.uint16
+    )
+    assert np.array_equal(
+        expected_registration_values,
+        registered_primary_image.numpy_array[2, 2, 0, 40:50, 40:50]
+    )
+
+    # filter the data
+    filt = WhiteTophat(masking_radius=15)
+    filtered_dots, filtered_nuclei, filtered_primary_image = [
+        filt.run(img, in_place=False) for img in (dots, nuclei, registered_primary_image)
+    ]
+
+    # assert on a random part of the filtered image
+    expected_filtered_values = np.array(
+        [[63, 160, 22, 67, 0, 0, 0, 0, 183, 272],
+         [481, 529, 150, 64, 45, 114, 0, 0, 0, 0],
+         [1044, 194, 298, 306, 0, 0, 42, 113, 0, 0],
+         [2008, 1059, 533, 148, 322, 95, 124, 0, 0, 18],
+         [2442, 1557, 1048, 784, 857, 123, 162, 107, 65, 0],
+         [2715, 2146, 1739, 1397, 1006, 545, 370, 0, 172, 0],
+         [2868, 2771, 2434, 2426, 1641, 1002, 671, 191, 109, 0],
+         [2686, 3078, 2984, 2601, 2092, 1439, 882, 531, 218, 0],
+         [1992, 2698, 3225, 2832, 2369, 1718, 1478, 1088, 385, 97],
+         [1880, 2122, 3027, 3178, 2398, 1652, 1522, 1375, 724, 285]],
+        dtype=np.uint16
+    )
+    assert np.array_equal(
+        expected_filtered_values,
+        filtered_primary_image.numpy_array[1, 1, 0, 40:50, 40:50]
+    )
+
+    # call spots
+    gsd = GaussianSpotDetector(
+        min_sigma=1,
+        max_sigma=10,
+        num_sigma=30,
+        threshold=0.01,
+        measurement_type='mean',
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+
+        # blobs = dots; define the spots in the dots image, but then find them again in the stack.
+        blobs_image = dots.max_proj(Indices.ROUND, Indices.Z)
+        intensities = gsd.run(primary_image, blobs_image=blobs_image)
+
+    # assert that the number of spots detected is 99
+    assert intensities.sizes[Features.AXIS] == 99
+
+    # decode
+    codebook_json = (
+        'https://dmf0bdeheu4zf.cloudfront.net/'
+        'TEST/20180821/ISS_TEST/fov_001/codebook.json'
+    )
+    codebook = Codebook.from_json(codebook_json)
+    decoded_intensities = codebook.decode_per_round_max(intensities)
+
+    # decoding identifies 4 genes, each with 1 count
+    genes, gene_counts = np.unique(decoded_intensities['target'], return_counts=True)
+    assert np.array_equal(genes, np.array(['CD68', 'GUS', 'None', 'ST-3', 'VEGF']))
+    assert np.array_equal(gene_counts, [1, 1, 95, 1, 1])
+
+    # segment
+    # TODO ambrosejcarr: do these need to be adjusted for the image size?
+    seg = Watershed(
+        dapi_threshold=.16,
+        input_threshold=.22,
+        min_distance=57
+    )
+    regions = seg.run(filtered_primary_image, filtered_nuclei)
+
+    # segmentation identifies only one cell
+    assert seg._segmentation_instance.num_cells == 1
+
+    # assign targets
+    pip = PointInPoly2D()
+    pip.run(decoded_intensities, regions)
+
+    # 18 of the spots are assigned to cell 1 (although most spots do not decode!)
+    assert np.sum(decoded_intensities['cell_id'] == 0) == 18

--- a/starfish/test/full_pipelines/api/test_iss_api.py
+++ b/starfish/test/full_pipelines/api/test_iss_api.py
@@ -13,6 +13,9 @@ from starfish.types import Features, Indices
 
 def test_iss_pipeline_cropped_data():
 
+    # set random seed to errors provoked by optimization functions
+    np.random.seed(777)
+
     # load the experiment
     experiment_json = (
         'https://dmf0bdeheu4zf.cloudfront.net/'

--- a/starfish/test/full_pipelines/api/test_merfish.py
+++ b/starfish/test/full_pipelines/api/test_merfish.py
@@ -1,45 +1,189 @@
-import pytest
+import numpy as np
+import pandas as pd
 
+from starfish import Codebook, Experiment
 from starfish.image._filter.gaussian_high_pass import GaussianHighPass
 from starfish.image._filter.gaussian_low_pass import GaussianLowPass
 from starfish.image._filter.richardson_lucy_deconvolution import DeconvolvePSF
 from starfish.spots._detector.pixel_spot_detector import PixelSpotDetector
-from starfish.types import Indices
+from starfish.types import Features, Indices
 
 
-@pytest.mark.skip("TODO ambrosejcarr: fix this test in a future PR. Currently no spots are "
-                  "generated, and this fails.")
-def test_merfish_pipeline(merfish_stack):
-    s = merfish_stack
+def test_merfish_pipeline_cropped_data():
+
+    # load the experiment
+    experiment_json = (
+        'https://dmf0bdeheu4zf.cloudfront.net/'
+        'TEST/20180821/MERFISH_TEST/fov_001/experiment.json'
+    )
+    experiment = Experiment.from_json(experiment_json)
+    primary_image = experiment.image
+
+    expected_primary_image = np.array(
+        [[6287, 6419, 6612, 6705, 6641, 6555, 6784, 6978, 7084, 7058],
+         [6449, 6364, 6414, 6570, 6565, 6621, 7049, 7178, 7136, 6863],
+         [6531, 6553, 6755, 6727, 6665, 6827, 6934, 6985, 6864, 6692],
+         [6805, 6895, 6962, 6898, 6816, 6629, 6687, 6826, 6781, 6838],
+         [6907, 6913, 6858, 6912, 6957, 6917, 6768, 6547, 6541, 6751],
+         [7111, 6979, 6778, 6820, 7059, 7039, 6986, 6768, 6730, 6715],
+         [7489, 7354, 7181, 7035, 7013, 7066, 7045, 6781, 6652, 6765],
+         [7630, 7498, 7322, 7199, 7234, 7194, 7116, 6735, 6718, 6667],
+         [7620, 7627, 7590, 7516, 7332, 7237, 7205, 6877, 6688, 6619],
+         [7673, 7728, 7626, 7696, 7461, 7312, 7156, 6990, 6770, 6662]],
+        dtype=np.uint16
+    )
+    assert np.array_equal(
+        expected_primary_image,
+        primary_image.numpy_array[5, 0, 0, 40:50, 45:55]
+    )
 
     # high pass filter
     ghp = GaussianHighPass(sigma=3)
-    ghp.run(s)
+    high_passed = ghp.run(primary_image, in_place=False)
+
+    expected_high_passed = np.array(
+        [[0, 0, 72, 131, 39, 0, 134, 306, 388, 337],
+         [0, 0, 0, 0, 0, 0, 332, 443, 381, 86],
+         [0, 0, 27, 0, 0, 63, 161, 202, 68, 0],
+         [0, 61, 127, 65, 0, 0, 0, 5, 0, 5],
+         [0, 0, 0, 0, 48, 28, 0, 0, 0, 0],
+         [0, 0, 0, 0, 69, 87, 71, 0, 0, 0],
+         [216, 128, 5, 0, 0, 49, 81, 0, 0, 0],
+         [233, 159, 44, 0, 86, 114, 103, 0, 0, 0],
+         [123, 195, 226, 225, 117, 100, 144, 0, 0, 0],
+         [100, 224, 196, 344, 191, 126, 51, 0, 0, 0]], dtype=np.uint16
+    )
+
+    assert np.array_equal(
+        expected_high_passed,
+        high_passed.numpy_array[5, 0, 0, 40:50, 45:55]
+    )
 
     # deconvolve the point spread function
     dpsf = DeconvolvePSF(num_iter=15, sigma=2)
-    dpsf.run(s)
+    deconvolved = dpsf.run(high_passed, in_place=False)
+
+    # assert that the deconvolved data is correct
+    expected_deconvolved_values = np.array(
+        [[0, 0, 3, 15, 28, 55, 152, 323, 425, 364],
+         [0, 0, 1, 7, 23, 74, 259, 508, 506, 284],
+         [0, 0, 1, 7, 20, 47, 105, 117, 72, 27],
+         [0, 0, 2, 7, 13, 16, 15, 6, 1, 0],
+         [0, 1, 3, 6, 8, 6, 2, 0, 0, 0],
+         [5, 4, 5, 6, 7, 3, 0, 0, 0, 0],
+         [48, 20, 14, 12, 11, 4, 0, 0, 0, 0],
+         [169, 77, 59, 52, 46, 16, 1, 0, 0, 0],
+         [125, 98, 142, 202, 220, 77, 5, 0, 0, 0],
+         [30, 61, 227, 619, 890, 315, 17, 0, 0, 0]], dtype=np.uint16
+    )
+    assert np.array_equal(
+        expected_deconvolved_values,
+        deconvolved.numpy_array[5, 0, 0, 40:50, 45:55]
+    )
 
     # low pass filter
     glp = GaussianLowPass(sigma=1)
-    glp.run(s)
+    low_passed = glp.run(deconvolved, in_place=False)
+
+    expected_low_passed = np.array(
+        [[2, 9, 19, 30, 43, 77, 149, 228, 260, 237],
+         [0, 1, 6, 15, 37, 87, 175, 258, 274, 226],
+         [0, 0, 3, 10, 27, 61, 113, 153, 149, 112],
+         [0, 1, 3, 8, 15, 27, 42, 49, 42, 28],
+         [6, 4, 4, 6, 9, 10, 10, 9, 6, 3],
+         [33, 16, 11, 10, 9, 6, 3, 1, 0, 0],
+         [95, 49, 34, 31, 26, 15, 5, 1, 0, 0],
+         [151, 91, 85, 98, 92, 55, 19, 3, 0, 0],
+         [134, 114, 163, 243, 258, 164, 58, 11, 1, 0],
+         [73, 102, 218, 395, 461, 309, 113, 21, 2, 0]],
+        dtype=np.uint16
+    )
+    assert np.array_equal(
+        expected_low_passed,
+        low_passed.numpy_array[5, 0, 0, 40:50, 45:55]
+    )
+
+    # cast to float
+    low_passed._data = low_passed._data.astype(np.float64)
 
     # scale the data by the scale factors
-    scale_factors = {(t[Indices.ROUND], t[Indices.CH]): t['scale_factor']
-                     for index, t in s.tile_metadata.iterrows()}
-    for indices in s.image._iter_indices():
-        data = s.image.get_slice(indices)[0]
-        scaled = data / scale_factors[indices[Indices.ROUND], indices[Indices.CH]]
-        s.image.set_slice(indices, scaled)
+    scale_factors = {
+        (t[Indices.ROUND], t[Indices.CH]): t['scale_factor']
+        for t in experiment.format_metadata['extras']['scale_factors']
+    }
+    for indices in low_passed._iter_indices():
+        data = low_passed.get_slice(indices)[0]
+        scaled = data / scale_factors[indices[Indices.ROUND.value], indices[Indices.CH.value]]
+        low_passed.set_slice(indices, scaled)
+
+    # assert that the scaled data is correct
+    expected_scaled_low_passed = np.array(
+        [[0.02516705, 0.11325171, 0.23908694, 0.37750569, 0.54109149,
+          0.96893128, 1.87494495, 2.86904327, 3.27171602, 2.98229498],
+         [0., 0.01258352, 0.07550114, 0.18875285, 0.46559036,
+          1.09476651, 2.20211655, 3.24654897, 3.44788534, 2.84387623],
+         [0., 0., 0.03775057, 0.12583523, 0.33975512,
+          0.76759491, 1.42193811, 1.92527904, 1.87494495, 1.40935459],
+         [0., 0.01258352, 0.03775057, 0.10066819, 0.18875285,
+          0.33975512, 0.52850797, 0.61659263, 0.52850797, 0.35233865],
+         [0.07550114, 0.05033409, 0.05033409, 0.07550114, 0.11325171,
+          0.12583523, 0.12583523, 0.11325171, 0.07550114, 0.03775057],
+         [0.41525626, 0.20133637, 0.13841875, 0.12583523, 0.11325171,
+          0.07550114, 0.03775057, 0.01258352, 0., 0.],
+         [1.1954347, 0.61659263, 0.42783979, 0.39008922, 0.3271716,
+          0.18875285, 0.06291762, 0.01258352, 0., 0.],
+         [1.90011199, 1.14510061, 1.06959947, 1.23318527, 1.15768413,
+          0.69209377, 0.23908694, 0.03775057, 0., 0.],
+         [1.6861921, 1.43452164, 2.05111427, 3.05779612, 3.24654897,
+          2.06369779, 0.72984434, 0.13841875, 0.01258352, 0.],
+         [0.91859719, 1.28351936, 2.74320804, 4.97049164, 5.80100417,
+          3.88830865, 1.42193811, 0.26425399, 0.02516705, 0.]]
+    )
+    assert np.allclose(
+        expected_scaled_low_passed,
+        low_passed.numpy_array[5, 0, 0, 40:50, 45:55]
+    )
 
     # detect and decode spots
+    codebook = Codebook.from_json(
+        'https://dmf0bdeheu4zf.cloudfront.net/'
+        'TEST/20180821/MERFISH_TEST/fov_001/codebook.json'
+    )
     psd = PixelSpotDetector(
-        codebook='https://dmf0bdeheu4zf.cloudfront.net/MERFISH/codebook.csv',
+        codebook=codebook,
         metric='euclidean',
         distance_threshold=0.5176,
         magnitude_threshold=1,
-        area_threshold=2,
-        crop_size=40
+        min_area=2,
+        max_area=np.inf,
+        norm_order=2,
+        crop_size=(0, 40, 40)
+    )
+    spot_intensities, prop_results = psd.run(low_passed)
+
+    # verify that the number of spots are correct
+    assert spot_intensities.sizes[Features.AXIS] == 1019
+
+    # compare to paper results
+    bench = pd.read_csv('https://dmf0bdeheu4zf.cloudfront.net/MERFISH/benchmark_results.csv',
+                        dtype={'barcode': object})
+
+    benchmark_counts = bench.groupby('gene')['gene'].count()
+    genes, counts = np.unique(spot_intensities[Features.TARGET], return_counts=True)
+    result_counts = pd.Series(counts, index=genes)
+
+    # assert that number of high-expression detected genes are correct
+    expected_counts = pd.Series(
+        [101, 84, 70, 48, 40],
+        index=(None, 'SRRM2', 'FASN', 'IGF2R', 'MYH10')
+    )
+    assert np.array_equal(
+        expected_counts.values,
+        result_counts.sort_values(ascending=False).head(5).values
     )
 
-    psd.run(s)
+    tmp = pd.concat([result_counts, benchmark_counts], join='inner', axis=1).values
+
+    corrcoef = np.corrcoef(tmp[:, 1], tmp[:, 0])[0, 1]
+
+    assert np.round(corrcoef, 4) == 0.9166

--- a/starfish/test/full_pipelines/api/test_merfish.py
+++ b/starfish/test/full_pipelines/api/test_merfish.py
@@ -11,6 +11,9 @@ from starfish.types import Features, Indices
 
 def test_merfish_pipeline_cropped_data():
 
+    # set random seed to errors provoked by optimization functions
+    np.random.seed(777)
+
     # load the experiment
     experiment_json = (
         'https://dmf0bdeheu4zf.cloudfront.net/'
@@ -51,7 +54,8 @@ def test_merfish_pipeline_cropped_data():
          [216, 128, 5, 0, 0, 49, 81, 0, 0, 0],
          [233, 159, 44, 0, 86, 114, 103, 0, 0, 0],
          [123, 195, 226, 225, 117, 100, 144, 0, 0, 0],
-         [100, 224, 196, 344, 191, 126, 51, 0, 0, 0]], dtype=np.uint16
+         [100, 224, 196, 344, 191, 126, 51, 0, 0, 0]],
+        dtype=np.uint16
     )
 
     assert np.array_equal(
@@ -74,7 +78,8 @@ def test_merfish_pipeline_cropped_data():
          [48, 20, 14, 12, 11, 4, 0, 0, 0, 0],
          [169, 77, 59, 52, 46, 16, 1, 0, 0, 0],
          [125, 98, 142, 202, 220, 77, 5, 0, 0, 0],
-         [30, 61, 227, 619, 890, 315, 17, 0, 0, 0]], dtype=np.uint16
+         [30, 61, 227, 619, 890, 315, 17, 0, 0, 0]],
+        dtype=np.uint16
     )
     assert np.array_equal(
         expected_deconvolved_values,
@@ -137,7 +142,8 @@ def test_merfish_pipeline_cropped_data():
          [1.6861921, 1.43452164, 2.05111427, 3.05779612, 3.24654897,
           2.06369779, 0.72984434, 0.13841875, 0.01258352, 0.],
          [0.91859719, 1.28351936, 2.74320804, 4.97049164, 5.80100417,
-          3.88830865, 1.42193811, 0.26425399, 0.02516705, 0.]]
+          3.88830865, 1.42193811, 0.26425399, 0.02516705, 0.]],
+        dtype=np.float
     )
     assert np.allclose(
         expected_scaled_low_passed,


### PR DESCRIPTION
Strategy: 
- verified real notebooks work
- cropped a small (x, y) piece of the 5-d tensor
- calculated the outputs over the small piece as a python test
- added assertions at each stage of processing to isolate earliest point of failure
- tests will probably fail on ANY change to processing algorithms, are designed to err on over-sensitivity. 

* Also adds non-functional test for allen_smFISH, currently blocked by checksum issues
* Overall testing time is reduced, as this reduces the time taken for the existing iss test. 
