### PR TITLE
Fix document generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ test:
 mypy:
 	mypy --ignore-missing-imports $(MODULES)
 
+docs-%:
+	make -C docs $*
+
 include notebooks/subdir.mk
 
 .PHONY: all lint lint-non-init lint-init test mypy

--- a/REQUIREMENTS-DEV.txt
+++ b/REQUIREMENTS-DEV.txt
@@ -7,4 +7,5 @@ mypy
 nbencdec >= 0.0.5
 recommonmark
 sphinx
+sphinx_rtd_theme
 -r REQUIREMENTS.txt


### PR DESCRIPTION
1. Add a proxy for Makefile (make docs-XXX will invoke make XXX in the docs subdir).
2. Add `sphinx_rtd_theme` as a requirement, which is necessary for make docs-html to complete.