### PR TITLE
Fix the function signature for <filter>.run(..)

### DIFF
--- a/starfish/image/_filter/__init__.py
+++ b/starfish/image/_filter/__init__.py
@@ -51,6 +51,6 @@ class Filter(PipelineComponent):
         print('Filtering images ...')
         stack = ImageStack.from_path_or_url(args.input)
         instance = args.filter_algorithm_class(**vars(args))
-        instance.run(stack)
+        instance.run(stack, in_place=True)
 
         stack.write(args.output)

--- a/starfish/image/_filter/_base.py
+++ b/starfish/image/_filter/_base.py
@@ -1,10 +1,8 @@
-from typing import Optional
-
 from starfish.imagestack.imagestack import ImageStack
 from starfish.pipeline.algorithmbase import AlgorithmBase
 
 
 class FilterAlgorithmBase(AlgorithmBase):
-    def run(self, stack: ImageStack) -> Optional[ImageStack]:
+    def run(self, stack: ImageStack) -> ImageStack:
         """Performs filtering on an ImageStack."""
         raise NotImplementedError()

--- a/starfish/image/_filter/bandpass.py
+++ b/starfish/image/_filter/bandpass.py
@@ -83,7 +83,7 @@ class Bandpass(FilterAlgorithmBase):
     def run(
             self, stack: ImageStack, in_place: bool=True, verbose: bool=False,
             n_processes: Optional[int]=None
-    ) -> Optional[ImageStack]:
+    ) -> ImageStack:
         """Perform filtering of an image stack
 
         Parameters
@@ -99,8 +99,9 @@ class Bandpass(FilterAlgorithmBase):
 
         Returns
         -------
-        Optional[ImageStack] :
-            if in-place is False, return the results of filter as a new stack
+        ImageStack :
+            If in-place is False, return the results of filter as a new stack.  Otherwise return the
+            original stack.
 
         """
         bandpass_ = partial(
@@ -111,6 +112,4 @@ class Bandpass(FilterAlgorithmBase):
             bandpass_,
             verbose=verbose, in_place=in_place, is_volume=self.is_volume, n_processes=n_processes
         )
-        if not in_place:
-            return result
-        return None
+        return result

--- a/starfish/image/_filter/clip.py
+++ b/starfish/image/_filter/clip.py
@@ -69,7 +69,7 @@ class Clip(FilterAlgorithmBase):
     def run(
             self, stack: ImageStack, in_place: bool=True, verbose: bool=False,
             n_processes: Optional[int]=None
-    ) -> Optional[ImageStack]:
+    ) -> ImageStack:
         """Perform filtering of an image stack
 
         Parameters
@@ -85,8 +85,9 @@ class Clip(FilterAlgorithmBase):
 
         Returns
         -------
-        Optional[ImageStack] :
-            if in-place is False, return the results of filter as a new stack
+        ImageStack :
+            If in-place is False, return the results of filter as a new stack.  Otherwise return the
+            original stack.
 
         """
         clip = partial(self.clip, p_min=self.p_min, p_max=self.p_max)
@@ -94,6 +95,4 @@ class Clip(FilterAlgorithmBase):
             clip,
             is_volume=self.is_volume, verbose=verbose, in_place=in_place, n_processes=n_processes
         )
-        if not in_place:
-            return result
-        return None
+        return result

--- a/starfish/image/_filter/gaussian_high_pass.py
+++ b/starfish/image/_filter/gaussian_high_pass.py
@@ -69,7 +69,7 @@ class GaussianHighPass(FilterAlgorithmBase):
     def run(
             self, stack: ImageStack, in_place: bool=True, verbose: bool=True,
             n_processes: Optional[int]=None
-    ) -> Optional[ImageStack]:
+    ) -> ImageStack:
         """Perform filtering of an image stack
 
         Parameters
@@ -85,8 +85,9 @@ class GaussianHighPass(FilterAlgorithmBase):
 
         Returns
         -------
-        Optional[ImageStack] :
-            if in-place is False, return the results of filter as a new stack
+        ImageStack :
+            If in-place is False, return the results of filter as a new stack.  Otherwise return the
+            original stack.
 
         """
         high_pass: Callable = partial(self.high_pass, sigma=self.sigma)
@@ -94,6 +95,4 @@ class GaussianHighPass(FilterAlgorithmBase):
             high_pass, is_volume=self.is_volume, verbose=verbose, in_place=in_place,
             n_processes=n_processes
         )
-        if not in_place:
-            return result
-        return None
+        return result

--- a/starfish/image/_filter/gaussian_low_pass.py
+++ b/starfish/image/_filter/gaussian_low_pass.py
@@ -69,7 +69,7 @@ class GaussianLowPass(FilterAlgorithmBase):
     def run(
             self, stack: ImageStack, in_place: bool=True, verbose: bool=False,
             n_processes: Optional[int]=None,
-    ) -> Optional[ImageStack]:
+    ) -> ImageStack:
         """Perform filtering of an image stack
 
         Parameters
@@ -85,8 +85,9 @@ class GaussianLowPass(FilterAlgorithmBase):
 
         Returns
         -------
-        Optional[ImageStack] :
-            if in-place is False, return the results of filter as a new stack
+        ImageStack :
+            If in-place is False, return the results of filter as a new stack.  Otherwise return the
+            original stack.
 
         """
         low_pass: Callable = partial(self.low_pass, sigma=self.sigma)
@@ -94,6 +95,4 @@ class GaussianLowPass(FilterAlgorithmBase):
             low_pass, is_volume=self.is_volume, verbose=verbose, in_place=in_place,
             n_processes=n_processes
         )
-        if not in_place:
-            return result
-        return None
+        return result

