### PR TITLE
[CODEBOOK 2/3] Use the file IO mechanism in Codebook to write codebooks for tests.

### DIFF
--- a/examples/get_iss_data.py
+++ b/examples/get_iss_data.py
@@ -10,6 +10,7 @@ import requests
 from skimage.io import imread
 from slicedimage import ImageFormat
 
+from starfish import Codebook
 from starfish.experiment.builder import FetchedTile, TileFetcher
 from starfish.experiment.builder import write_experiment_json
 from starfish.types import Coordinates, Features, Indices, Number
@@ -126,7 +127,7 @@ def format_data(input_dir, output_dir, d):
         default_shape=SHAPE
     )
 
-    codebook = [
+    codebook_array = [
         {
             Features.CODEWORD: [
                 {Indices.ROUND.value: 0, Indices.CH.value: 3, Features.CODE_VALUE: 1},
@@ -146,8 +147,9 @@ def format_data(input_dir, output_dir, d):
             Features.TARGET: "ACTB_mouse"
         },
     ]
+    codebook = Codebook.from_code_array(codebook_array)
     codebook_json_filename = "codebook.json"
-    write_json(codebook, os.path.join(output_dir, codebook_json_filename))
+    codebook.to_json(os.path.join(output_dir, codebook_json_filename))
 
 
 if __name__ == "__main__":

--- a/starfish/experiment/builder/__init__.py
+++ b/starfish/experiment/builder/__init__.py
@@ -10,6 +10,7 @@ from slicedimage import (
     Writer,
 )
 
+from starfish.codebook.codebook import Codebook
 from starfish.experiment.version import CURRENT_VERSION
 from starfish.types import Coordinates, Indices
 from .defaultproviders import RandomNoiseTile, tile_fetcher_factory
@@ -201,7 +202,7 @@ def write_experiment_json(
     with open(os.path.join(path, "experiment.json"), "w") as fh:
         json.dump(experiment_doc, fh, indent=4)
 
-    codebook_stub = [
+    codebook_array = [
         {
             "codeword": [
                 {"r": 0, "c": 0, "v": 1},
@@ -209,5 +210,6 @@ def write_experiment_json(
             "target": "PLEASE_REPLACE_ME"
         },
     ]
-    with open(os.path.join(path, "codebook.json"), "w") as fh:
-        json.dump(codebook_stub, fh, indent=4)
+    codebook = Codebook.from_code_array(codebook_array)
+    codebook_json_filename = "codebook.json"
+    codebook.to_json(os.path.join(path, codebook_json_filename))

--- a/starfish/test/dataset_fixtures.py
+++ b/starfish/test/dataset_fixtures.py
@@ -1,6 +1,3 @@
-import json
-import os
-import shutil
 import tempfile
 from copy import deepcopy
 from typing import Generator
@@ -97,15 +94,11 @@ def simple_codebook_array():
 
 @pytest.fixture(scope='module')
 def simple_codebook_json(simple_codebook_array) -> Generator[str, None, None]:
-    directory = tempfile.mkdtemp()
-    codebook_json = os.path.join(directory, 'simple_codebook.json')
-    with open(codebook_json, 'w') as f:
-        json.dump(simple_codebook_array, f)
+    with tempfile.NamedTemporaryFile() as tf:
+        codebook = Codebook.from_code_array(simple_codebook_array)
+        codebook.to_json(tf.name)
 
-    yield codebook_json
-
-    shutil.rmtree(directory)
-
+        yield tf.name
 
 @pytest.fixture(scope='module')
 def loaded_codebook(simple_codebook_json):


### PR DESCRIPTION
This allows us to update the codebook format without mucking around in code elsewhere.