### PR TITLE
Add __repr__ strings to ImageStack, Experiment, and FieldOfView

### DIFF
--- a/starfish/experiment/__init__.py
+++ b/starfish/experiment/__init__.py
@@ -67,10 +67,10 @@ class FieldOfView:
     def __repr__(self):
         auxiliary_images = '\n    '.join(f'{k}: {v}' for k, v in self._auxiliary_images.items())
         return (
-                f"<starfish.FieldOfView>\n"
-                f"  Primary Image: {self._primary_image}\n"
-                f"  Auxiliary Images:\n"
-                f"    {auxiliary_images}"
+            f"<starfish.FieldOfView>\n"
+            f"  Primary Image: {self._primary_image}\n"
+            f"  Auxiliary Images:\n"
+            f"    {auxiliary_images}"
         )
 
     @property
@@ -136,21 +136,22 @@ class Experiment:
 
     def __repr__(self):
 
-        # truncate the list of fields of view if it is very long
-        print_nmax = 4
-        if len(self._fovs) > print_nmax:
-            fovs = self._fovs[:print_nmax] + ["...,\n"]
-        else:
-            fovs = self._fovs
+        # truncate the list of fields of view if it is longer than print_n_fov
+        print_n_fov = 4
+        n_fields_of_view = list(self.items())[:print_n_fov]
+        fields_of_view_str = "\n".join(
+            f'{k}: {v}' for k, v in n_fields_of_view
+        )
 
-        # convert fovs to string, careful not to re-convert the ellipsis
-        string_fovs = ",\n".join(repr(f) if not isinstance(f, str) else f for f in fovs)
+        # add an ellipsis if not all fields of view are being printed
+        if len(self._fovs) > print_n_fov:
+            fov_repr = f"{{\n{fields_of_view_str}\n  ...,\n}}"
+        else:
+            fov_repr = f"{{\n{fields_of_view_str}\n}}"
 
         # return the formatted string
-        return (
-            f"<starfish.Experiment (FOVs={len(self._fovs)})>\n"
-            f"FOVs:\n[{string_fovs}]"
-        )
+        object_repr = f"<starfish.Experiment (FOVs={len(self._fovs)})>\n"
+        return object_repr + fov_repr
 
     @classmethod
     def from_json(cls, json_url: str) -> "Experiment":
@@ -255,6 +256,15 @@ class Experiment:
         if len(fovs) == 0:
             raise IndexError(f"No field of view with name \"{item}\"")
         return fovs[0]
+
+    def keys(self):
+        return (fov.name for fov in self.fovs())
+
+    def values(self):
+        return (fov for fov in self.fovs())
+
+    def items(self):
+        return ((fov.name, fov) for fov in self.fovs())
 
     @property
     def codebook(self) -> Codebook:

--- a/starfish/experiment/__init__.py
+++ b/starfish/experiment/__init__.py
@@ -137,13 +137,14 @@ class Experiment:
     def __repr__(self):
 
         # truncate the list of fields of view if it is very long
-        if len(self._fovs) > 4:
-            fovs = self._fovs[:4] + ['...,\n']
+        print_nmax = 4
+        if len(self._fovs) > print_nmax:
+            fovs = self._fovs[:print_nmax] + ["...,\n"]
         else:
             fovs = self._fovs
 
         # convert fovs to string, careful not to re-convert the ellipsis
-        string_fovs = ',\n'.join(repr(f) if not isinstance(f, str) else f for f in fovs)
+        string_fovs = ",\n".join(repr(f) if not isinstance(f, str) else f for f in fovs)
 
         # return the formatted string
         return (

--- a/starfish/experiment/__init__.py
+++ b/starfish/experiment/__init__.py
@@ -64,6 +64,15 @@ class FieldOfView:
         else:
             self._auxiliary_images = dict()
 
+    def __repr__(self):
+        auxiliary_images = '\n    '.join(f'{k}: {v}' for k, v in self._auxiliary_images.items())
+        return (
+                f"<starfish.FieldOfView>\n"
+                f"  Primary Image: {self._primary_image}\n"
+                f"  Auxiliary Images:\n"
+                f"    {auxiliary_images}"
+        )
+
     @property
     def name(self) -> Optional[str]:
         return self._name
@@ -124,6 +133,23 @@ class Experiment:
         self._codebook = codebook
         self._extras = extras
         self._src_doc = src_doc
+
+    def __repr__(self):
+
+        # truncate the list of fields of view if it is very long
+        if len(self._fovs) > 4:
+            fovs = self._fovs[:4] + ['...,\n']
+        else:
+            fovs = self._fovs
+
+        # convert fovs to string, careful not to re-convert the ellipsis
+        string_fovs = ',\n'.join(repr(f) if not isinstance(f, str) else f for f in fovs)
+
+        # return the formatted string
+        return (
+            f"<starfish.Experiment (FOVs={len(self._fovs)})>\n"
+            f"FOVs:\n[{string_fovs}]"
+        )
 
     @classmethod
     def from_json(cls, json_url: str) -> "Experiment":

--- a/starfish/stack.py
+++ b/starfish/stack.py
@@ -163,6 +163,10 @@ class ImageStack:
                 f"data using skimage.img_as_float32 prior to calling set_slice."
             )
 
