### PR TITLE
Clean up gaussian tests

### DIFF
--- a/starfish/test/pipeline/test_filter.py
+++ b/starfish/test/pipeline/test_filter.py
@@ -23,18 +23,8 @@ def test_gaussian_high_pass(sigma: Union[Number, Tuple[Number]]) -> None:
     assert np.sum(result.numpy_array) < sum_before
 
 
-@pytest.mark.parametrize('sigma', (1, (1, 1)))
-def test_gaussian_high_pass_apply(sigma: Union[Number, Tuple[Number]]) -> None:
-    """same as test_gaussian_high_pass, but tests apply loop functionality."""
-    image_stack = random_data_image_stack_factory()
-    sum_before = np.sum(image_stack.numpy_array)
-    ghp = gaussian_high_pass.GaussianHighPass(sigma=sigma)
-    result = ghp.run(image_stack)
-    assert np.sum(result.numpy_array) < sum_before
-
-
 @pytest.mark.parametrize('sigma', (1, (1, 0, 1)))
-def test_gaussian_high_pass_apply_3d(sigma: Union[Number, Tuple[Number]]) -> None:
+def test_gaussian_high_pass_3d(sigma: Union[Number, Tuple[Number]]) -> None:
     """same as test_gaussian_high_pass, but tests apply loop functionality in 3d"""
     image_stack = random_data_image_stack_factory()
     sum_before = np.sum(image_stack.numpy_array)


### PR DESCRIPTION
1. Remove `test_gaussian_high_pass_apply`, which is the same as `test_gaussian_high_pass`.
2. Rename `test_gaussian_high_pass_apply_3d` to `test_gaussian_high_pass_3d`.
