### PR TITLE
CLI commands should always write to an explicit file

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ starfish filter -i /tmp/starfish/registered/hybridization.json -o /tmp/starfish/
 starfish filter -i /tmp/starfish/formatted/nuclei-fov_000.json -o /tmp/starfish/filtered/nuclei.json WhiteTophat --masking-radius 15
 starfish filter -i /tmp/starfish/formatted/dots-fov_000.json -o /tmp/starfish/filtered/dots.json WhiteTophat --masking-radius 15
 
-starfish detect_spots --input /tmp/starfish/filtered/hybridization.json --output /tmp/starfish/results GaussianSpotDetector --blobs-stack /tmp/starfish/filtered/dots.json --min-sigma 4 --max-sigma 6 --num-sigma 20 --threshold 0.01
+starfish detect_spots --input /tmp/starfish/filtered/hybridization.json --output /tmp/starfish/results/spots.nc GaussianSpotDetector --blobs-stack /tmp/starfish/filtered/dots.json --min-sigma 4 --max-sigma 6 --num-sigma 20 --threshold 0.01
 
 starfish segment --hybridization-stack /tmp/starfish/filtered/hybridization.json --nuclei-stack /tmp/starfish/filtered/nuclei.json -o /tmp/starfish/results/regions.geojson Watershed --dapi-threshold .16 --input-threshold .22 --min-distance 57
 
-starfish target_assignment --coordinates-geojson /tmp/starfish/results/regions.geojson --intensities /tmp/starfish/results/spots.nc --output /tmp/starfish/results/regions.json PointInPoly2D
+starfish target_assignment --coordinates-geojson /tmp/starfish/results/regions.geojson --intensities /tmp/starfish/results/spots.nc --output /tmp/starfish/results/targeted-spots.nc PointInPoly2D
 
-starfish decode -i /tmp/starfish/results/spots.nc --codebook /tmp/starfish/formatted/codebook.json -o /tmp/starfish/results/spots.nc PerRoundMaxChannelDecoder
+starfish decode -i /tmp/starfish/results/targeted-spots.nc --codebook /tmp/starfish/formatted/codebook.json -o /tmp/starfish/results/decoded-spots.nc PerRoundMaxChannelDecoder
 ```
 
 ## interactive visualization in Jupyter notebooks

--- a/starfish/spots/_detector/__init__.py
+++ b/starfish/spots/_detector/__init__.py
@@ -72,4 +72,4 @@ class SpotFinder(PipelineComponent):
             blobs_image=blobs_image,
             reference_image_from_max_projection=args.reference_image_from_max_projection
         )
-        intensities.save(os.path.join(args.output, 'spots.nc'))
+        intensities.save(args.output)

--- a/starfish/test/full_pipelines/cli/test_iss.py
+++ b/starfish/test/full_pipelines/cli/test_iss.py
@@ -127,7 +127,8 @@ class TestWithIssData(unittest.TestCase):
             "starfish", "detect_spots",
             "--input", lambda tempdir, *args, **kwargs: os.path.join(
                 tempdir, "filtered", "hybridization.json"),
-            "--output", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "results"),
+            "--output", lambda tempdir, *args, **kwargs: os.path.join(
+                tempdir, "results", "spots.nc"),
             "GaussianSpotDetector",
             "--blobs-stack", lambda tempdir, *args, **kwargs: os.path.join(
                 tempdir, "filtered", "dots.json"),


### PR DESCRIPTION
They should not be given a directory to write an arbitrary file.  This makes it hard to compose pipelines in the CLI.

Updated README.