### PR TITLE
DOC: link spots modules to docs

### DIFF
--- a/docs/source/API/spots/decoding/decoding.rst
+++ b/docs/source/API/spots/decoding/decoding.rst
@@ -2,3 +2,18 @@
 
 Decoding
 ========
+
+Decoders can be imported using ``starfish.spots.Decoder``, which registers all classes that subclass
+``DecoderAlgorithmBase``:
+
+.. code-block:: python
+
+    from starfish.spots import Decoder
+
+.. contents::
+
+Per Round Max Channel Decoder
+-----------------------------
+
+.. autoclass:: starfish.spots.Decoder.PerRoundMaxChannelDecoder
+    :members:

--- a/docs/source/API/spots/detection/detection.rst
+++ b/docs/source/API/spots/detection/detection.rst
@@ -1,4 +1,31 @@
 .. _detection
 
-Detection
+Detecting
 =========
+
+Spot Detectors can be imported using ``starfish.spots.SpotFinder``, which registers all classes that
+subclass ``SpotFinderAlgorithmBase``:
+
+.. code-block:: python
+
+    from starfish.spots import SpotFinder
+
+.. contents::
+
+Gaussian Spot Detector
+----------------------
+
+.. autoclass:: starfish.spots.SpotFinder.GaussianSpotDetector
+    :members:
+
+Local Max Peak Finder
+---------------------
+
+.. autoclass:: starfish.spots.SpotFinder.LocalMaxPeakFinder
+    :members:
+
+Pixel Spot Detector
+-------------------
+
+.. autoclass:: starfish.spots.SpotFinder.PixelSpotDetector
+    :members:

--- a/docs/source/API/spots/target_assignment/target_assignment.rst
+++ b/docs/source/API/spots/target_assignment/target_assignment.rst
@@ -2,3 +2,18 @@
 
 Target Assignment
 =================
+
+TargetAssignment can be imported using ``starfish.spots.TargetAssignment``, which registers all
+classes that subclass ``TargetAssignmentAlgorithmBase``:
+
+.. code-block:: python
+
+    from starfish.spots import TargetAssignment
+
+.. contents::
+
+Point In Poly 2D
+----------------
+
+.. autoclass:: starfish.spots.TargetAssignment.PointInPoly2D
+    :members:

--- a/starfish/spots/_decoder/__init__.py
+++ b/starfish/spots/_decoder/__init__.py
@@ -49,5 +49,5 @@ class Decoder(PipelineComponent):
         codebook = Codebook.from_json(args.codebook)
 
         # decode and save output
-        intensities = instance.decode(intensities, codebook)
+        intensities = instance.run(intensities, codebook)
         intensities.save(args.output)

--- a/starfish/spots/_decoder/_base.py
+++ b/starfish/spots/_decoder/_base.py
@@ -2,6 +2,6 @@ from starfish.pipeline.algorithmbase import AlgorithmBase
 
 
 class DecoderAlgorithmBase(AlgorithmBase):
-    def decode(self, encoded, codebook):
+    def run(self, encoded, codebook):
         """Performs decoding on the spots found, using the codebook specified."""
         raise NotImplementedError()

--- a/starfish/spots/_decoder/per_round_max_channel_decoder.py
+++ b/starfish/spots/_decoder/per_round_max_channel_decoder.py
@@ -1,7 +1,10 @@
+from starfish.codebook import Codebook
+from starfish.intensity_table import IntensityTable
 from ._base import DecoderAlgorithmBase
 
 
 class PerRoundMaxChannelDecoder(DecoderAlgorithmBase):
+
     def __init__(self, **kwargs):
         pass
 
@@ -9,5 +12,20 @@ class PerRoundMaxChannelDecoder(DecoderAlgorithmBase):
     def add_arguments(cls, group_parser):
         pass
 
-    def decode(self, intensities, codebook):
+    def run(self, intensities: IntensityTable, codebook: Codebook) -> IntensityTable:
+        """Decode spots by selecting the max-valued channel in each sequencing round
+
+        Parameters
+        ----------
+        intensities : IntensityTable
+            IntensityTable to be decoded
+        codebook : Codebook
+            Contains codes to decode IntensityTable
+
+        Returns
+        -------
+        IntensityTable :
+            IntensityTable decoded and appended with Features.TARGET and Features.QUALITY values.
+
+        """
         return codebook.decode_per_round_max(intensities)


### PR DESCRIPTION
- Link up `spots` modules to the docs. 
- Add docstring to `PerRoundMaxChannelDecode`
- Refactor `DecoderAlgorithmBase.decode` to `DecoderAlgorithmBase.run` to match starfish API. 