--- a/starfish/image/_filter/mean_high_pass.py
+++ b/starfish/image/_filter/mean_high_pass.py
@@ -90,7 +90,7 @@ class MeanHighPass(FilterAlgorithmBase):
     def run(
             self, stack: ImageStack, in_place: bool=True, verbose: bool=False,
             n_processes: Optional[int]=None
-    ) -> Optional[ImageStack]:
+    ) -> ImageStack:
         """Perform filtering of an image stack
 
         Parameters
@@ -106,8 +106,9 @@ class MeanHighPass(FilterAlgorithmBase):
 
         Returns
         -------
-        Optional[ImageStack] :
-            if in_place is False, return the results of filter as a new stack
+        ImageStack :
+            If in-place is False, return the results of filter as a new stack.  Otherwise return the
+            original stack.
 
         """
         high_pass: Callable = partial(self.high_pass, size=self.size)
@@ -115,6 +116,4 @@ class MeanHighPass(FilterAlgorithmBase):
             high_pass,
             is_volume=self.is_volume, verbose=verbose, in_place=in_place, n_processes=n_processes
         )
-        if not in_place:
-            return result
-        return None
+        return result

--- a/starfish/image/_filter/richardson_lucy_deconvolution.py
+++ b/starfish/image/_filter/richardson_lucy_deconvolution.py
@@ -137,7 +137,7 @@ class DeconvolvePSF(FilterAlgorithmBase):
     def run(
             self, stack: ImageStack, in_place: bool=True, verbose=False,
             n_processes: Optional[int]=None
-    ) -> Optional[ImageStack]:
+    ) -> ImageStack:
         """Perform filtering of an image stack
 
         Parameters
@@ -153,8 +153,9 @@ class DeconvolvePSF(FilterAlgorithmBase):
 
         Returns
         -------
-        Optional[ImageStack] :
-            if in-place is False, return the results of filter as a new stack
+        ImageStack :
+            If in-place is False, return the results of filter as a new stack.  Otherwise return the
+            original stack.
 
         """
         func = partial(
@@ -165,6 +166,4 @@ class DeconvolvePSF(FilterAlgorithmBase):
             func,
             in_place=in_place, verbose=verbose, n_processes=n_processes
         )
-        if not in_place:
-            return result
-        return None
+        return result

--- a/starfish/image/_filter/scale_by_percentile.py
+++ b/starfish/image/_filter/scale_by_percentile.py
@@ -63,7 +63,7 @@ class ScaleByPercentile(FilterAlgorithmBase):
     def run(
             self, stack: ImageStack, in_place: bool=True, verbose: bool=False,
             n_processes: Optional[int]=None
-    ) -> Optional[ImageStack]:
+    ) -> ImageStack:
         """Perform filtering of an image stack
 
         Parameters
@@ -79,8 +79,9 @@ class ScaleByPercentile(FilterAlgorithmBase):
 
         Returns
         -------
-        Optional[ImageStack] :
-            if in-place is False, return the results of filter as a new stack
+        ImageStack :
+            If in-place is False, return the results of filter as a new stack.  Otherwise return the
+            original stack.
 
         """
         clip = partial(self.scale, p=self.p)
@@ -88,6 +89,4 @@ class ScaleByPercentile(FilterAlgorithmBase):
             clip,
             is_volume=self.is_volume, verbose=verbose, in_place=in_place, n_processes=n_processes
         )
-        if not in_place:
-            return result
-        return None
+        return result

--- a/starfish/image/_filter/white_tophat.py
+++ b/starfish/image/_filter/white_tophat.py
@@ -50,7 +50,7 @@ class WhiteTophat(FilterAlgorithmBase):
     def run(
             self, stack: ImageStack, in_place: bool=True, verbose: bool=False,
             n_processes: Optional[int]=None
-    ) -> Optional[ImageStack]:
+    ) -> ImageStack:
         """Perform filtering of an image stack
 
         Parameters
@@ -66,14 +66,13 @@ class WhiteTophat(FilterAlgorithmBase):
 
         Returns
         -------
-        Optional[ImageStack] :
-            if in-place is False, return the results of filter as a new stack
+        ImageStack :
+            If in-place is False, return the results of filter as a new stack.  Otherwise return the
+            original stack.
 
         """
         result = stack.apply(
             self.white_tophat,
             is_volume=self.is_volume, verbose=verbose, in_place=in_place, n_processes=n_processes
         )
-        if not in_place:
-            return result
-        return None
+        return result

--- a/starfish/image/_filter/zero_by_channel_magnitude.py
+++ b/starfish/image/_filter/zero_by_channel_magnitude.py
@@ -1,6 +1,5 @@
 import argparse
 from copy import deepcopy
-from typing import Optional
 
 import numpy as np
 from tqdm import tqdm
@@ -36,7 +35,7 @@ class ZeroByChannelMagnitude(FilterAlgorithmBase):
 
     def run(
             self, stack: ImageStack, in_place: bool = True, verbose=False,
-    ) -> Optional[ImageStack]:
+    ) -> ImageStack:
         """Perform filtering of an image stack
 
         Parameters
@@ -50,8 +49,9 @@ class ZeroByChannelMagnitude(FilterAlgorithmBase):
 
         Returns
         -------
-        Optional[ImageStack] :
-            if in-place is False, return the results of filter as a new stack
+        ImageStack :
+            If in-place is False, return the results of filter as a new stack.  Otherwise return the
+            original stack.
 
         """
 


### PR DESCRIPTION
It should always return an ImageStack.  If it's in_place, then it returns the original.  If not, it returns the new ImageStack.

Test plan: `pytest starfish/test/pipeline/test_filter.py`