### PR TITLE
Remove type handling code from Clip pipeline component

### DIFF
--- a/starfish/image/_filter/clip.py
+++ b/starfish/image/_filter/clip.py
@@ -60,11 +60,7 @@ class Clip(FilterAlgorithmBase):
         """
         v_min, v_max = np.percentile(image, [p_min, p_max])
 
-        # asking for a float percentile clipping value from an integer image will
-        # convert to float, so store the dtype so it can be restored
-        dtype = image.dtype
-        image = image.clip(min=v_min, max=v_max)
-        return image.astype(dtype)
+        return image.clip(min=v_min, max=v_max)
 
     def run(
             self, stack: ImageStack, in_place: bool=False, verbose: bool=False,


### PR DESCRIPTION
Everything should transact in float32.

Thanks to @kevinyamauchi for [noticing this](https://github.com/spacetx/starfish/pull/621#issue-217750314)

Test plan: make -j all
