### PR TITLE
Introduce tile_fetcher_factory

### DIFF
--- a/starfish/experiment/builder/__init__.py
+++ b/starfish/experiment/builder/__init__.py
@@ -12,7 +12,7 @@ from slicedimage import (
 
 from starfish.experiment.version import CURRENT_VERSION
 from starfish.types import Indices
-from .defaultproviders import RandomNoiseTile, RandomNoiseTileFetcher
+from .defaultproviders import RandomNoiseTile, tile_fetcher_factory
 from .providers import FetchedTile, TileFetcher
 
 
@@ -139,7 +139,7 @@ def write_experiment_json(
         Default shape for the tiles in this experiment.
     """
     if primary_tile_fetcher is None:
-        primary_tile_fetcher = RandomNoiseTileFetcher()
+        primary_tile_fetcher = tile_fetcher_factory(RandomNoiseTile)
     if aux_tile_fetcher is None:
         aux_tile_fetcher = {}
     if postprocess_func is None:
@@ -174,7 +174,7 @@ def write_experiment_json(
         auxiliary_image = build_image(
             fov_count,
             aux_dimensions[Indices.ROUND], aux_dimensions[Indices.CH], aux_dimensions[Indices.Z],
-            aux_tile_fetcher.get(aux_name, RandomNoiseTileFetcher()),
+            aux_tile_fetcher.get(aux_name, tile_fetcher_factory(RandomNoiseTile)),
             default_shape=default_shape,
         )
         Writer.write_to_path(

--- a/starfish/experiment/builder/defaultproviders.py
+++ b/starfish/experiment/builder/defaultproviders.py
@@ -2,7 +2,7 @@
 This module implements default providers of data to the experiment builders.
 """
 
-from typing import Mapping, Tuple, Union
+from typing import Mapping, Tuple, Type, Union
 
 import numpy as np
 from slicedimage import (
@@ -39,10 +39,25 @@ class RandomNoiseTile(FetchedTile):
         return np.random.randint(0, 256, size=self.shape, dtype=np.uint8)
 
 
-class RandomNoiseTileFetcher(TileFetcher):
+def tile_fetcher_factory(
+        fetched_tile_cls: Type[FetchedTile],
+        pass_tile_indices: bool=False,
+        *fetched_tile_constructor_args,
+        **fetched_tile_constructor_kwargs,
+) -> TileFetcher:
     """
-    This is a simple implementation of :class:`.ImageFetcher` that simply returns a
-    :class:`.RandomNoiseImage` for every fov, hyb, ch, z combination.
+    Given a class of that implements :class:`.FetchedTile`, return a TileFetcher that returns an
+    instance of that class.  If `pass_tile_indices` is True, then the TileFetcher is constructed
+    with fov/round/ch/z.  The constructor is always invoked with variable-length arguments from
+    `fetched_tile_constructor_args` and keyword arguments from `fetched_tile_constructor_kwargs`.
     """
-    def get_tile(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
-        return RandomNoiseTile()
+    class ResultingClass(TileFetcher):
+        def get_tile(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
+            args = list()
+            if pass_tile_indices:
+                args.extend([fov, hyb, ch, z])
+            args.extend(fetched_tile_constructor_args)
+
+            return fetched_tile_cls(*args, **fetched_tile_constructor_kwargs)
+
+    return ResultingClass()

--- a/starfish/experiment/builder/providers.py
+++ b/starfish/experiment/builder/providers.py
@@ -16,6 +16,8 @@ class FetchedTile:
     """
     This is the contract for providing the data for constructing a :class:`slicedimage.Tile`.
     """
+    def __init__(self, *args, **kwargs):
+        pass
 
     @property
     def shape(self) -> Tuple[int, ...]:


### PR DESCRIPTION
Most TileFetchers are very simple.  They simply return an instance of a FetchedTile.  Rather than duplicate this code over and over again, we can just create a factory that builds these, based on the most common patterns.

Test plan: `starfish build --fov-count 1 --hybridization-dimensions '{"h": 2, "c": 2, "z": 1}' /tmp/2`