### PR TITLE
Change tile_data_handle to tile_data

### DIFF
--- a/REQUIREMENTS-DEV.txt
+++ b/REQUIREMENTS-DEV.txt
@@ -80,7 +80,7 @@ semantic-version==2.6.0
 showit==1.1.4
 simplegeneric==0.8.1
 six==1.11.0
-slicedimage==0.0.6
+slicedimage==0.0.7
 snowballstemmer==1.2.1
 Sphinx==1.8.0
 sphinx-rtd-theme==0.4.1

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -36,7 +36,7 @@ seaborn==0.9.0
 semantic-version==2.6.0
 showit==1.1.4
 six==1.11.0
-slicedimage==0.0.6
+slicedimage==0.0.7
 toolz==0.9.0
 tqdm==4.26.0
 trackpy==0.4.1

--- a/REQUIREMENTS.txt.in
+++ b/REQUIREMENTS.txt.in
@@ -12,7 +12,7 @@ scikit-learn
 scipy
 seaborn
 showit >= 1.1.4
-slicedimage == 0.0.6
+slicedimage == 0.0.7
 scikit-learn
 tqdm
 trackpy

--- a/examples/get_iss_breast_data.py
+++ b/examples/get_iss_breast_data.py
@@ -1,10 +1,8 @@
 import argparse
-import io
 import os
-from datetime import datetime
-from typing import IO, Mapping, Tuple, Union
+from typing import Mapping, Tuple, Union
 
-from skimage.external import tifffile
+import numpy as np
 from skimage.io import imread
 from slicedimage import ImageFormat
 
@@ -42,18 +40,8 @@ class IssCroppedBreastTile(FetchedTile):
         return crp
 
     @property
-    def tile_data_handle(self) -> IO:
-        im = self.crop(imread(self.file_path))
-        fh = io.BytesIO()
-        with tifffile.TiffWriter(fh) as tifffh:
-            tifffh.save(
-                im,
-                # always write with a fixed timestamp so we don't get different tile files each time
-                # we run this script.
-                datetime=datetime.fromtimestamp(0)
-            )
-        fh.seek(0)
-        return fh
+    def tile_data(self) -> np.ndarray:
+        return self.crop(imread(self.file_path))
 
 
 class ISSCroppedBreastPrimaryTileFetcher(TileFetcher):

--- a/examples/get_iss_data.py
+++ b/examples/get_iss_data.py
@@ -3,9 +3,11 @@ import io
 import json
 import os
 import zipfile
-from typing import IO, Mapping, Tuple, Union
+from typing import Mapping, Tuple, Union
 
+import numpy as np
 import requests
+from skimage.io import imread
 from slicedimage import ImageFormat
 
 from starfish.experiment.builder import FetchedTile, TileFetcher
@@ -38,8 +40,8 @@ class ISSTile(FetchedTile):
         return ImageFormat.TIFF
 
     @property
-    def tile_data_handle(self) -> IO:
-        return open(self.file_path, "rb")
+    def tile_data(self) -> np.ndarray:
+        return imread(self.file_path)
 
 
 class ISSPrimaryTileFetcher(TileFetcher):

--- a/examples/get_merfish_u20s_data.py
+++ b/examples/get_merfish_u20s_data.py
@@ -1,9 +1,9 @@
 import argparse
-import io
 import os
 from typing import IO, Mapping, Tuple, Union
 
-from skimage.io import imread, imsave
+import numpy as np
+from skimage.io import imread
 from slicedimage import ImageFormat
 
 from starfish.experiment.builder import FetchedTile, TileFetcher, write_experiment_json
@@ -54,13 +54,9 @@ class MERFISHTile(FetchedTile):
     def format(self) -> ImageFormat:
         return ImageFormat.TIFF
 
-    def tile_data_handle(self) -> IO:
+    def tile_data(self) -> IO:
         im = imread(self.file_path)
-        im = im[self.map[(self.hyb, self.ch)], :, :]
-        fh = io.BytesIO()
-        imsave(fh, im, plugin='tifffile')
-        fh.seek(0)
-        return fh
+        return im[self.map[(self.hyb, self.ch)], :, :]
 
 
 class MERFISHAuxTile(FetchedTile):
@@ -76,12 +72,8 @@ class MERFISHAuxTile(FetchedTile):
     def format(self) -> ImageFormat:
         return ImageFormat.TIFF
 
