### PR TITLE
Experiments can only point to Collections.

### DIFF
--- a/examples/get_iss_data.py
+++ b/examples/get_iss_data.py
@@ -83,11 +83,6 @@ def format_data(input_dir, output_dir, d):
     def add_codebook(experiment_json_doc):
         experiment_json_doc['codebook'] = "codebook.json"
 
-        # TODO: (ttung) remove the following unholy hacks.  this is because we want to point at a
-        # tileset rather than a collection.
-        experiment_json_doc['primary_images'] = "hybridization-fov_000.json"
-        experiment_json_doc['auxiliary_images']['nuclei'] = "nuclei-fov_000.json"
-        experiment_json_doc['auxiliary_images']['dots'] = "dots-fov_000.json"
         return experiment_json_doc
 
     # the magic numbers here are just for the ISS example data set.

--- a/starfish/experiment/__init__.py
+++ b/starfish/experiment/__init__.py
@@ -108,9 +108,9 @@ class Experiment:
     codebook      Returns the codebook associated with this experiment.
     extras        Returns the extras dictionary associated with this experiment.
     """
-    CURRENT_VERSION = Version("2.0.0")
-    MIN_SUPPORTED_VERSION = Version("2.0.0")
-    MAX_SUPPORTED_VERSION = Version("2.0.0")
+    CURRENT_VERSION = Version("3.0.0")
+    MIN_SUPPORTED_VERSION = Version("3.0.0")
+    MAX_SUPPORTED_VERSION = Version("3.0.0")
 
     def __init__(
             self,
@@ -153,30 +153,15 @@ class Experiment:
 
         extras = experiment_document['extras']
 
-        primary_image: Union[Collection, TileSet] = Reader.parse_doc(
-            experiment_document['primary_images'], baseurl)
-        auxiliary_images: MutableMapping[str, Union[Collection, TileSet]] = dict()
+        primary_image: Collection = Reader.parse_doc(experiment_document['primary_images'], baseurl)
+        auxiliary_images: MutableMapping[str, Collection] = dict()
         for aux_image_type, aux_image_url in experiment_document['auxiliary_images'].items():
             auxiliary_images[aux_image_type] = Reader.parse_doc(aux_image_url, baseurl)
 
-        if isinstance(primary_image, TileSet):
-            # make sure that all the aux images are also TileSets
-            for aux_image_tileset in auxiliary_images.values():
-                assert isinstance(aux_image_tileset, TileSet)
-
-            fov = FieldOfView(
-                None,
-                primary_image_tileset=primary_image,
-                auxiliary_image_tilesets=auxiliary_images
-            )
-            return Experiment([fov], codebook, extras, src_doc=experiment_document)
-
-        # everything should be Collections
         fovs: MutableSequence[FieldOfView] = list()
         for fov_name, primary_tileset in primary_image.all_tilesets():
             aux_image_tilesets_for_fov: MutableMapping[str, TileSet] = dict()
             for aux_image_type, aux_image_collection in auxiliary_images.items():
-                assert isinstance(aux_image_collection, Collection)
                 aux_image_tileset = aux_image_collection.find_tileset(fov_name)
                 if aux_image_tileset is not None:
                     aux_image_tilesets_for_fov[aux_image_type] = aux_image_tileset

--- a/starfish/test/full_pipelines/api/test_allen_smFISH.py
+++ b/starfish/test/full_pipelines/api/test_allen_smFISH.py
@@ -16,7 +16,7 @@ def test_allen_smFISH_cropped_data():
 
     # load the experiment
     experiment_json = (
-        "https://dmf0bdeheu4zf.cloudfront.net/20180905/allen_smFISH-TEST/experiment.json"
+        "https://dmf0bdeheu4zf.cloudfront.net/20180911/allen_smFISH-TEST/experiment.json"
     )
     experiment = Experiment.from_json(experiment_json)
 

--- a/starfish/test/full_pipelines/api/test_dartfish.py
+++ b/starfish/test/full_pipelines/api/test_dartfish.py
@@ -15,7 +15,7 @@ def test_dartfish_pipeline_cropped_data():
 
     # load the experiment
     experiment_json = (
-        "https://dmf0bdeheu4zf.cloudfront.net/20180905/DARTFISH-TEST/experiment.json"
+        "https://dmf0bdeheu4zf.cloudfront.net/20180911/DARTFISH-TEST/experiment.json"
     )
     experiment = Experiment.from_json(experiment_json)
 

--- a/starfish/test/full_pipelines/api/test_iss_api.py
+++ b/starfish/test/full_pipelines/api/test_iss_api.py
@@ -18,7 +18,7 @@ def test_iss_pipeline_cropped_data():
 
     # load the experiment
     experiment_json = (
-        "https://dmf0bdeheu4zf.cloudfront.net/20180905/ISS-TEST/experiment.json"
+        "https://dmf0bdeheu4zf.cloudfront.net/20180911/ISS-TEST/experiment.json"
     )
     experiment = Experiment.from_json(experiment_json)
     dots = experiment.fov()['dots']

--- a/starfish/test/full_pipelines/api/test_merfish.py
+++ b/starfish/test/full_pipelines/api/test_merfish.py
@@ -16,7 +16,7 @@ def test_merfish_pipeline_cropped_data():
 
     # load the experiment
     experiment_json = (
-        "https://dmf0bdeheu4zf.cloudfront.net/20180905/MERFISH-TEST/experiment.json"
+        "https://dmf0bdeheu4zf.cloudfront.net/20180911/MERFISH-TEST/experiment.json"
     )
     experiment = Experiment.from_json(experiment_json)
     primary_image = experiment.fov().primary_image

--- a/starfish/test/full_pipelines/cli/test_iss.py
+++ b/starfish/test/full_pipelines/cli/test_iss.py
@@ -52,15 +52,27 @@ class TestWithIssData(unittest.TestCase):
         [
             "starfish", "registration",
             "--input", lambda tempdir, *args, **kwargs: get_jsonpath_from_file(
-                [tempdir, "formatted", "experiment.json"],
-                "$['primary_images']",
+                [
+                    tempdir,
+                    get_jsonpath_from_file(
+                        [tempdir, "formatted", "experiment.json"],
+                        "$['primary_images']",
+                    ),
+                ],
+                "$['contents']['fov_000']"
             ),
             "--output", lambda tempdir, *args, **kwargs: os.path.join(
                 tempdir, "registered", "hybridization.json"),
             "FourierShiftRegistration",
             "--reference-stack", lambda tempdir, *args, **kwargs: get_jsonpath_from_file(
-                [tempdir, "formatted", "experiment.json"],
-                "$['auxiliary_images']['dots']",
+                [
+                    tempdir,
+                    get_jsonpath_from_file(
+                        [tempdir, "formatted", "experiment.json"],
+                        "$['auxiliary_images']['dots']",
+                    ),
+                ],
+                "$['contents']['fov_000']"
             ),
             "--upsampling", "1000",
         ],
@@ -80,8 +92,14 @@ class TestWithIssData(unittest.TestCase):
         [
             "starfish", "filter",
             "--input", lambda tempdir, *args, **kwargs: get_jsonpath_from_file(
-                [tempdir, "formatted", "experiment.json"],
-                "$['auxiliary_images']['nuclei']",
+                [
+                    tempdir,
+                    get_jsonpath_from_file(
+                        [tempdir, "formatted", "experiment.json"],
+                        "$['auxiliary_images']['nuclei']",
+                    ),
+                ],
+                "$['contents']['fov_000']"
             ),
             "--output", lambda tempdir, *args, **kwargs: os.path.join(
                 tempdir, "filtered", "nuclei.json"),
@@ -91,8 +109,14 @@ class TestWithIssData(unittest.TestCase):
         [
             "starfish", "filter",
             "--input", lambda tempdir, *args, **kwargs: get_jsonpath_from_file(
-                [tempdir, "formatted", "experiment.json"],
-                "$['auxiliary_images']['dots']",
+                [
+                    tempdir,
+                    get_jsonpath_from_file(
+                        [tempdir, "formatted", "experiment.json"],
+                        "$['auxiliary_images']['dots']",
+                    ),
+                ],
+                "$['contents']['fov_000']"
             ),
             "--output", lambda tempdir, *args, **kwargs: os.path.join(
                 tempdir, "filtered", "dots.json"),


### PR DESCRIPTION
This allows fovs to definitively be addressed by name.