### PR TITLE
[Easy] add suggested gitignore directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ starfish.egg-info/
 .pytest_cache/
 build/
 dist/
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ starfish.egg-info/
 .pytest_cache/
 build/
 dist/
-.venv
+.venv/


### PR DESCRIPTION
Now that we suggest a specific `venv` install, `gitignore` that by default. 