### PR TITLE
Use slicedimage's backends to load codebooks.

### DIFF
--- a/starfish/codebook.py
+++ b/starfish/codebook.py
@@ -1,13 +1,12 @@
 import json
-import urllib.request
 import uuid
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import numpy as np
 import pandas as pd
-import validators
 import xarray as xr
 from sklearn.neighbors import NearestNeighbors
+from slicedimage.io import resolve_path_or_url
 
 from starfish.intensity_table import IntensityTable
 from starfish.types import Features, Indices, Number
@@ -298,12 +297,9 @@ class Codebook(xr.DataArray):
             Codebook with shape (targets, channels, imaging_rounds)
 
         """
-        if validators.url(json_codebook):
-            with urllib.request.urlopen(json_codebook) as response:
-                code_array = json.loads(response.read().decode('utf-8'))
-        else:
-            with open(json_codebook, 'r') as f:
-                code_array = json.load(f)
+        backend, name, _ = resolve_path_or_url(json_codebook)
+        with backend.read_contextmanager(name) as fh:
+            code_array = json.load(fh)
         return cls.from_code_array(code_array, n_round, n_ch)
 
     def to_json(self, filename: str) -> None:

--- a/starfish/test/pipeline/test_codebook.py
+++ b/starfish/test/pipeline/test_codebook.py
@@ -1,8 +1,6 @@
-import json
 import os
 import tempfile
 import warnings
-from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -24,34 +22,6 @@ from starfish.types import Features, Indices
 def test_loading_codebook_from_json_local_file(simple_codebook_json):
     cb = Codebook.from_json(simple_codebook_json, n_ch=2, n_round=2)
     assert isinstance(cb, Codebook)
-
-
-@patch('starfish.codebook.urllib.request.urlopen')
-def test_loading_codebook_from_json_https_file(mock_urlopen):
-
-    # codebook data to pass to the mock
-    _return_value = json.dumps(
-        [
-            {
-                Features.CODEWORD: [
-                    {Indices.ROUND.value: 0, Indices.CH.value: 0, Features.CODE_VALUE: 1},
-                    {Indices.ROUND.value: 1, Indices.CH.value: 1, Features.CODE_VALUE: 1}
-                ],
-                Features.TARGET: "SCUBE2"
-            }
-        ]
-    ).encode()
-
-    # mock urlopen.read() to return data corresponding to a codebook
-    a = MagicMock()
-    a.read.side_effect = [_return_value]
-    a.__enter__.return_value = a
-    mock_urlopen.return_value = a
-
-    # test that the function loads the codebook from the link when called
-    cb = Codebook.from_json('https://www.alink.com/file.json', n_ch=2, n_round=2)
-    assert isinstance(cb, Codebook)
-    assert mock_urlopen.call_count == 1
 
 
 def test_loading_codebook_from_list(simple_codebook_array):


### PR DESCRIPTION
This allows us to use file:/// schema URLs.