+    def __repr__(self):
+        shape = ', '.join(f'{k}: {v}' for k, v in self._data.sizes.items())
+        return f"<starfish.ImageStack ({shape})>"
+
     @classmethod
     def from_url(cls, url: str, baseurl: Optional[str]):
         """


### PR DESCRIPTION
Updated API proposal: 

```python
import starfish
```

```python
experiment = starfish.Experiment.from_json('https://dmf0bdeheu4zf.cloudfront.net/browse/formatted/20180912/iss_breast/experiment.json')
```

```python
experiment

    <starfish.Experiment (FOVs=16)>
    {'fov_000': <starfish.FieldOfView>
      Primary Image: <slicedimage._tileset.TileSet object at 0x12f60f0f0>
      Auxiliary Images:
        nuclei: <slicedimage._tileset.TileSet object at 0x12f6899e8>
        dots: <slicedimage._tileset.TileSet object at 0x12f698e80>, 'fov_001': <starfish.FieldOfView>
      Primary Image: <slicedimage._tileset.TileSet object at 0x12f60fd30>
      Auxiliary Images:
        nuclei: <slicedimage._tileset.TileSet object at 0x12f689240>
        dots: <slicedimage._tileset.TileSet object at 0x12f698550>, 'fov_002': <starfish.FieldOfView>
      Primary Image: <slicedimage._tileset.TileSet object at 0x12f607630>
      Auxiliary Images:
        nuclei: <slicedimage._tileset.TileSet object at 0x12f6896d8>
        dots: <slicedimage._tileset.TileSet object at 0x12f698160>, 'fov_003': <starfish.FieldOfView>
      Primary Image: <slicedimage._tileset.TileSet object at 0x12f609550>
      Auxiliary Images:
        nuclei: <slicedimage._tileset.TileSet object at 0x12f689f98>
        dots: <slicedimage._tileset.TileSet object at 0x12f698f60>}
```



```python
experiment.keys()

    <generator object Experiment.keys.<locals>.<genexpr> at 0x12f67e9e8>
```

```python
list(experiment.keys())[:2]

    ['fov_000', 'fov_001']
```

```python
experiment.items()

    <generator object Experiment.items.<locals>.<genexpr> at 0x12f6f2360>
```

```python
list(experiment.items())[:2]

    [('fov_000', <starfish.FieldOfView>
        Primary Image: <slicedimage._tileset.TileSet object at 0x12f60f0f0>
        Auxiliary Images:
          nuclei: <slicedimage._tileset.TileSet object at 0x12f6899e8>
          dots: <slicedimage._tileset.TileSet object at 0x12f698e80>),
     ('fov_001', <starfish.FieldOfView>
        Primary Image: <slicedimage._tileset.TileSet object at 0x12f60fd30>
        Auxiliary Images:
          nuclei: <slicedimage._tileset.TileSet object at 0x12f689240>
          dots: <slicedimage._tileset.TileSet object at 0x12f698550>)]
```

```python
experiment.values()

    <generator object Experiment.values.<locals>.<genexpr> at 0x12f6bee60>
```

```python
list(experiment.values())[:2]

    [<starfish.FieldOfView>
       Primary Image: <slicedimage._tileset.TileSet object at 0x12f60f0f0>
       Auxiliary Images:
         nuclei: <slicedimage._tileset.TileSet object at 0x12f6899e8>
         dots: <slicedimage._tileset.TileSet object at 0x12f698e80>,
     <starfish.FieldOfView>
       Primary Image: <slicedimage._tileset.TileSet object at 0x12f60fd30>
       Auxiliary Images:
         nuclei: <slicedimage._tileset.TileSet object at 0x12f689240>
         dots: <slicedimage._tileset.TileSet object at 0x12f698550>]
```



```python
experiment['fov_001'].primary_image

    100%|_______________| 16/16 [00:00<00:00, 64.30it/s]

    <starfish.ImageStack (r: 4, c: 4, z: 1, y: 1044, x: 1390)>
```

```python
experiment

    <starfish.Experiment (FOVs=16)>
    {
      'fov_000': <starfish.FieldOfView>
      Primary Image: <slicedimage._tileset.TileSet object at 0x12f60f0f0>
      Auxiliary Images:
        nuclei: <slicedimage._tileset.TileSet object at 0x12f6899e8>
        dots: <slicedimage._tileset.TileSet object at 0x12f698e80>, 'fov_001': <starfish.FieldOfView>
      Primary Image: <starfish.ImageStack (r: 4, c: 4, z: 1, y: 1044, x: 1390)>
      Auxiliary Images:
        nuclei: <slicedimage._tileset.TileSet object at 0x12f689240>
        dots: <slicedimage._tileset.TileSet object at 0x12f698550>, 'fov_002': <starfish.FieldOfView>
      Primary Image: <slicedimage._tileset.TileSet object at 0x12f607630>
      Auxiliary Images:
        nuclei: <slicedimage._tileset.TileSet object at 0x12f6896d8>
        dots: <slicedimage._tileset.TileSet object at 0x12f698160>, 'fov_003': <starfish.FieldOfView>
      Primary Image: <slicedimage._tileset.TileSet object at 0x12f609550>
      Auxiliary Images:
        nuclei: <slicedimage._tileset.TileSet object at 0x12f689f98>
        dots: <slicedimage._tileset.TileSet object at 0x12f698f60>
      ...,
    }
```