### PR TITLE
Update README.rst to reflect position in root directory, not docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Starfish
 Introduction
 ------------
 
-.. image:: /../../design/logo.png
+.. image:: design/logo.png
     :width: 250px
 
 The goal of *starfish* is to **prototype** a reference pipeline for the analysis of image-based
@@ -40,7 +40,7 @@ associated file manifests that this package plans to standardize and implement.
 
 .. _document: https://docs.google.com/document/d/1IHIngoMKr-Tnft2xOI3Q-5rL3GSX2E3PnJrpsOX5ZWs/edit?usp=sharing
 
-.. image:: /../../design/pipeline-diagram.png
+.. image:: design/pipeline-diagram.png
     :alt: pipeline diagram
 
 Documentation


### PR DESCRIPTION
README points at wrong image loctions, breaks splash page docs. 