### PR TITLE
Build docs with python 3.6

### DIFF
--- a/docs/source/API/image/filtering/filtering.rst
+++ b/docs/source/API/image/filtering/filtering.rst
@@ -16,53 +16,53 @@ Filters can be imported using ``starfish.image.Filter``, which registers all cla
 Bandpass
 --------
 
-.. autoclass:: starfish.image.Filter.Bandpass
+.. autoclass:: starfish.image._filter.bandpass.Bandpass
    :members:
 
 Clip
 ----
 
-.. autoclass:: starfish.image.Filter.Clip
+.. autoclass:: starfish.image._filter.clip.Clip
     :members:
 
 Gaussian High Pass
 ------------------
 
-.. autoclass:: starfish.image.Filter.GaussianHighPass
+.. autoclass:: starfish.image._filter.gaussian_high_pass.GaussianHighPass
     :members:
 
 Gaussian Low Pass
 -----------------
 
-.. autoclass:: starfish.image.Filter.GaussianLowPass
+.. autoclass:: starfish.image._filter.gaussian_low_pass.GaussianLowPass
     :members:
 
 Mean High Pass
 --------------
 
-.. autoclass:: starfish.image.Filter.MeanHighPass
+.. autoclass:: starfish.image._filter.mean_high_pass.MeanHighPass
     :members:
 
 Deconvolve PSF
 --------------
 
-.. autoclass:: starfish.image.Filter.DeconvolvePSF
+.. autoclass:: starfish.image._filter.richardson_lucy_deconvolution.DeconvolvePSF
     :members:
 
 Scale By Percentile
 -------------------
 
-.. autoclass:: starfish.image.Filter.ScaleByPercentile
+.. autoclass:: starfish.image._filter.scale_by_percentile.ScaleByPercentile
     :members:
 
 White Top Hat
 -------------
 
-.. autoclass:: starfish.image.Filter.WhiteTophat
+.. autoclass:: starfish.image._filter.white_tophat.WhiteTophat
     :members:
 
 Zero By Channel Magnitude
 -------------------------
 
-.. autoclass:: starfish.image.Filter.ZeroByChannelMagnitude
+.. autoclass:: starfish.image._filter.zero_by_channel_magnitude.ZeroByChannelMagnitude
     :members:

--- a/docs/source/API/image/registration/registration.rst
+++ b/docs/source/API/image/registration/registration.rst
@@ -16,6 +16,6 @@ that subclass ``RegistrationAlgorithmBase``:
 Fourier Shift
 -------------
 
-.. autoclass:: starfish.image.Registration.FourierShiftRegistration
+.. autoclass:: starfish.image._registration.fourier_shift.FourierShiftRegistration
    :members:
 

--- a/docs/source/API/image/segmentation/segmentation.rst
+++ b/docs/source/API/image/segmentation/segmentation.rst
@@ -16,6 +16,6 @@ that subclass ``SegmentationAlgorithmBase``:
 Watershed
 ---------
 
-.. autoclass:: starfish.image.Segmentation.Watershed
+.. autoclass:: starfish.image._segmentation.watershed.Watershed
    :members:
 

--- a/docs/source/API/spots/decoding/decoding.rst
+++ b/docs/source/API/spots/decoding/decoding.rst
@@ -15,5 +15,5 @@ Decoders can be imported using ``starfish.spots.Decoder``, which registers all c
 Per Round Max Channel Decoder
 -----------------------------
 
-.. autoclass:: starfish.spots.Decoder.PerRoundMaxChannelDecoder
+.. autoclass:: starfish.spots._decoder.per_round_max_channel_decoder.PerRoundMaxChannelDecoder
     :members:

--- a/docs/source/API/spots/detection/detection.rst
+++ b/docs/source/API/spots/detection/detection.rst
@@ -15,17 +15,17 @@ subclass ``SpotFinderAlgorithmBase``:
 Gaussian Spot Detector
 ----------------------
 
-.. autoclass:: starfish.spots.SpotFinder.GaussianSpotDetector
+.. autoclass:: starfish.spots._detector.gaussian.GaussianSpotDetector
     :members:
 
 Local Max Peak Finder
 ---------------------
 
-.. autoclass:: starfish.spots.SpotFinder.LocalMaxPeakFinder
+.. autoclass:: starfish.spots._detector.local_max_peak_finder.LocalMaxPeakFinder
     :members:
 
 Pixel Spot Detector
 -------------------
 
-.. autoclass:: starfish.spots.SpotFinder.PixelSpotDetector
+.. autoclass:: starfish.spots._detector.pixel_spot_detector.PixelSpotDetector
     :members:

--- a/docs/source/API/spots/target_assignment/target_assignment.rst
+++ b/docs/source/API/spots/target_assignment/target_assignment.rst
@@ -15,5 +15,5 @@ classes that subclass ``TargetAssignmentAlgorithmBase``:
 Point In Poly 2D
 ----------------
 
-.. autoclass:: starfish.spots.TargetAssignment.PointInPoly2D
+.. autoclass:: starfish.spots._target_assignment.point_in_poly.PointInPoly2D
     :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,6 +17,9 @@ dir_, _ = os.path.split(__file__)
 root_dir = os.path.abspath(os.path.join(dir_, '..', '..'))
 sys.path.insert(0, root_dir)
 
+# needed to build on readthedocs, avoids Tk invocation
+import matplotlib
+matplotlib.use('agg')
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -140,7 +140,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'Starfish.tex', 'Starfish Documentation',
-     'Ambrose J. Carr, Tony Tung, Shannon Axelrod, Brian Long, Jeremy Freeman, Deep Ganguli'),
+     'Ambrose J. Carr, Tony Tung, Shannon Axelrod, Brian Long, Jeremy Freeman, Deep Ganguli', 'manual'),
 ]
 
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,3 +3,6 @@ build:
 
 python:
     version: 3.6
+
+requirements_file: 
+    null

--- a/starfish/readthedocs.yml
+++ b/starfish/readthedocs.yml
@@ -1,0 +1,5 @@
+build:
+    image: latest
+
+python:
+    version: 3.6


### PR DESCRIPTION
per http://blog.readthedocs.com/python-36-support/ , this is how to make our docs build not fail.