### PR TITLE
[easy] Move experiment version data to its own package.

### DIFF
--- a/starfish/experiment/builder/__init__.py
+++ b/starfish/experiment/builder/__init__.py
@@ -10,7 +10,7 @@ from slicedimage import (
     Writer,
 )
 
-from starfish.experiment.experiment import Experiment
+from starfish.experiment.version import CURRENT_VERSION
 from starfish.types import Indices
 from .defaultproviders import RandomNoiseTile, RandomNoiseTileFetcher
 from .providers import FetchedTile, TileFetcher
@@ -151,7 +151,7 @@ def write_experiment_json(
         postprocess_func = lambda doc: doc
 
     experiment_doc: Dict[str, Any] = {
-        'version': str(Experiment.CURRENT_VERSION),
+        'version': str(CURRENT_VERSION),
         'auxiliary_images': {},
         'extras': {},
     }

--- a/starfish/experiment/experiment.py
+++ b/starfish/experiment/experiment.py
@@ -8,6 +8,7 @@ from slicedimage.urlpath import pathjoin
 
 from starfish.codebook import Codebook
 from starfish.imagestack.imagestack import ImageStack
+from .version import MAX_SUPPORTED_VERSION, MIN_SUPPORTED_VERSION
 
 
 class FieldOfView:
@@ -117,10 +118,6 @@ class Experiment:
     codebook      Returns the codebook associated with this experiment.
     extras        Returns the extras dictionary associated with this experiment.
     """
-    CURRENT_VERSION = Version("3.0.0")
-    MIN_SUPPORTED_VERSION = Version("3.0.0")
-    MAX_SUPPORTED_VERSION = Version("3.0.0")
-
     def __init__(
             self,
             fovs: Sequence[FieldOfView],
@@ -206,11 +203,11 @@ class Experiment:
     @classmethod
     def verify_version(cls, semantic_version_str: str) -> None:
         version = Version(semantic_version_str)
-        if not (Experiment.MIN_SUPPORTED_VERSION <= version <= Experiment.MAX_SUPPORTED_VERSION):
+        if not (MIN_SUPPORTED_VERSION <= version <= MAX_SUPPORTED_VERSION):
             raise ValueError(
                 f"version {version} not supported.  This version of the starfish library only "
-                f"supports formats from {Experiment.MIN_SUPPORTED_VERSION} to "
-                f"{Experiment.MAX_SUPPORTED_VERSION}")
+                f"supports formats from {MIN_SUPPORTED_VERSION} to "
+                f"{MAX_SUPPORTED_VERSION}")
 
     def fov(
             self,

--- a/starfish/experiment/version.py
+++ b/starfish/experiment/version.py
@@ -1,0 +1,5 @@
+from semantic_version import Version
+
+CURRENT_VERSION = Version("3.0.0")
+MIN_SUPPORTED_VERSION = Version("3.0.0")
+MAX_SUPPORTED_VERSION = Version("3.0.0")

--- a/starfish/test/test_version.py
+++ b/starfish/test/test_version.py
@@ -1,17 +1,18 @@
 import pytest
 
 from starfish.experiment.experiment import Experiment
+from starfish.experiment.version import MAX_SUPPORTED_VERSION, MIN_SUPPORTED_VERSION
 
 
 def test_min_version():
     with pytest.raises(ValueError):
         Experiment.verify_version("0.0.0-dev")
-    Experiment.verify_version(str(Experiment.MIN_SUPPORTED_VERSION))
-    Experiment.verify_version(str(Experiment.MAX_SUPPORTED_VERSION))
+    Experiment.verify_version(str(MIN_SUPPORTED_VERSION))
+    Experiment.verify_version(str(MAX_SUPPORTED_VERSION))
 
 
 def test_max_version():
     with pytest.raises(ValueError):
         Experiment.verify_version("4294967296.0.0")
-    Experiment.verify_version(str(Experiment.MIN_SUPPORTED_VERSION))
-    Experiment.verify_version(str(Experiment.MAX_SUPPORTED_VERSION))
+    Experiment.verify_version(str(MIN_SUPPORTED_VERSION))
+    Experiment.verify_version(str(MAX_SUPPORTED_VERSION))


### PR DESCRIPTION
This can be imported easily.