### PR TITLE
Remove some unused items

### DIFF
--- a/starfish/codebook.py
+++ b/starfish/codebook.py
@@ -139,7 +139,7 @@ class Codebook(xr.DataArray):
         Examples
         --------
 
-        >>> from starfish.constants import Indices
+        >>> from starfish.types import Indices
         >>> from starfish.codebook import Codebook
         >>> codebook = [
         >>>     {
@@ -248,7 +248,7 @@ class Codebook(xr.DataArray):
 
         Examples
         --------
-        >>> from starfish.constants import Indices
+        >>> from starfish.types import Indices
         >>> from starfish.codebook import Codebook
         >>> import tempfile
         >>> import json

--- a/starfish/intensity_table.py
+++ b/starfish/intensity_table.py
@@ -53,9 +53,6 @@ class IntensityTable(xr.DataArray):
 
     """
 
-    # constant that stores the attr key for the shape of ImageStack
-    IMAGE_SHAPE = 'image_shape'
-
     @staticmethod
     def _build_xarray_coords(
             spot_attributes: pd.DataFrame, channel_index: np.ndarray, round_index: np.ndarray

--- a/starfish/test/dataset_fixtures.py
+++ b/starfish/test/dataset_fixtures.py
@@ -42,20 +42,6 @@ def merfish_stack() -> Experiment:
     return deepcopy(s)
 
 
-@pytest.fixture(scope='session')
-def labeled_synthetic_dataset():
-    stp = synthesize.SyntheticSpotTileProvider()
-    image = ImageStack.synthetic_stack(tile_data_provider=stp.tile)
-    max_proj = image.max_proj(Indices.ROUND, Indices.CH, Indices.Z)
-    view = max_proj.reshape((1, 1, 1) + max_proj.shape)
-    dots = ImageStack.from_numpy_array(view)
-
-    def labeled_synthetic_dataset_factory():
-        return deepcopy(image), deepcopy(dots), deepcopy(stp.codebook)
-
-    return labeled_synthetic_dataset_factory
-
-
 @pytest.fixture(scope='function')
 def small_intensity_table():
     intensities = np.array([


### PR DESCRIPTION
- Update doctests in codebook that escaped refactoring of constants -> types.
- Remove an `image_shape` attr that escaped expulsion from IntensityTable.
- Remove a fixture that wasn't used.
