### PR TITLE
Save the coordinates from the tiles to an xarray during ImageStack construction

### DIFF
--- a/REQUIREMENTS-DEV.txt
+++ b/REQUIREMENTS-DEV.txt
@@ -82,7 +82,7 @@ semantic-version==2.6.0
 showit==1.1.4
 simplegeneric==0.8.1
 six==1.11.0
-slicedimage==0.0.7
+slicedimage==0.1.0
 snowballstemmer==1.2.1
 Sphinx==1.8.0
 sphinx-rtd-theme==0.4.1

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -36,7 +36,7 @@ seaborn==0.9.0
 semantic-version==2.6.0
 showit==1.1.4
 six==1.11.0
-slicedimage==0.0.7
+slicedimage==0.1.0
 toolz==0.9.0
 tqdm==4.26.0
 trackpy==0.4.1

--- a/REQUIREMENTS.txt.in
+++ b/REQUIREMENTS.txt.in
@@ -12,7 +12,7 @@ scikit-learn
 scipy
 seaborn
 showit >= 1.1.4
-slicedimage == 0.0.7
+slicedimage == 0.1.0
 scikit-learn
 tqdm
 trackpy

--- a/starfish/data/__init__.py
+++ b/starfish/data/__init__.py
@@ -11,7 +11,7 @@ def MERFISH(use_test_data: bool=False):
 
 def allen_smFISH(use_test_data: bool=False):
     return Experiment.from_json(
-        'https://dmf0bdeheu4zf.cloudfront.net/20180919/allen_smFISH/experiment.json')
+        'https://dmf0bdeheu4zf.cloudfront.net/20180924/allen_smFISH/experiment.json')
 
 
 def DARTFISH(use_test_data: bool=False):

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -27,7 +27,12 @@ from starfish.errors import DataFormatWarning
 from starfish.experiment.builder import build_image, TileFetcher
 from starfish.experiment.builder.defaultproviders import OnesTile, tile_fetcher_factory
 from starfish.intensity_table import IntensityTable
-from starfish.types import Coordinates, Indices
+from starfish.types import (
+    Coordinates,
+    Indices,
+    PHYSICAL_COORDINATE_DIMENSION,
+    PhysicalCoordinateTypes,
+)
 
 _DimensionMetadata = collections.namedtuple("_DimensionMetadata", ['order', 'required'])
 
@@ -100,6 +105,8 @@ class ImageStack:
 
         shape: MutableSequence[int] = []
         dims: MutableSequence[str] = []
+        coordinates_shape: MutableSequence[int] = []
+        coordinates_dimensions: MutableSequence[str] = []
         for ix in range(ImageStack.N_AXES):
             size_for_axis: Optional[int] = None
             dim_for_axis: Optional[Indices] = None
@@ -108,6 +115,7 @@ class ImageStack:
                 if ix == axis_data.order:
                     size_for_axis = self._get_dimension_size(axis_name)
                     dim_for_axis = axis_name
