### PR TITLE
Allow TileFetchers to provide the coordinates for a tile.

### DIFF
--- a/examples/get_iss_breast_data.py
+++ b/examples/get_iss_breast_data.py
@@ -2,14 +2,14 @@ import argparse
 import io
 import os
 from datetime import datetime
-from typing import IO, Tuple
+from typing import IO, Mapping, Tuple, Union
 
 from skimage.external import tifffile
 from skimage.io import imread
 from slicedimage import ImageFormat
 
 from starfish.experiment.builder import FetchedTile, TileFetcher, write_experiment_json
-from starfish.types import Indices
+from starfish.types import Coordinates, Indices, Number
 from starfish.util.argparse import FsExistsType
 
 SHAPE = 1044, 1390
@@ -22,6 +22,15 @@ class IssCroppedBreastTile(FetchedTile):
     @property
     def shape(self) -> Tuple[int, ...]:
         return SHAPE
+
+    @property
+    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+        # FIXME: (dganguli) please provide proper coordinates here.
+        return {
+            Coordinates.X: (0.0, 0.0001),
+            Coordinates.Y: (0.0, 0.0001),
+            Coordinates.Z: (0.0, 0.0001),
+        }
 
     @property
     def format(self) -> ImageFormat:

--- a/examples/get_iss_data.py
+++ b/examples/get_iss_data.py
@@ -3,14 +3,14 @@ import io
 import json
 import os
 import zipfile
-from typing import IO, Tuple
+from typing import IO, Mapping, Tuple, Union
 
 import requests
 from slicedimage import ImageFormat
 
 from starfish.experiment.builder import FetchedTile, TileFetcher
 from starfish.experiment.builder import write_experiment_json
-from starfish.types import Features, Indices
+from starfish.types import Coordinates, Features, Indices, Number
 from starfish.util.argparse import FsExistsType
 
 SHAPE = 980, 1330
@@ -23,6 +23,15 @@ class ISSTile(FetchedTile):
     @property
     def shape(self) -> Tuple[int, ...]:
         return SHAPE
+
+    @property
+    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+        # FIXME: (dganguli) please provide proper coordinates here.
+        return {
+            Coordinates.X: (0.0, 0.0001),
+            Coordinates.Y: (0.0, 0.0001),
+            Coordinates.Z: (0.0, 0.0001),
+        }
 
     @property
     def format(self) -> ImageFormat:

--- a/examples/get_merfish_u20s_data.py
+++ b/examples/get_merfish_u20s_data.py
@@ -1,13 +1,13 @@
 import argparse
 import io
 import os
-from typing import IO, Tuple
+from typing import IO, Mapping, Tuple, Union
 
 from skimage.io import imread, imsave
 from slicedimage import ImageFormat
 
 from starfish.experiment.builder import FetchedTile, TileFetcher, write_experiment_json
-from starfish.types import Indices
+from starfish.types import Coordinates, Indices, Number
 from starfish.util.argparse import FsExistsType
 
 SHAPE = 2048, 2048
@@ -40,6 +40,15 @@ class MERFISHTile(FetchedTile):
     @property
     def shape(self) -> Tuple[int, ...]:
         return SHAPE
+
+    @property
+    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+        # FIXME: (dganguli) please provide proper coordinates here.
+        return {
+            Coordinates.X: (0.0, 0.0001),
+            Coordinates.Y: (0.0, 0.0001),
+            Coordinates.Z: (0.0, 0.0001),
+        }
 
     @property
     def format(self) -> ImageFormat:

--- a/starfish/experiment/builder/__init__.py
+++ b/starfish/experiment/builder/__init__.py
@@ -89,11 +89,7 @@ def build_image(
                 for ch_ix in range(ch_count):
                     image = image_fetcher.get_tile(fov_ix, hyb_ix, ch_ix, z_ix)
                     tile = Tile(
-                        {
-                            Coordinates.X: (0.0, 0.0001),
-                            Coordinates.Y: (0.0, 0.0001),
-                            Coordinates.Z: (0.0, 0.0001),
-                        },
+                        image.coordinates,
                         {
                             Indices.Z: z_ix,
                             Indices.ROUND: hyb_ix,

--- a/starfish/experiment/builder/defaultproviders.py
+++ b/starfish/experiment/builder/defaultproviders.py
@@ -3,7 +3,7 @@ This module implements default providers of data to the experiment builders.
 """
 
 from io import BytesIO
-from typing import IO, Tuple
+from typing import IO, Mapping, Tuple, Union
 
 import numpy as np
 from skimage.io import imsave
@@ -11,6 +11,7 @@ from slicedimage import (
     ImageFormat,
 )
 
+from starfish.types import Coordinates, Number
 from .providers import FetchedTile, TileFetcher
 
 
@@ -22,6 +23,14 @@ class RandomNoiseTile(FetchedTile):
     @property
     def shape(self) -> Tuple[int, ...]:
         return 1536, 1024
+
+    @property
+    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+        return {
+            Coordinates.X: (0.0, 0.0001),
+            Coordinates.Y: (0.0, 0.0001),
+            Coordinates.Z: (0.0, 0.0001),
+        }
 
     @property
     def format(self) -> ImageFormat:

--- a/starfish/experiment/builder/providers.py
+++ b/starfish/experiment/builder/providers.py
@@ -2,11 +2,13 @@
 This module describes the contracts to provide data to the experiment builder.
 """
 
-from typing import IO, Tuple
+from typing import IO, Mapping, Tuple, Union
 
 from slicedimage import (
     ImageFormat,
 )
+
+from starfish.types import Coordinates, Number
 
 
 class FetchedTile:
@@ -22,6 +24,17 @@ class FetchedTile:
         -------
         Tuple[int, ...]
             The tile shape in (y, x)
+        """
+        raise NotImplementedError()
+
+    @property
+    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+        """Return the tile's coordinates in the global coordinate space..
+
+        Returns
+        -------
+        Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]
+            Maps from a coordinate type (e.g. 'x', 'y', or 'z') to its value or range.
         """
         raise NotImplementedError()
 


### PR DESCRIPTION
There are some TODOs introduced by this PR that @dganguli will probably need to fill in.

Test plan: `python examples/get_iss_breast_data.py /Users/ttung/Downloads/starfish_data/mignardi_breast_1/raw/ ../starfish-formatted-data/breast/` + visual inspection

Depends on #566