-    def tile_data_handle(self) -> IO:
-        im = imread(self.file_path)[self.dapi_index, :, :]
-        fh = io.BytesIO()
-        imsave(fh, im, plugin='tifffile')
-        fh.seek(0)
-        return fh
+    def tile_data(self) -> np.ndarray:
+        return imread(self.file_path)[self.dapi_index, :, :]
 
 
 class MERFISHTileFetcher(TileFetcher):

--- a/starfish/experiment/builder/__init__.py
+++ b/starfish/experiment/builder/__init__.py
@@ -35,11 +35,6 @@ def _tile_opener(toc_path: str, tile: Tile, file_ext: str) -> BinaryIO:
         "wb")
 
 
-def _tile_writer(tile: Tile, fh: BinaryIO) -> ImageFormat:
-    tile.copy(fh)
-    return ImageFormat.TIFF
-
-
 def _fov_path_generator(parent_toc_path: str, toc_name: str) -> str:
     toc_basename = os.path.splitext(os.path.basename(parent_toc_path))[0]
     return os.path.join(
@@ -98,7 +93,7 @@ def build_image(
                         image.shape,
                         extras=image.extras,
                     )
-                    tile.set_source_fh_contextmanager(image.tile_data_handle, image.format)
+                    tile.numpy_array = image.tile_data
                     fov_images.add_tile(tile)
         collection.add_partition("fov_{:03}".format(fov_ix), fov_images)
     return collection
@@ -169,7 +164,7 @@ def write_experiment_json(
         pretty=True,
         partition_path_generator=_fov_path_generator,
         tile_opener=_tile_opener,
-        tile_writer=_tile_writer,
+        tile_format=ImageFormat.TIFF,
     )
     experiment_doc['primary_images'] = "primary_image.json"
 
@@ -188,7 +183,7 @@ def write_experiment_json(
             pretty=True,
             partition_path_generator=_fov_path_generator,
             tile_opener=_tile_opener,
-            tile_writer=_tile_writer,
+            tile_format=ImageFormat.TIFF,
         )
         experiment_doc['auxiliary_images'][aux_name] = "{}.json".format(aux_name)
 

--- a/starfish/experiment/builder/defaultproviders.py
+++ b/starfish/experiment/builder/defaultproviders.py
@@ -2,11 +2,9 @@
 This module implements default providers of data to the experiment builders.
 """
 
-from io import BytesIO
-from typing import IO, Mapping, Tuple, Union
+from typing import Mapping, Tuple, Union
 
 import numpy as np
-from skimage.io import imsave
 from slicedimage import (
     ImageFormat,
 )
@@ -37,12 +35,8 @@ class RandomNoiseTile(FetchedTile):
         return ImageFormat.TIFF
 
     @property
-    def tile_data_handle(self) -> IO:
-        arr = np.random.randint(0, 256, size=self.shape, dtype=np.uint8)
-        output = BytesIO()
-        imsave(output, arr, plugin="tifffile")
-        output.seek(0)
-        return output
+    def tile_data(self) -> np.ndarray:
+        return np.random.randint(0, 256, size=self.shape, dtype=np.uint8)
 
 
 class RandomNoiseTileFetcher(TileFetcher):

--- a/starfish/experiment/builder/providers.py
+++ b/starfish/experiment/builder/providers.py
@@ -2,8 +2,9 @@
 This module describes the contracts to provide data to the experiment builder.
 """
 
-from typing import IO, Mapping, Tuple, Union
+from typing import Mapping, Tuple, Union
 
+import numpy as np
 from slicedimage import (
     ImageFormat,
 )
@@ -61,13 +62,13 @@ class FetchedTile:
         raise NotImplementedError()
 
     @property
-    def tile_data_handle(self) -> IO:
-        """Return an open file handle containing image data
+    def tile_data(self) -> np.ndarray:
+        """Return the image data representing the tile.
 
         Returns
         -------
-        IO :
-            An open file handle that references image data
+        ndarray :
+            The image data
         """
         raise NotImplementedError()
 


### PR DESCRIPTION
Instead of returning a file handle to the source, we now just get the tile data and use the new file_format argument to `generate_partition_document` introduced in https://github.com/spacetx/slicedimage/pull/64.  This means we don't have to generate the TIFF file and save to an in-memory file in the experiment/image builders.

This was previously opened as #584 but github helpfully closed that for me.

Test plan: test_iss cli test should cover this case.  separately, re-ran the entire test suite.