### PR TITLE
Tweak linting infrastructure

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
 max-line-length=100
-ignore: E301, E302, E305, E401, F401, E731, F811
+ignore: E301, E302, E305, E731, F811
 application-import-names = starfish, examples, validate_sptx
 import-order-style = smarkets

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,13 @@ MODULES=starfish examples validate_sptx
 
 all:	lint mypy test
 
-lint:
-	flake8 $(MODULES)
+lint:   lint-non-init lint-init
+
+lint-non-init:
+	flake8 --ignore 'E301, E302, E305, E401, E731, F811' --exclude='*__init__.py' $(MODULES)
+
+lint-init:
+	flake8 --ignore 'E301, E302, E305, E401, F401, E731, F811' --filename='*__init__.py' $(MODULES)
 
 test:
 	pytest -v -n 8 --cov starfish --cov validate_sptx
@@ -14,3 +19,5 @@ mypy:
 	mypy --ignore-missing-imports $(MODULES)
 
 include notebooks/subdir.mk
+
+.PHONY: all lint lint-non-init lint-init test mypy

--- a/starfish/spots/_target_assignment/_base.py
+++ b/starfish/spots/_target_assignment/_base.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import regional
 
 from starfish.intensity_table import IntensityTable

--- a/starfish/stack.py
+++ b/starfish/stack.py
@@ -24,7 +24,7 @@ from tqdm import tqdm
 
 from starfish.errors import DataFormatWarning
 from starfish.intensity_table import IntensityTable
-from starfish.types import Coordinates, Indices, SpotAttributes
+from starfish.types import Coordinates, Indices
 
 _DimensionMetadata = collections.namedtuple("_DimensionMetadata", ['order', 'required'])
 

--- a/starfish/test/full_pipelines/api/test_dartfish.py
+++ b/starfish/test/full_pipelines/api/test_dartfish.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from starfish import Codebook, Experiment
+from starfish import Experiment
 from starfish.image._filter.scale_by_percentile import ScaleByPercentile
 from starfish.image._filter.zero_by_channel_magnitude import ZeroByChannelMagnitude
 from starfish.spots._detector.pixel_spot_detector import PixelSpotDetector

--- a/starfish/test/full_pipelines/api/test_merfish.py
+++ b/starfish/test/full_pipelines/api/test_merfish.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from starfish import Codebook, Experiment
+from starfish import Experiment
 from starfish.image._filter.gaussian_high_pass import GaussianHighPass
 from starfish.image._filter.gaussian_low_pass import GaussianLowPass
 from starfish.image._filter.richardson_lucy_deconvolution import DeconvolvePSF

--- a/starfish/test/full_pipelines/cli/test_validate.py
+++ b/starfish/test/full_pipelines/cli/test_validate.py
@@ -1,9 +1,3 @@
-import json
-import os
-import shutil
-import subprocess
-import sys
-import tempfile
 import unittest
 
 from starfish.util import exec

--- a/starfish/test/image/test_imagestack.py
+++ b/starfish/test/image/test_imagestack.py
@@ -5,7 +5,7 @@ from starfish.intensity_table import IntensityTable
 from starfish.stack import ImageStack
 # don't inspect pytest fixtures in pycharm
 # noinspection PyUnresolvedReferences
-from starfish.test.dataset_fixtures import (
+from starfish.test.dataset_fixtures import (  # noqa: F401
     codebook_intensities_image_for_single_synthetic_spot,
     loaded_codebook,
     simple_codebook_array,

--- a/starfish/test/pipeline/test_codebook.py
+++ b/starfish/test/pipeline/test_codebook.py
@@ -8,7 +8,7 @@ import pytest
 from starfish.codebook import Codebook
 # don't inspect pytest fixtures in pycharm
 # noinspection PyUnresolvedReferences
-from starfish.test.dataset_fixtures import (
+from starfish.test.dataset_fixtures import (  # noqa: F401
     euclidean_decoded_intensities,
     loaded_codebook,
     per_channel_max_decoded_intensities,

--- a/starfish/test/pipeline/test_intensity_table.py
+++ b/starfish/test/pipeline/test_intensity_table.py
@@ -9,7 +9,7 @@ from starfish.spots._detector.combine_adjacent_features import combine_adjacent_
 from starfish.stack import ImageStack
 # don't inspect pytest fixtures in pycharm
 # noinspection PyUnresolvedReferences
-from starfish.test.dataset_fixtures import (
+from starfish.test.dataset_fixtures import (  # noqa: F401
     loaded_codebook,
     simple_codebook_array,
     simple_codebook_json,

--- a/starfish/test/pipeline/test_spot_detection.py
+++ b/starfish/test/pipeline/test_spot_detection.py
@@ -9,7 +9,7 @@ from starfish.spots._detector.local_max_peak_finder import LocalMaxPeakFinder
 from starfish.stack import ImageStack
 # don't inspect pytest fixtures in pycharm
 # noinspection PyUnresolvedReferences
-from starfish.test.dataset_fixtures import (
+from starfish.test.dataset_fixtures import (  # noqa: F401
     synthetic_dataset_with_truth_values,
     synthetic_dataset_with_truth_values_and_called_spots,
     synthetic_single_spot_2d,

--- a/starfish/util/exec.py
+++ b/starfish/util/exec.py
@@ -1,18 +1,9 @@
-import json
 import os
 import shutil
 import subprocess
-import sys
 import tempfile
-import unittest
 from typing import Callable, Sequence, Union
 
-import jsonpath_rw
-import numpy as np
-import pandas as pd
-
-from starfish.intensity_table import IntensityTable
-from starfish.types import Features
 from starfish.util import clock
 
 

--- a/validate_sptx/cli.py
+++ b/validate_sptx/cli.py
@@ -1,8 +1,5 @@
-import argparse
-import json
 import sys
 
-from starfish.util.argparse import FsExistsType
 from validate_sptx.validate_sptx import validate
 
 

--- a/validate_sptx/test_fuzz.py
+++ b/validate_sptx/test_fuzz.py
@@ -1,5 +1,3 @@
-import os
-
 from pkg_resources import resource_filename
 
 from .util import Fuzzer, SpaceTxValidator


### PR DESCRIPTION
Enable F401 (unused import) _except_ for __init__.py.  There's too much code in __init__.py that pulls stuff in for the benefit of setting up a package, so we don't want that validation.