### PR TITLE
Fix image type Filter docstrings

### DIFF
--- a/starfish/image/_filter/gaussian_high_pass.py
+++ b/starfish/image/_filter/gaussian_high_pass.py
@@ -48,7 +48,7 @@ class GaussianHighPass(FilterAlgorithmBase):
 
         Parameters
         ----------
-        image : numpy.ndarray[np.uint16]
+        image : numpy.ndarray[np.float32]
             2-d or 3-d image data
         sigma : Union[Number, Tuple[Number]]
             Standard deviation of gaussian kernel

--- a/starfish/image/_filter/gaussian_low_pass.py
+++ b/starfish/image/_filter/gaussian_low_pass.py
@@ -44,7 +44,7 @@ class GaussianLowPass(FilterAlgorithmBase):
 
         Parameters
         ----------
-        image : np.ndarray[np.uint16]
+        image : np.ndarray[np.float32]
             2-d or 3-d image data
         sigma : Union[Number, Tuple[Number]]
             Standard deviation of the Gaussian kernel that will be applied. If a float, an


### PR DESCRIPTION
Some of the Filter classes have unclear or potentially wrong types in the docstring for the input image in the filtering method (e.g., high_pass() in GaussianHighPass). I changed the GHP and GLP filters to np.float32 based on my current understanding of the pipeline and the preserve_float_range() calls.

In going through the filters, I noticed that some (e.g., Clip) still have code to support int. Should filters still support int even though the pipeline internal standard is float? I can make a separate issue if this requires discussion.