### PR TITLE
Build consistent files for iss breast data set.

### DIFF
--- a/examples/get_iss_breast_data.py
+++ b/examples/get_iss_breast_data.py
@@ -1,9 +1,11 @@
 import argparse
 import io
 import os
+from datetime import datetime
 from typing import IO, Tuple
 
-from skimage.io import imread, imsave
+from skimage.external import tifffile
+from skimage.io import imread
 from slicedimage import ImageFormat
 
 from starfish.experiment.builder import FetchedTile, TileFetcher, write_experiment_json
@@ -34,7 +36,13 @@ class IssCroppedBreastTile(FetchedTile):
     def tile_data_handle(self) -> IO:
         im = self.crop(imread(self.file_path))
         fh = io.BytesIO()
-        imsave(fh, im, plugin='tifffile')
+        with tifffile.TiffWriter(fh) as tifffh:
+            tifffh.save(
+                im,
+                # always write with a fixed timestamp so we don't get different tile files each time
+                # we run this script.
+                datetime=datetime.fromtimestamp(0)
+            )
         fh.seek(0)
         return fh
 


### PR DESCRIPTION
tifffile writes files that include a timestamp.  If that timestamp is not provided, it defaults to the current time.  That means every time we run the script, we get slightly different files.  This is undesirable because:
  1. it makes it hard to upload data sets with file format changes.
  2. it pollutes the disk cache

With this change, we now set the timestamp to unixtime 0.

Test plan: regenerated the ISS breast data set, then ran strings on one of the TIFF files.
```
[tt]:~/microscopy/starfish-formatted-data> strings breast/nuclei-fov_007-Z0-H0-C0.tiff | grep 1969
1969:12:31 16:00:00
```