### PR TITLE
Add README badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 Starfish
 ========
 
+.. docs badge
+
+.. image:: https://readthedocs.org/projects/pip/badge/?version=latest&style=flat
+
 .. ideally we could use the ..include directive here instead of copy and pasting the following
    information
 

--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,11 @@
 Starfish
 ========
 
-.. badges
-
-.. image:: https://readthedocs.org/projects/pip/badge/?version=latest&style=flat
-
 .. image:: https://travis-ci.org/spacetx/starfish.svg?branch=master
     :target: https://travis-ci.org/spacetx/starfish
+    :width: 30%
+.. image:: https://readthedocs.org/projects/pip/badge/?version=latest&style=flat
+    :width: 30%
 
 .. ideally we could use the ..include directive here instead of copy and pasting the following
    information

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,12 @@
 Starfish
 ========
 
-.. docs badge
+.. badges
 
 .. image:: https://readthedocs.org/projects/pip/badge/?version=latest&style=flat
+
+.. image:: https://travis-ci.org/spacetx/starfish.svg?branch=master
+    :target: https://travis-ci.org/spacetx/starfish
 
 .. ideally we could use the ..include directive here instead of copy and pasting the following
    information

--- a/README.rst
+++ b/README.rst
@@ -5,9 +5,10 @@ Starfish
     :target: https://travis-ci.org/spacetx/starfish
     :width: 30%
 .. image:: https://codecov.io/gh/spacetx/starfish/branch/master/graph/badge.svg
-  :target: https://codecov.io/gh/spacetx/starfish
-.. image:: https://readthedocs.org/projects/pip/badge/?version=latest&style=flat
-    :width: 30%
+    :target: https://codecov.io/gh/spacetx/starfish
+.. image:: https://readthedocs.org/projects/spacetx-starfish/badge/?version=latest
+    :target: https://spacetx-starfish.readthedocs.io/en/latest/?badge=latest
+    :alt: Documentation Status
 
 .. ideally we could use the ..include directive here instead of copy and pasting the following
    information

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,8 @@ Starfish
 .. image:: https://travis-ci.org/spacetx/starfish.svg?branch=master
     :target: https://travis-ci.org/spacetx/starfish
     :width: 30%
+.. image:: https://codecov.io/gh/spacetx/starfish/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/spacetx/starfish
 .. image:: https://readthedocs.org/projects/pip/badge/?version=latest&style=flat
     :width: 30%
 


### PR DESCRIPTION
Adds badges for: 
- docs master build
- travis master build
- code coverage

Testing strategy: 
Look at rendered README: https://github.com/spacetx/starfish/blob/ajc-badge-docs/README.rst