### PR TITLE
Point notebooks at data sets without the 'fov' fields in TileSets.

### DIFF
--- a/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
+++ b/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
@@ -50,7 +50,7 @@
     "if test:\n",
     "    experiment = Experiment.from_json('https://dmf0bdeheu4zf.cloudfront.net/20180919/MERFISH-TEST/experiment.json')\n",
     "else:\n",
-    "    experiment = Experiment.from_json('https://dmf0bdeheu4zf.cloudfront.net/20180919/MERFISH/experiment.json')"
+    "    experiment = Experiment.from_json('https://dmf0bdeheu4zf.cloudfront.net/20180924/MERFISH/experiment.json')"
    ]
   },
   {

--- a/notebooks/allen_smFISH.ipynb
+++ b/notebooks/allen_smFISH.ipynb
@@ -47,7 +47,7 @@
     "if test:\n",
     "    experiment_json = 'https://dmf0bdeheu4zf.cloudfront.net/20180919/allen_smFISH-TESE/experiment.json'\n",
     "else:\n",
-    "    experiment_json = 'https://dmf0bdeheu4zf.cloudfront.net/20180919/allen_smFISH/experiment.json'"
+    "    experiment_json = 'https://dmf0bdeheu4zf.cloudfront.net/20180924/allen_smFISH/experiment.json'"
    ]
   },
   {

--- a/notebooks/osmFISH.ipynb
+++ b/notebooks/osmFISH.ipynb
@@ -35,7 +35,7 @@
     "if test:\n",
     "    experiment = Experiment.from_json('https://dmf0bdeheu4zf.cloudfront.net/20180919/osmFISH-TEST/experiment.json')\n",
     "else:\n",
-    "    experiment = Experiment.from_json('https://dmf0bdeheu4zf.cloudfront.net/20180919/osmFISH/experiment.json')"
+    "    experiment = Experiment.from_json('https://dmf0bdeheu4zf.cloudfront.net/20180924/osmFISH/experiment.json')"
    ]
   },
   {

--- a/notebooks/py/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
+++ b/notebooks/py/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
@@ -35,7 +35,7 @@ test = os.getenv("USE_TEST_DATA") is not None
 if test:
     experiment = Experiment.from_json('https://dmf0bdeheu4zf.cloudfront.net/20180919/MERFISH-TEST/experiment.json')
 else:
-    experiment = Experiment.from_json('https://dmf0bdeheu4zf.cloudfront.net/20180919/MERFISH/experiment.json')
+    experiment = Experiment.from_json('https://dmf0bdeheu4zf.cloudfront.net/20180924/MERFISH/experiment.json')
 # EPY: END code
 
 # EPY: START markdown

--- a/notebooks/py/allen_smFISH.py
+++ b/notebooks/py/allen_smFISH.py
@@ -32,7 +32,7 @@ test = os.getenv("USE_TEST_DATA") is not None
 if test:
     experiment_json = 'https://dmf0bdeheu4zf.cloudfront.net/20180919/allen_smFISH-TESE/experiment.json'
 else:
-    experiment_json = 'https://dmf0bdeheu4zf.cloudfront.net/20180919/allen_smFISH/experiment.json'
+    experiment_json = 'https://dmf0bdeheu4zf.cloudfront.net/20180924/allen_smFISH/experiment.json'
 # EPY: END code
 
 # EPY: START markdown

--- a/notebooks/py/assay_comparison.py
+++ b/notebooks/py/assay_comparison.py
@@ -96,7 +96,7 @@ iss_dots = experiment.fov()['dots'].max_proj(Indices.CH, Indices.ROUND, Indices.
 
 # EPY: START code
 stack = Experiment.from_json(
-    'https://dmf0bdeheu4zf.cloudfront.net/20180919/MERFISH/experiment.json'
+    'https://dmf0bdeheu4zf.cloudfront.net/20180924/MERFISH/experiment.json'
 )
 merfish_nuclei = experiment.fov()['nuclei'].max_proj(Indices.CH, Indices.ROUND, Indices.Z)
 

--- a/notebooks/py/osmFISH.py
+++ b/notebooks/py/osmFISH.py
@@ -22,7 +22,7 @@ test = os.getenv("USE_TEST_DATA") is not None
 if test:
     experiment = Experiment.from_json('https://dmf0bdeheu4zf.cloudfront.net/20180919/osmFISH-TEST/experiment.json')
 else:
-    experiment = Experiment.from_json('https://dmf0bdeheu4zf.cloudfront.net/20180919/osmFISH/experiment.json')
+    experiment = Experiment.from_json('https://dmf0bdeheu4zf.cloudfront.net/20180924/osmFISH/experiment.json')
 # EPY: END code
 
 # EPY: START markdown


### PR DESCRIPTION
The fov field was removed in https://github.com/spacetx/sptx-format/pull/24, but some of the data sets still have it.

Test plan: make -j run_notebooks