### PR TITLE
Refactor synthetic_stack to use build_image in experiment/builder

### DIFF
--- a/starfish/experiment/builder/defaultproviders.py
+++ b/starfish/experiment/builder/defaultproviders.py
@@ -39,6 +39,36 @@ class RandomNoiseTile(FetchedTile):
         return np.random.randint(0, 256, size=self.shape, dtype=np.uint8)
 
 
+class OnesTile(FetchedTile):
+    """
+    This is a simple implementation of :class:`.FetchedImage` that simply is entirely all pixels at
+    maximum intensity.
+    """
+    def __init__(self, shape: Tuple[int, int]) -> None:
+        super().__init__()
+        self._shape = shape
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        return self._shape
+
+    @property
+    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+        return {
+            Coordinates.X: (0.0, 0.0001),
+            Coordinates.Y: (0.0, 0.0001),
+            Coordinates.Z: (0.0, 0.0001),
+        }
+
+    @property
+    def format(self) -> ImageFormat:
+        return ImageFormat.TIFF
+
+    @property
+    def tile_data(self) -> np.ndarray:
+        return np.full(shape=self.shape, fill_value=1.0, dtype=np.float32)
+
+
 def tile_fetcher_factory(
         fetched_tile_cls: Type[FetchedTile],
         pass_tile_indices: bool=False,

--- a/starfish/test/image/test_imagestack_metadata.py
+++ b/starfish/test/image/test_imagestack_metadata.py
@@ -1,7 +1,6 @@
-from typing import Any
-
 import pytest
 
+from starfish.experiment.builder.defaultproviders import OnesTile, tile_fetcher_factory
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Indices
 
@@ -10,21 +9,32 @@ NUM_CH = 2
 NUM_Z = 12
 
 
+class OnesTilesWithExtras(OnesTile):
+    def __init__(self, extras: dict, *args, **kwargs) -> None:
+        super().__init__((10, 10))
+        self._extras = extras
+
+    @property
+    def extras(self):
+        return self._extras
+
+
 def test_metadata():
     """
     Normal situation where all the tiles have uniform keys for both indices and extras.
     """
-    def tile_extras_provider(round_: int, ch: int, z: int) -> Any:
-        return {
+    tile_fetcher = tile_fetcher_factory(
+        OnesTilesWithExtras,
+        False,
+        {
             'random_key': {
-                Indices.ROUND: round_,
-                Indices.CH: ch,
-                Indices.Z: z,
+                'hello': "world",
             }
         }
+    )
 
     stack = ImageStack.synthetic_stack(
-        num_round=NUM_ROUND, num_ch=NUM_CH, num_z=NUM_Z, tile_extras_provider=tile_extras_provider,
+        num_round=NUM_ROUND, num_ch=NUM_CH, num_z=NUM_Z, tile_fetcher=tile_fetcher,
     )
     table = stack.tile_metadata
     assert len(table) == NUM_ROUND * NUM_CH * NUM_Z
@@ -34,20 +44,30 @@ def test_missing_extras():
     """
     If the extras are not present on some of the tiles, it should still work.
     """
-    def tile_extras_provider(round_: int, ch: int, z: int) -> Any:
-        if round_ == 0:
-            return {
-                'random_key': {
-                    Indices.ROUND: round_,
-                    Indices.CH: ch,
-                    Indices.Z: z,
-                }
+    class OnesTilesWithExtrasMostly(OnesTile):
+        def __init__(self, round, hyb, ch, z, extras: dict) -> None:
+            super().__init__((10, 10))
+            self._round = round
+            self._extras = extras
+
+        @property
+        def extras(self):
+            if self._round == 0:
+                return None
+            return self._extras
+
+    tile_fetcher = tile_fetcher_factory(
+        OnesTilesWithExtrasMostly,
+        True,
+        {
+            'random_key': {
+                'hello': "world",
             }
-        else:
-            return None
+        }
+    )
 
     stack = ImageStack.synthetic_stack(
-        num_round=NUM_ROUND, num_ch=NUM_CH, num_z=NUM_Z, tile_extras_provider=tile_extras_provider,
+        num_round=NUM_ROUND, num_ch=NUM_CH, num_z=NUM_Z, tile_fetcher=tile_fetcher,
     )
     table = stack.tile_metadata
     assert len(table) == NUM_ROUND * NUM_CH * NUM_Z
@@ -57,15 +77,18 @@ def test_conflict():
     """
     Tiles that have extras that conflict with indices should produce an error.
     """
-    def tile_extras_provider(round_: int, ch: int, z: int) -> Any:
-        return {
-            Indices.ROUND: round_,
-            Indices.CH: ch,
-            Indices.Z: z,
+    tile_fetcher = tile_fetcher_factory(
+        OnesTilesWithExtras,
+        False,
+        {
+            Indices.ROUND: {
+                'hello': "world",
+            }
         }
+    )
 
     stack = ImageStack.synthetic_stack(
-        num_round=NUM_ROUND, num_ch=NUM_CH, num_z=NUM_Z, tile_extras_provider=tile_extras_provider,
+        num_round=NUM_ROUND, num_ch=NUM_CH, num_z=NUM_Z, tile_fetcher=tile_fetcher,
     )
     with pytest.raises(ValueError):
         stack.tile_metadata

--- a/starfish/test/image/test_slicedimage_dtype.py
+++ b/starfish/test/image/test_slicedimage_dtype.py
@@ -1,11 +1,15 @@
 import warnings
+from typing import Mapping, Tuple, Union
 
 import numpy as np
 import pytest
 from skimage import img_as_float32
+from slicedimage import ImageFormat
 
 from starfish.errors import DataFormatWarning
+from starfish.experiment.builder import FetchedTile, TileFetcher
 from starfish.imagestack.imagestack import ImageStack
+from starfish.types import Coordinates, Number
 
 NUM_ROUND = 2
 NUM_CH = 2
@@ -14,10 +18,36 @@ HEIGHT = 10
 WIDTH = 10
 
 
-def create_tile_data_provider(dtype: np.number, corner_dtype: np.number):
+class OnesTilesByDtype(FetchedTile):
+    def __init__(self, dtype: np.number) -> None:
+        super().__init__()
+        self._dtype = dtype
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        return HEIGHT, WIDTH
+
+    @property
+    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+        return {
+            Coordinates.X: (0.0, 0.0001),
+            Coordinates.Y: (0.0, 0.0001),
+            Coordinates.Z: (0.0, 0.0001),
+        }
+
+    @property
+    def format(self) -> ImageFormat:
+        return ImageFormat.TIFF
+
+    @property
+    def tile_data(self) -> np.ndarray:
+        return np.ones((HEIGHT, WIDTH), dtype=self._dtype)
+
+
+class CornerDifferentDtype(TileFetcher):
     """
-    Makes a stack that's all of the same type, except the round=0,ch=0,z=0 corner, which is a
-    different type.  All the tiles are initialized with ones.
+    TileFetcher that fetches tiles all of the same type, except the round=0,ch=0,z=0 corner, which
+    is a different type.  All the tiles are initialized with ones.
 
     Parameters
     ----------
@@ -25,18 +55,18 @@ def create_tile_data_provider(dtype: np.number, corner_dtype: np.number):
         The data type of all the tiles except the hyd=0,ch=0,z=0 corner.
     corner_dtype
         The data type of the tile in the hyd=0,ch=0,z=0 corner.
-
-    Returns
-    -------
-    ImageStack :
-        The image stack with the tiles initialized as described.
     """
-    def tile_data_provider(round_: int, ch: int, z: int, height: int, width: int) -> np.ndarray:
+    def __init__(self, dtype: np.number, corner_dtype: np.number) -> None:
+        self._dtype = dtype
+        self._corner_dtype = corner_dtype
+
+    def get_tile(self, fov: int, round_: int, ch: int, z: int) -> FetchedTile:
         if round_ == 0 and ch == 0 and z == 0:
-            return np.ones((height, width), dtype=corner_dtype)
+            dtype = self._corner_dtype
         else:
-            return np.ones((height, width), dtype=dtype)
-    return tile_data_provider
+            dtype = self._dtype
+
+        return OnesTilesByDtype(dtype)
 
 
 def test_multiple_tiles_of_different_kind():
@@ -44,7 +74,7 @@ def test_multiple_tiles_of_different_kind():
         ImageStack.synthetic_stack(
             NUM_ROUND, NUM_CH, NUM_Z,
             HEIGHT, WIDTH,
-            tile_data_provider=create_tile_data_provider(np.uint32, np.float32),
+            tile_fetcher=CornerDifferentDtype(np.uint32, np.float32),
         )
 
 
@@ -52,7 +82,7 @@ def test_multiple_tiles_of_same_dtype():
     stack = ImageStack.synthetic_stack(
         NUM_ROUND, NUM_CH, NUM_Z,
         HEIGHT, WIDTH,
-        tile_data_provider=create_tile_data_provider(np.uint32, np.uint32),
+        tile_fetcher=CornerDifferentDtype(np.uint32, np.uint32),
     )
     expected = np.ones(
         (NUM_ROUND,
@@ -68,7 +98,7 @@ def test_int_type_promotion():
         stack = ImageStack.synthetic_stack(
             NUM_ROUND, NUM_CH, NUM_Z,
             HEIGHT, WIDTH,
-            tile_data_provider=create_tile_data_provider(np.int32, np.int8),
+            tile_fetcher=CornerDifferentDtype(np.int32, np.int8),
         )
         assert len(warnings_) == 2
         assert issubclass(warnings_[0].category, DataFormatWarning)
@@ -91,7 +121,7 @@ def test_uint_type_promotion():
         stack = ImageStack.synthetic_stack(
             NUM_ROUND, NUM_CH, NUM_Z,
             HEIGHT, WIDTH,
-            tile_data_provider=create_tile_data_provider(np.uint32, np.uint8),
+            tile_fetcher=CornerDifferentDtype(np.uint32, np.uint8),
         )
         assert len(warnings_) == 2
         assert issubclass(warnings_[0].category, DataFormatWarning)
@@ -114,7 +144,7 @@ def test_float_type_demotion():
         stack = ImageStack.synthetic_stack(
             NUM_ROUND, NUM_CH, NUM_Z,
             HEIGHT, WIDTH,
-            tile_data_provider=create_tile_data_provider(np.float64, np.float32),
+            tile_fetcher=CornerDifferentDtype(np.float64, np.float32),
         )
         assert len(warnings_) == 2
         assert issubclass(warnings_[0].category, DataFormatWarning)


### PR DESCRIPTION
This allows us to unify all the stack creation code paths.

Test plan: make -j all run_notebooks

Depends on #610 