### PR TITLE
[CODEBOOK 1/3] Move codebook to its own package.

### DIFF
--- a/notebooks/DARTFISH_Pipeline_-_Human_Occipital_Cortex_-_1_FOV.ipynb
+++ b/notebooks/DARTFISH_Pipeline_-_Human_Occipital_Cortex_-_1_FOV.ipynb
@@ -26,8 +26,6 @@
     "from starfish import data\n",
     "from starfish.types import Features, Indices\n",
     "\n",
-    "from starfish.codebook import Codebook\n",
-    "\n",
     "from starfish.intensity_table import IntensityTable\n",
     "\n",
     "from starfish.image import Filter\n",

--- a/notebooks/py/DARTFISH_Pipeline_-_Human_Occipital_Cortex_-_1_FOV.py
+++ b/notebooks/py/DARTFISH_Pipeline_-_Human_Occipital_Cortex_-_1_FOV.py
@@ -21,8 +21,6 @@ import os
 from starfish import data
 from starfish.types import Features, Indices
 
-from starfish.codebook import Codebook
-
 from starfish.intensity_table import IntensityTable
 
 from starfish.image import Filter

--- a/starfish/__init__.py
+++ b/starfish/__init__.py
@@ -10,7 +10,7 @@ from . import image
 # spot detection and manipulation
 from . import spots
 # top-level objects
-from .codebook import Codebook
+from .codebook.codebook import Codebook
 from .experiment.experiment import Experiment
 from .imagestack.imagestack import ImageStack
 from .intensity_table import IntensityTable

--- a/starfish/codebook/codebook.py
+++ b/starfish/codebook/codebook.py
@@ -95,7 +95,7 @@ class Codebook(xr.DataArray):
 
         Examples
         --------
-        >>> from starfish.codebook import Codebook
+        >>> from starfish import Codebook
         >>> Codebook._empty_codebook(['ACTA', 'ACTB'], n_ch=3, n_round=2)
         <xarray.Codebook (target: 2, c: 3, h: 2)>
         array([[[0, 0],
@@ -146,7 +146,7 @@ class Codebook(xr.DataArray):
         Construct a codebook from some array data in python memory::
 
             >>> from starfish.types import Indices
-            >>> from starfish.codebook import Codebook
+            >>> from starfish import Codebook
             >>> codebook = [
             >>>     {
             >>>         Features.CODEWORD: [
@@ -257,7 +257,7 @@ class Codebook(xr.DataArray):
         Create a codebook from in-memory data::
 
             >>> from starfish.types import Indices
-            >>> from starfish.codebook import Codebook
+            >>> from starfish import Codebook
             >>> import tempfile
             >>> import json
             >>> import os
@@ -591,7 +591,7 @@ class Codebook(xr.DataArray):
         --------
         Create a Codebook with 2 rounds, 3 channels, and 2 codes::
 
-            >>> from starfish.codebook import Codebook
+            >>> from starfish import Codebook
             >>> Codebook.synthetic_one_hot_codebook(n_round=2, n_channel=3, n_codes=2)
             <xarray.Codebook (target: 2, c: 3, h: 2)>
             array([[[0, 1],

--- a/starfish/experiment/experiment.py
+++ b/starfish/experiment/experiment.py
@@ -7,7 +7,7 @@ from slicedimage import Collection, TileSet
 from slicedimage.io import Reader, resolve_path_or_url, resolve_url
 from slicedimage.urlpath import pathjoin
 
-from starfish.codebook import Codebook
+from starfish.codebook.codebook import Codebook
 from starfish.imagestack.imagestack import ImageStack
 from validate_sptx import validate_sptx
 from .version import MAX_SUPPORTED_VERSION, MIN_SUPPORTED_VERSION

--- a/starfish/spots/_decoder/__init__.py
+++ b/starfish/spots/_decoder/__init__.py
@@ -1,7 +1,7 @@
 import argparse
 from typing import Type
 
-from starfish.codebook import Codebook
+from starfish.codebook.codebook import Codebook
 from starfish.intensity_table import IntensityTable
 from starfish.pipeline import AlgorithmBase, PipelineComponent
 from starfish.util.argparse import FsExistsType

--- a/starfish/spots/_decoder/per_round_max_channel_decoder.py
+++ b/starfish/spots/_decoder/per_round_max_channel_decoder.py
@@ -1,4 +1,4 @@
-from starfish.codebook import Codebook
+from starfish.codebook.codebook import Codebook
 from starfish.intensity_table import IntensityTable
 from ._base import DecoderAlgorithmBase
 

--- a/starfish/spots/_detector/pixel_spot_detector.py
+++ b/starfish/spots/_detector/pixel_spot_detector.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-from starfish.codebook import Codebook
+from starfish.codebook.codebook import Codebook
 from starfish.imagestack.imagestack import ImageStack
 from starfish.intensity_table import IntensityTable
 from ._base import SpotFinderAlgorithmBase

--- a/starfish/test/dataset_fixtures.py
+++ b/starfish/test/dataset_fixtures.py
@@ -10,7 +10,7 @@ import pandas as pd
 import pytest
 from scipy.ndimage.filters import gaussian_filter
 
-from starfish.codebook import Codebook
+from starfish.codebook.codebook import Codebook
 from starfish.experiment.experiment import Experiment
 from starfish.image._filter.white_tophat import WhiteTophat
 from starfish.imagestack.imagestack import ImageStack

--- a/starfish/util/synthesize.py
+++ b/starfish/util/synthesize.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 import numpy as np
 
-from starfish.codebook import Codebook
+from starfish.codebook.codebook import Codebook
 from starfish.imagestack.imagestack import ImageStack
 from starfish.intensity_table import IntensityTable
 


### PR DESCRIPTION
This allows us to modularize it like experiment and imagestack.

Test plan: make -j fast run_notebooks