+                    break
 
             if size_for_axis is None or dim_for_axis is None:
                 raise ValueError(
@@ -115,10 +123,13 @@ class ImageStack:
 
             shape.append(size_for_axis)
             dims.append(dim_for_axis.value)
+            coordinates_shape.append(size_for_axis)
+            coordinates_dimensions.append(dim_for_axis.value)
 
         shape.extend(self._tile_shape)
         dims.extend([Indices.Y.value, Indices.X.value])
-
+        coordinates_dimensions.append(PHYSICAL_COORDINATE_DIMENSION)
+        coordinates_shape.append(6)
         # now that we know the tile data type (kind and size), we can allocate the data array.
         self._data = xr.DataArray(
             np.zeros(
@@ -126,6 +137,23 @@ class ImageStack:
                 dtype=np.float32,
             ),
             dims=dims,
+        )
+        self._coordinates = xr.DataArray(
+            np.empty(
+                shape=coordinates_shape,
+                dtype=np.float32,
+            ),
+            dims=coordinates_dimensions,
+            coords={
+                PHYSICAL_COORDINATE_DIMENSION: [
+                    PhysicalCoordinateTypes.X_MIN.value,
+                    PhysicalCoordinateTypes.X_MAX.value,
+                    PhysicalCoordinateTypes.Y_MIN.value,
+                    PhysicalCoordinateTypes.Y_MAX.value,
+                    PhysicalCoordinateTypes.Z_MIN.value,
+                    PhysicalCoordinateTypes.Z_MAX.value,
+                ],
+            },
         )
 
         # iterate through the tiles and set the data.
@@ -146,6 +174,23 @@ class ImageStack:
 
             data = img_as_float32(data)
             self.set_slice(indices={Indices.ROUND: h, Indices.CH: c, Indices.Z: zlayer}, data=data)
+            coordinate_selector = {
+                Indices.ROUND.value: h,
+                Indices.CH.value: c,
+                Indices.Z.value: zlayer,
+            }
+            coordinates_values = [
+                tile.coordinates[Coordinates.X][0], tile.coordinates[Coordinates.X][1],
+                tile.coordinates[Coordinates.Y][0], tile.coordinates[Coordinates.Y][1],
+            ]
+            if Coordinates.Z in tile.coordinates:
+                coordinates_values.extend([
+                    tile.coordinates[Coordinates.Z][0], tile.coordinates[Coordinates.Z][1],
+                ])
+            else:
+                coordinates_values.extend([np.nan, np.nan])
+
+            self._coordinates.loc[coordinate_selector] = np.array(coordinates_values)
 
     @staticmethod
     def _validate_data_dtype_and_range(data: Union[np.ndarray, xr.DataArray]) -> None:
@@ -773,6 +818,34 @@ class ImageStack:
         result['x'] = self._data.shape[-1]
 
         return result
+
+    def coordinates(
+            self,
+            indices: Mapping[Indices, int],
+            physical_axis: Coordinates) -> Tuple[float, float]:
+        """Given a set of indices that uniquely identify a tile and a physical axis, return the min
+        and the max coordinates for that tile along that axis."""
+        selectors: Mapping[str, Any] = {
+            Indices.ROUND.value: indices[Indices.ROUND],
+            Indices.CH.value: indices[Indices.CH],
+            Indices.Z.value: indices[Indices.Z],
+        }
+        min_selectors = dict(selectors)
+        max_selectors = dict(selectors)
+        if physical_axis == Coordinates.X:
+            min_selectors[PHYSICAL_COORDINATE_DIMENSION] = PhysicalCoordinateTypes.X_MIN
+            max_selectors[PHYSICAL_COORDINATE_DIMENSION] = PhysicalCoordinateTypes.X_MAX
+        elif physical_axis == Coordinates.Y:
+            min_selectors[PHYSICAL_COORDINATE_DIMENSION] = PhysicalCoordinateTypes.Y_MIN
+            max_selectors[PHYSICAL_COORDINATE_DIMENSION] = PhysicalCoordinateTypes.Y_MAX
+        elif physical_axis == Coordinates.Z:
+            min_selectors[PHYSICAL_COORDINATE_DIMENSION] = PhysicalCoordinateTypes.Z_MIN
+            max_selectors[PHYSICAL_COORDINATE_DIMENSION] = PhysicalCoordinateTypes.Z_MAX
+
+        return (
+            self._coordinates.loc[min_selectors].item(),
+            self._coordinates.loc[max_selectors].item(),
+        )
 
     def _get_dimension_size(self, dimension: Indices):
         axis_data = ImageStack.AXES_DATA[dimension]

--- a/starfish/test/full_pipelines/cli/test_merfish_cli.py
+++ b/starfish/test/full_pipelines/cli/test_merfish_cli.py
@@ -24,7 +24,7 @@ class TestWithMerfishData(CLITest, unittest.TestCase):
             [
                 sys.executable,
                 "examples/get_cli_test_data.py",
-                "https://dmf0bdeheu4zf.cloudfront.net/20180828/MERFISH-TEST/experiment.json",
+                "https://dmf0bdeheu4zf.cloudfront.net/20180926/MERFISH-TEST/experiment.json",
                 lambda tempdir, *args, **kwargs: os.path.join(tempdir, "registered")
             ],
             [

--- a/starfish/test/image/test_imagestack_coordinates.py
+++ b/starfish/test/image/test_imagestack_coordinates.py
@@ -1,0 +1,157 @@
+from typing import Mapping, Tuple, Union
+
+import numpy as np
+from slicedimage import ImageFormat
+
+from starfish.experiment.builder import FetchedTile, tile_fetcher_factory
+from starfish.imagestack.imagestack import ImageStack
+from starfish.types import Coordinates, Indices, Number
+
+NUM_ROUND = 8
+NUM_CH = 1
+NUM_Z = 1
+HEIGHT = 10
+WIDTH = 10
+
+
+def round_to_x(r: int) -> Tuple[float, float]:
+    return (r + 1) * 1000, (r + 1) * 100
+
+
+def round_to_y(r: int) -> Tuple[float, float]:
+    return (r + 1) * 10, (r + 1) * 0.1
+
+
+def round_to_z(r: int) -> Tuple[float, float]:
+    return (r + 1) * 0.01, (r + 1) * 0.001
+
+
+class OffsettedTiles(FetchedTile):
+    """Tiles that are physically offset based on round."""
+    def __init__(self, fov: int, _round: int, ch: int, z: int) -> None:
+        super().__init__()
+        self._round = _round
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        return HEIGHT, WIDTH
+
+    @property
+    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+        return {
+            Coordinates.X: round_to_x(self._round),
+            Coordinates.Y: round_to_y(self._round),
+            Coordinates.Z: round_to_z(self._round),
+        }
+
+    @property
+    def format(self) -> ImageFormat:
+        return ImageFormat.TIFF
+
+    @property
+    def tile_data(self) -> np.ndarray:
+        return np.ones((HEIGHT, WIDTH), dtype=np.float32)
+
+
+def test_coordinates():
+    """Set up an ImageStack with tiles that are offset based on round.  Verify that the coordinates
+    retrieved match.
+    """
+    stack = ImageStack.synthetic_stack(
+        NUM_ROUND, NUM_CH, NUM_Z,
+        HEIGHT, WIDTH,
+        tile_fetcher=tile_fetcher_factory(
+            OffsettedTiles,
+            True,
+        )
+    )
+
+    for _round in range(NUM_ROUND):
+        for ch in range(NUM_CH):
+            for z in range(NUM_Z):
+                indices = {
+                    Indices.ROUND: _round,
+                    Indices.CH: ch,
+                    Indices.Z: z
+                }
+
+                xmin, xmax = stack.coordinates(indices, Coordinates.X)
+                ymin, ymax = stack.coordinates(indices, Coordinates.Y)
+                zmin, zmax = stack.coordinates(indices, Coordinates.Z)
+
+                expected_xmin, expected_xmax = round_to_x(_round)
+                expected_ymin, expected_ymax = round_to_y(_round)
+                expected_zmin, expected_zmax = round_to_z(_round)
+
+                assert np.isclose(xmin, expected_xmin)
+                assert np.isclose(xmax, expected_xmax)
+                assert np.isclose(ymin, expected_ymin)
+                assert np.isclose(ymax, expected_ymax)
+                assert np.isclose(zmin, expected_zmin)
+                assert np.isclose(zmax, expected_zmax)
+
+
+class OffsettedScalarTiles(FetchedTile):
+    """Tiles that are physically offset based on round, but only have a single scalar coordinate."""
+    def __init__(self, fov: int, _round: int, ch: int, z: int) -> None:
+        super().__init__()
+        self._round = _round
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        return HEIGHT, WIDTH
+
+    @property
+    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+        return {
+            Coordinates.X: round_to_x(self._round)[0],
+            Coordinates.Y: round_to_y(self._round)[0],
+            Coordinates.Z: round_to_z(self._round)[0],
+        }
+
+    @property
+    def format(self) -> ImageFormat:
+        return ImageFormat.TIFF
+
+    @property
+    def tile_data(self) -> np.ndarray:
+        return np.ones((HEIGHT, WIDTH), dtype=np.float32)
+
+
+def test_scalar_coordinates():
+    """Set up an ImageStack where only a single scalar physical coordinate is provided per axis.
+    Internally, this should be converted to a range where the two endpoints are identical to the
+    physical coordinate provided.
+    """
+    stack = ImageStack.synthetic_stack(
+        NUM_ROUND, NUM_CH, NUM_Z,
+        HEIGHT, WIDTH,
+        tile_fetcher=tile_fetcher_factory(
+            OffsettedScalarTiles,
+            True,
+        )
+    )
+
+    for _round in range(NUM_ROUND):
+        for ch in range(NUM_CH):
+            for z in range(NUM_Z):
+                indices = {
+                    Indices.ROUND: _round,
+                    Indices.CH: ch,
+                    Indices.Z: z
+                }
+
+                xmin, xmax = stack.coordinates(indices, Coordinates.X)
+                ymin, ymax = stack.coordinates(indices, Coordinates.Y)
+                zmin, zmax = stack.coordinates(indices, Coordinates.Z)
+
+                expected_x = round_to_x(_round)[0]
+                expected_y = round_to_y(_round)[0]
+                expected_z = round_to_z(_round)[0]
+
+                assert np.isclose(xmin, expected_x)
+                assert np.isclose(xmax, expected_x)
+                assert np.isclose(ymin, expected_y)
+                assert np.isclose(ymax, expected_y)
+                assert np.isclose(zmin, expected_z)
+                assert np.isclose(zmax, expected_z)

--- a/starfish/types/__init__.py
+++ b/starfish/types/__init__.py
@@ -1,6 +1,12 @@
 from typing import Union
 
-from ._constants import Coordinates, Features, Indices
+from ._constants import (
+    Coordinates,
+    Features,
+    Indices,
+    PHYSICAL_COORDINATE_DIMENSION,
+    PhysicalCoordinateTypes,
+)
 from ._spot_attributes import SpotAttributes
 
 Number = Union[int, float]

--- a/starfish/types/_constants.py
+++ b/starfish/types/_constants.py
@@ -20,6 +20,24 @@ class Coordinates(AugmentedEnum):
     X = 'xc'
 
 
+PHYSICAL_COORDINATE_DIMENSION = "physical_coordinate"
+"""
+This is the xarray dimension name for the physical coordinates of the tiles.
+"""
+
+
+class PhysicalCoordinateTypes(AugmentedEnum):
+    """
+    These are more accurately the xarray coordinates for the physical coordinates of a tile.
+    """
+    Z_MAX = 'zmax'
+    Z_MIN = 'zmin'
+    Y_MAX = 'ymax'
+    Y_MIN = 'ymin'
+    X_MAX = 'xmax'
+    X_MIN = 'xmin'
+
+
 class Indices(AugmentedEnum):
     ROUND = 'r'
     CH = 'c'


### PR DESCRIPTION
Test plan: Added a test to verify that the coordinates are saved and retrieved correctly.

Note that this will not pass tests until a new slicedimage package is released.

Depends on #610, #586, spacetx/slicedimage#66

Fixes #560 
