### PR TITLE
Remove duplication of the --blobs-stack argparse parameter

### DIFF
--- a/docs/source/usage/iss/iss_cli.sh
+++ b/docs/source/usage/iss/iss_cli.sh
@@ -34,8 +34,8 @@ starfish filter \
 starfish detect_spots \
     --input /tmp/starfish/filtered/primary_image.json \
     --output /tmp/starfish/results/spots.nc \
-    GaussianSpotDetector \
     --blobs-stack /tmp/starfish/filtered/dots.json \
+    GaussianSpotDetector \
     --min-sigma 4 \
     --max-sigma 6 \
     --num-sigma 20 \

--- a/starfish/spots/_detector/gaussian.py
+++ b/starfish/spots/_detector/gaussian.py
@@ -8,7 +8,6 @@ from skimage.feature import blob_log
 from starfish.imagestack.imagestack import ImageStack
 from starfish.intensity_table import IntensityTable
 from starfish.types import Features, Indices, Number, SpotAttributes
-from starfish.util.argparse import FsExistsType
 from ._base import SpotFinderAlgorithmBase
 from .detect import detect_spots, measure_spot_intensity
 
@@ -149,7 +148,6 @@ class GaussianSpotDetector(SpotFinderAlgorithmBase):
 
     @classmethod
     def add_arguments(cls, group_parser):
-        group_parser.add_argument("--blobs-stack", type=FsExistsType(), required=True)
         group_parser.add_argument(
             "--min-sigma", default=4, type=int, help="Minimum spot size (in standard deviation)")
         group_parser.add_argument(

--- a/starfish/test/full_pipelines/cli/test_iss.py
+++ b/starfish/test/full_pipelines/cli/test_iss.py
@@ -136,9 +136,9 @@ class TestWithIssData(unittest.TestCase):
                 tempdir, "filtered", "hybridization.json"),
             "--output", lambda tempdir, *args, **kwargs: os.path.join(
                 tempdir, "results", "spots.nc"),
-            "GaussianSpotDetector",
             "--blobs-stack", lambda tempdir, *args, **kwargs: os.path.join(
                 tempdir, "filtered", "dots.json"),
+            "GaussianSpotDetector",
             "--min-sigma", "4",
             "--max-sigma", "6",
             "--num-sigma", "20",


### PR DESCRIPTION
It's now a part of the spot detectors' arguments, so it needs to precede the algorithm name.

Test plan: `. docs/source/usage/iss/iss_cli.sh`