### PR TITLE
Remove MERFISH fixture, speed up filter tests

### DIFF
--- a/starfish/test/dataset_fixtures.py
+++ b/starfish/test/dataset_fixtures.py
@@ -11,35 +11,12 @@ import pytest
 from scipy.ndimage.filters import gaussian_filter
 
 from starfish.codebook import Codebook
-from starfish.experiment import Experiment
 from starfish.image._filter.white_tophat import WhiteTophat
 from starfish.intensity_table import IntensityTable
 from starfish.spots._detector.gaussian import GaussianSpotDetector
 from starfish.stack import ImageStack
 from starfish.types import Features, Indices
 from starfish.util import synthesize
-
-
-# TODO ambrosejcarr: all fixtures should emit a stack and a codebook
-@pytest.fixture(scope='session')
-def merfish_stack() -> Experiment:
-    """retrieve MERFISH testing data from cloudfront and expose it at the module level
-
-    Notes
-    -----
-    Because download takes time, this fixture runs once per session -- that is, the download is run
-    only once.
-
-    Returns
-    -------
-    Stack :
-        starfish.io.Stack object containing MERFISH data
-    """
-    s = Experiment()
-    s.read(
-        'https://dmf0bdeheu4zf.cloudfront.net/20180802/MERFISH/fov_001/experiment.json'
-    )
-    return deepcopy(s)
 
 
 @pytest.fixture(scope='session')

--- a/starfish/test/pipeline/test_filter.py
+++ b/starfish/test/pipeline/test_filter.py
@@ -3,44 +3,41 @@ from typing import Tuple, Union
 import numpy as np
 import pytest
 
-from starfish.experiment import Experiment
 from starfish.image._filter import gaussian_high_pass
-from starfish.test.dataset_fixtures import merfish_stack
+from starfish.stack import ImageStack
 from starfish.types import Number
 
 
-@pytest.mark.parametrize('sigma', (1, (1, 1)))
-def test_gaussian_high_pass(merfish_stack: Experiment, sigma: Union[Number, Tuple[Number]]):
-    """high pass is subtractive, sum of array should be less after running
-
-    Parameters
-    ----------
-    merfish_stack : Experiment
-        pytest fixture that exposes a starfish.io.Stack object containing MERFISH testing data
-    sigma : Union[int, Tuple[int]]
-        the standard deviation of the gaussian kernel
-    """
-    ghp = gaussian_high_pass.GaussianHighPass(sigma=sigma)
-    sum_before = np.sum(merfish_stack.image.numpy_array)
-    ghp.run(merfish_stack.image)
-    assert np.sum(merfish_stack.image.numpy_array) < sum_before
+def random_data_image_stack_factory():
+    data = np.random.uniform(0, 10, 100).reshape(1, 1, 1, 10, 10).astype(np.uint16)
+    return ImageStack.from_numpy_array(data)
 
 
 @pytest.mark.parametrize('sigma', (1, (1, 1)))
-def test_gaussian_high_pass_apply(merfish_stack: Experiment, sigma: Union[Number, Tuple[Number]]):
-    """same as test_gaussian_high_pass, but tests apply loop functionality"""
-    sum_before = np.sum(merfish_stack.image.numpy_array)
+def test_gaussian_high_pass(sigma: Union[Number, Tuple[Number]]) -> None:
+    """high pass is subtractive, sum of array should be less after running."""
+    image_stack = random_data_image_stack_factory()
     ghp = gaussian_high_pass.GaussianHighPass(sigma=sigma)
-    ghp.run(merfish_stack.image)
-    assert np.sum(merfish_stack.image.numpy_array) < sum_before
+    sum_before = np.sum(image_stack.numpy_array)
+    ghp.run(image_stack)
+    assert np.sum(image_stack.numpy_array) < sum_before
+
+
+@pytest.mark.parametrize('sigma', (1, (1, 1)))
+def test_gaussian_high_pass_apply(sigma: Union[Number, Tuple[Number]]) -> None:
+    """same as test_gaussian_high_pass, but tests apply loop functionality."""
+    image_stack = random_data_image_stack_factory()
+    sum_before = np.sum(image_stack.numpy_array)
+    ghp = gaussian_high_pass.GaussianHighPass(sigma=sigma)
+    ghp.run(image_stack)
+    assert np.sum(image_stack.numpy_array) < sum_before
 
 
 @pytest.mark.parametrize('sigma', (1, (1, 0, 1)))
-def test_gaussian_high_pass_apply_3d(
-        merfish_stack: Experiment, sigma: Union[Number, Tuple[Number]]
-):
-    """same as test_gaussian_high_pass, but tests apply loop functionality"""
-    sum_before = np.sum(merfish_stack.image.numpy_array)
+def test_gaussian_high_pass_apply_3d(sigma: Union[Number, Tuple[Number]]) -> None:
+    """same as test_gaussian_high_pass, but tests apply loop functionality in 3d"""
+    image_stack = random_data_image_stack_factory()
+    sum_before = np.sum(image_stack.numpy_array)
     ghp = gaussian_high_pass.GaussianHighPass(sigma=sigma, is_volume=True)
-    ghp.run(merfish_stack.image)
-    assert np.sum(merfish_stack.image.numpy_array) < sum_before
+    ghp.run(image_stack)
+    assert np.sum(image_stack.numpy_array) < sum_before


### PR DESCRIPTION
- Removes a slow fixture and replaces it with some synthetic data. 
- Gains ~ 5s on testing time. 