### PR TITLE
Add missing @property annotation to tile_data_handle

### DIFF
--- a/starfish/experiment/builder/imagedata.py
+++ b/starfish/experiment/builder/imagedata.py
@@ -51,6 +51,7 @@ class RandomNoiseTile(FetchedTile):
     def format(self) -> ImageFormat:
         return ImageFormat.TIFF
 
+    @property
     def tile_data_handle(self) -> IO:
         arr = np.random.randint(0, 256, size=self.shape, dtype=np.uint8)
         output = BytesIO()


### PR DESCRIPTION
This causes the issue @joshmoore is seeing [here](https://github.com/joshmoore/build-starfish/issues/1#issuecomment-416537231)

Test Plan: ran `starfish build --fov-count 1 --hybridization-dimensions '{"h": 2, "c": 2, "z": 1}' /tmp/2`