### PR TITLE
Change python3.6 executable to python

### DIFF
--- a/notebooks/subdir.mk
+++ b/notebooks/subdir.mk
@@ -4,7 +4,7 @@ py_run_targets := $(addprefix run__, $(py_files))
 ipynb_validate_targets := $(addprefix validate__, $(ipynb_files))
 ipynb_regenerate_targets := $(addprefix regenerate__notebooks/, $(addsuffix .ipynb, $(notdir $(basename $(py_files)))))
 py_regenerate_targets := $(addprefix regenerate__notebooks/py/, $(addsuffix .py, $(notdir $(basename $(ipynb_files)))))
-PYTHON := python3.6
+PYTHON := python
 
 all: $(ipynb_validate_targets)
 run_notebooks: $(py_run_targets)


### PR DESCRIPTION
virtualenv only guarantees that python is in your path, not python3.6 (which is provided by _some_ virtualenvs).