### PR TITLE
[easy] Hide code that the user doesn't need to see.

### DIFF
--- a/starfish/image/_filter/__init__.py
+++ b/starfish/image/_filter/__init__.py
@@ -21,11 +21,11 @@ class Filter(PipelineComponent):
     filter_group: argparse.ArgumentParser
 
     @classmethod
-    def get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
+    def _get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
         return _base.FilterAlgorithmBase
 
     @classmethod
-    def add_to_parser(cls, subparsers):
+    def _add_to_parser(cls, subparsers):
         """Adds the filter component to the CLI argument parser."""
         filter_group = subparsers.add_parser("filter")
         filter_group.add_argument("-i", "--input", type=FsExistsType(), required=True)
@@ -33,10 +33,10 @@ class Filter(PipelineComponent):
         filter_group.set_defaults(starfish_command=Filter._cli)
         filter_subparsers = filter_group.add_subparsers(dest="filter_algorithm_class")
 
-        for algorithm_cls in cls.algorithm_to_class_map().values():
-            group_parser = filter_subparsers.add_parser(algorithm_cls.get_algorithm_name())
+        for algorithm_cls in cls._algorithm_to_class_map().values():
+            group_parser = filter_subparsers.add_parser(algorithm_cls._get_algorithm_name())
             group_parser.set_defaults(filter_algorithm_class=algorithm_cls)
-            algorithm_cls.add_arguments(group_parser)
+            algorithm_cls._add_arguments(group_parser)
 
         cls.filter_group = filter_group
 

--- a/starfish/image/_filter/bandpass.py
+++ b/starfish/image/_filter/bandpass.py
@@ -38,7 +38,7 @@ class Bandpass(FilterAlgorithmBase):
         self.is_volume = is_volume
 
     @classmethod
-    def add_arguments(cls, group_parser) -> None:
+    def _add_arguments(cls, group_parser) -> None:
         group_parser.add_argument(
             "--lshort", type=float, help="filter signals below this frequency")
         group_parser.add_argument(
@@ -50,7 +50,7 @@ class Bandpass(FilterAlgorithmBase):
             help="truncate the filter at this many standard deviations")
 
     @staticmethod
-    def bandpass(
+    def _bandpass(
             image: np.ndarray, lshort: Number, llong: int, threshold: Number, truncate: Number
     ) -> np.ndarray:
         """Apply a bandpass filter to remove noise and background variation
@@ -105,7 +105,7 @@ class Bandpass(FilterAlgorithmBase):
 
         """
         bandpass_ = partial(
-            self.bandpass,
+            self._bandpass,
             lshort=self.lshort, llong=self.llong, threshold=self.threshold, truncate=self.truncate
         )
         result = stack.apply(

--- a/starfish/image/_filter/clip.py
+++ b/starfish/image/_filter/clip.py
@@ -28,14 +28,14 @@ class Clip(FilterAlgorithmBase):
         self.is_volume = is_volume
 
     @classmethod
-    def add_arguments(cls, group_parser) -> None:
+    def _add_arguments(cls, group_parser) -> None:
         group_parser.add_argument(
             "--p-min", default=0, type=int, help="clip intensities below this percentile")
         group_parser.add_argument(
             "--p-max", default=100, type=int, help="clip intensities above this percentile")
 
     @staticmethod
-    def clip(image: np.ndarray, p_min: int, p_max: int) -> np.ndarray:
+    def _clip(image: np.ndarray, p_min: int, p_max: int) -> np.ndarray:
         """Clip values of img below and above percentiles p_min and p_max
 
         Parameters
@@ -86,7 +86,7 @@ class Clip(FilterAlgorithmBase):
             original stack.
 
         """
-        clip = partial(self.clip, p_min=self.p_min, p_max=self.p_max)
+        clip = partial(self._clip, p_min=self.p_min, p_max=self.p_max)
         result = stack.apply(
             clip,
             is_volume=self.is_volume, verbose=verbose, in_place=in_place, n_processes=n_processes

--- a/starfish/image/_filter/gaussian_high_pass.py
+++ b/starfish/image/_filter/gaussian_high_pass.py
@@ -32,7 +32,7 @@ class GaussianHighPass(FilterAlgorithmBase):
         self.is_volume = is_volume
 
     @classmethod
-    def add_arguments(cls, group_parser: argparse.ArgumentParser) -> None:
+    def _add_arguments(cls, group_parser: argparse.ArgumentParser) -> None:
         group_parser.add_argument(
             "--sigma", type=float, help="standard deviation of gaussian kernel")
         group_parser.add_argument(
@@ -40,7 +40,7 @@ class GaussianHighPass(FilterAlgorithmBase):
             help="indicates that the image stack should be filtered in 3d")
 
     @staticmethod
-    def high_pass(
+    def _high_pass(
             image: Union[xr.DataArray, np.ndarray],
             sigma: Union[Number, Tuple[Number]],
             rescale: bool=False
@@ -65,7 +65,7 @@ class GaussianHighPass(FilterAlgorithmBase):
 
         """
 
-        blurred = GaussianLowPass.low_pass(image, sigma)
+        blurred = GaussianLowPass._low_pass(image, sigma)
         filtered = image - blurred
         filtered = preserve_float_range(filtered, rescale)
 
@@ -95,7 +95,7 @@ class GaussianHighPass(FilterAlgorithmBase):
             original stack.
 
         """
-        high_pass: Callable = partial(self.high_pass, sigma=self.sigma)
+        high_pass: Callable = partial(self._high_pass, sigma=self.sigma)
         result = stack.apply(
             high_pass, is_volume=self.is_volume, verbose=verbose, in_place=in_place,
             n_processes=n_processes

--- a/starfish/image/_filter/gaussian_low_pass.py
+++ b/starfish/image/_filter/gaussian_low_pass.py
@@ -30,7 +30,7 @@ class GaussianLowPass(FilterAlgorithmBase):
         self.is_volume = is_volume
 
     @classmethod
-    def add_arguments(cls, group_parser: argparse.ArgumentParser) -> None:
+    def _add_arguments(cls, group_parser: argparse.ArgumentParser) -> None:
         group_parser.add_argument(
             "--sigma", type=float, help="standard deviation of gaussian kernel")
         group_parser.add_argument(
@@ -38,7 +38,7 @@ class GaussianLowPass(FilterAlgorithmBase):
             help="indicates that the image stack should be filtered in 3d")
 
     @staticmethod
-    def low_pass(
+    def _low_pass(
             image: np.ndarray,
             sigma: Union[Number, Tuple[Number]],
             rescale: bool=False
@@ -97,7 +97,7 @@ class GaussianLowPass(FilterAlgorithmBase):
             original stack.
 
         """
-        low_pass: Callable = partial(self.low_pass, sigma=self.sigma)
+        low_pass: Callable = partial(self._low_pass, sigma=self.sigma)
         result = stack.apply(
             low_pass, is_volume=self.is_volume, verbose=verbose, in_place=in_place,
             n_processes=n_processes

--- a/starfish/image/_filter/mean_high_pass.py
+++ b/starfish/image/_filter/mean_high_pass.py
@@ -40,7 +40,7 @@ class MeanHighPass(FilterAlgorithmBase):
         self.is_volume = is_volume
 
     @classmethod
-    def add_arguments(cls, group_parser: argparse.ArgumentParser) -> None:
+    def _add_arguments(cls, group_parser: argparse.ArgumentParser) -> None:
         group_parser.add_argument(
             "--size", type=float, help="width of the kernel")
         group_parser.add_argument(
@@ -48,7 +48,7 @@ class MeanHighPass(FilterAlgorithmBase):
             help="indicates that the image stack should be filtered in 3d")
 
     @staticmethod
-    def high_pass(image: np.ndarray, size: Number, rescale: bool=False) -> np.ndarray:
+    def _high_pass(image: np.ndarray, size: Number, rescale: bool=False) -> np.ndarray:
         """
         Applies a mean high pass filter to an image
 
@@ -100,7 +100,7 @@ class MeanHighPass(FilterAlgorithmBase):
             original stack.
 
         """
-        high_pass: Callable = partial(self.high_pass, size=self.size)
+        high_pass: Callable = partial(self._high_pass, size=self.size)
         result = stack.apply(
             high_pass,
             is_volume=self.is_volume, verbose=verbose, in_place=in_place, n_processes=n_processes

--- a/starfish/image/_filter/richardson_lucy_deconvolution.py
+++ b/starfish/image/_filter/richardson_lucy_deconvolution.py
@@ -39,7 +39,7 @@ class DeconvolvePSF(FilterAlgorithmBase):
         )
 
     @classmethod
-    def add_arguments(cls, group_parser: argparse.ArgumentParser) -> None:
+    def _add_arguments(cls, group_parser: argparse.ArgumentParser) -> None:
         group_parser.add_argument(
             '--num-iter', type=int, help='number of iterations to run')
         group_parser.add_argument(
@@ -51,7 +51,7 @@ class DeconvolvePSF(FilterAlgorithmBase):
     # Here be dragons. This algorithm had a bug, but the results looked nice. Now we've "fixed" it
     # and the results look bad. #548 addresses this problem.
     @staticmethod
-    def richardson_lucy_deconv(
+    def _richardson_lucy_deconv(
             image: np.ndarray, iterations: int, psf: np.ndarray, clip: bool) -> np.ndarray:
         """
         Deconvolves input image with a specified point spread function.
@@ -161,7 +161,7 @@ class DeconvolvePSF(FilterAlgorithmBase):
 
         """
         func = partial(
-            self.richardson_lucy_deconv,
+            self._richardson_lucy_deconv,
             iterations=self.num_iter, psf=self.psf, clip=self.clip
         )
         result = stack.apply(

--- a/starfish/image/_filter/scale_by_percentile.py
+++ b/starfish/image/_filter/scale_by_percentile.py
@@ -25,12 +25,12 @@ class ScaleByPercentile(FilterAlgorithmBase):
         self.is_volume = is_volume
 
     @classmethod
-    def add_arguments(cls, group_parser) -> None:
+    def _add_arguments(cls, group_parser) -> None:
         group_parser.add_argument(
             "--p", default=100, type=int, help="scale images by this percentile")
 
     @staticmethod
-    def scale(image: np.ndarray, p: int) -> np.ndarray:
+    def _scale(image: np.ndarray, p: int) -> np.ndarray:
         """Clip values of img below and above percentiles p_min and p_max
 
         Parameters
@@ -84,7 +84,7 @@ class ScaleByPercentile(FilterAlgorithmBase):
             original stack.
 
         """
-        clip = partial(self.scale, p=self.p)
+        clip = partial(self._scale, p=self.p)
         result = stack.apply(
             clip,
             is_volume=self.is_volume, verbose=verbose, in_place=in_place, n_processes=n_processes

--- a/starfish/image/_filter/white_tophat.py
+++ b/starfish/image/_filter/white_tophat.py
@@ -35,12 +35,12 @@ class WhiteTophat(FilterAlgorithmBase):
         self.is_volume = is_volume
 
     @classmethod
-    def add_arguments(cls, group_parser) -> None:
+    def _add_arguments(cls, group_parser) -> None:
         group_parser.add_argument(
             "--masking-radius", default=15, type=int,
             help="diameter of morphological masking disk in pixels")
 
-    def white_tophat(self, image: np.ndarray) -> np.ndarray:
+    def _white_tophat(self, image: np.ndarray) -> np.ndarray:
         if self.is_volume:
             structuring_element = ball(self.masking_radius)
         else:
@@ -72,7 +72,7 @@ class WhiteTophat(FilterAlgorithmBase):
 
         """
         result = stack.apply(
-            self.white_tophat,
+            self._white_tophat,
             is_volume=self.is_volume, verbose=verbose, in_place=in_place, n_processes=n_processes
         )
         return result

--- a/starfish/image/_filter/zero_by_channel_magnitude.py
+++ b/starfish/image/_filter/zero_by_channel_magnitude.py
@@ -29,7 +29,7 @@ class ZeroByChannelMagnitude(FilterAlgorithmBase):
         self.normalize = normalize
 
     @classmethod
-    def add_arguments(cls, group_parser: argparse.ArgumentParser) -> None:
+    def _add_arguments(cls, group_parser: argparse.ArgumentParser) -> None:
         group_parser.add_argument(
             '--thresh', type=int, help='minimum magnitude threshold for pixels across channels')
 

--- a/starfish/image/_registration/__init__.py
+++ b/starfish/image/_registration/__init__.py
@@ -13,11 +13,11 @@ class Registration(PipelineComponent):
     register_group: argparse.ArgumentParser
 
     @classmethod
-    def get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
+    def _get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
         return RegistrationAlgorithmBase
 
     @classmethod
-    def add_to_parser(cls, subparsers):
+    def _add_to_parser(cls, subparsers):
         """Adds the registration component to the CLI argument parser."""
         register_group = subparsers.add_parser("registration")
         register_group.add_argument("-i", "--input", type=FsExistsType(), required=True)
@@ -25,10 +25,10 @@ class Registration(PipelineComponent):
         register_group.set_defaults(starfish_command=Registration._cli)
         registration_subparsers = register_group.add_subparsers(dest="registration_algorithm_class")
 
-        for algorithm_cls in cls.algorithm_to_class_map().values():
-            group_parser = registration_subparsers.add_parser(algorithm_cls.get_algorithm_name())
+        for algorithm_cls in cls._algorithm_to_class_map().values():
+            group_parser = registration_subparsers.add_parser(algorithm_cls._get_algorithm_name())
             group_parser.set_defaults(registration_algorithm_class=algorithm_cls)
-            algorithm_cls.add_arguments(group_parser)
+            algorithm_cls._add_arguments(group_parser)
 
         cls.register_group = register_group
 

--- a/starfish/image/_registration/fourier_shift.py
+++ b/starfish/image/_registration/fourier_shift.py
@@ -43,7 +43,7 @@ class FourierShiftRegistration(RegistrationAlgorithmBase):
             self.reference_stack = ImageStack.from_path_or_url(reference_stack)
 
     @classmethod
-    def add_arguments(cls, group_parser) -> None:
+    def _add_arguments(cls, group_parser) -> None:
         group_parser.add_argument("--upsampling", default=1, type=int, help="Amount of up-sampling")
         group_parser.add_argument(
             "--reference-stack", type=FsExistsType(), required=True,

--- a/starfish/image/_segmentation/__init__.py
+++ b/starfish/image/_segmentation/__init__.py
@@ -14,11 +14,11 @@ class Segmentation(PipelineComponent):
     segmentation_group: argparse.ArgumentParser
 
     @classmethod
-    def get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
+    def _get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
         return SegmentationAlgorithmBase
 
     @classmethod
-    def add_to_parser(cls, subparsers) -> None:
+    def _add_to_parser(cls, subparsers) -> None:
         """Adds the segmentation component to the CLI argument parser."""
         segmentation_group = subparsers.add_parser("segment")
         segmentation_group.add_argument("--hybridization-stack", type=FsExistsType(), required=True)
@@ -28,10 +28,10 @@ class Segmentation(PipelineComponent):
         segmentation_subparsers = segmentation_group.add_subparsers(
             dest="segmentation_algorithm_class")
 
-        for algorithm_cls in cls.algorithm_to_class_map().values():
-            group_parser = segmentation_subparsers.add_parser(algorithm_cls.get_algorithm_name())
+        for algorithm_cls in cls._algorithm_to_class_map().values():
+            group_parser = segmentation_subparsers.add_parser(algorithm_cls._get_algorithm_name())
             group_parser.set_defaults(segmentation_algorithm_class=algorithm_cls)
-            algorithm_cls.add_arguments(group_parser)
+            algorithm_cls._add_arguments(group_parser)
 
         cls.segmentation_group = segmentation_group
 

--- a/starfish/image/_segmentation/watershed.py
+++ b/starfish/image/_segmentation/watershed.py
@@ -27,7 +27,7 @@ class Watershed(SegmentationAlgorithmBase):
         self._segmentation_instance: Optional[_WatershedSegmenter] = None
 
     @classmethod
-    def add_arguments(cls, group_parser) -> None:
+    def _add_arguments(cls, group_parser) -> None:
         group_parser.add_argument(
             "--dapi-threshold", default=.16, type=float, help="DAPI threshold")
         group_parser.add_argument(

--- a/starfish/pipeline/algorithmbase.py
+++ b/starfish/pipeline/algorithmbase.py
@@ -3,7 +3,7 @@ import argparse
 
 class AlgorithmBase:
     @classmethod
-    def get_algorithm_name(cls):
+    def _get_algorithm_name(cls):
         """
         Returns the name of the algorithm.  This should be a valid python identifier, i.e.,
         https://docs.python.org/3/reference/lexical_analysis.html#identifiers
@@ -11,6 +11,6 @@ class AlgorithmBase:
         return cls.__name__
 
     @classmethod
-    def add_arguments(cls, group_parser: argparse.ArgumentParser):
+    def _add_arguments(cls, group_parser: argparse.ArgumentParser):
         """Adds the arguments for the algorithm."""
         raise NotImplementedError()

--- a/starfish/pipeline/pipelinecomponent.py
+++ b/starfish/pipeline/pipelinecomponent.py
@@ -18,25 +18,25 @@ class PipelineComponentType(type):
 
     @classmethod
     def _ensure_algorithms_setup(mcs, cls):
-        if cls._algorithm_to_class_map is None:
-            cls._algorithm_to_class_map = dict()
+        if cls._algorithm_to_class_map_int is None:
+            cls._algorithm_to_class_map_int = dict()
 
-            queue = collections.deque(cls.get_algorithm_base_class().__subclasses__())
+            queue = collections.deque(cls._get_algorithm_base_class().__subclasses__())
             while len(queue) > 0:
                 algorithm_cls = queue.popleft()
                 queue.extend(algorithm_cls.__subclasses__())
 
-                cls._algorithm_to_class_map[algorithm_cls.__name__] = algorithm_cls
+                cls._algorithm_to_class_map_int[algorithm_cls.__name__] = algorithm_cls
 
-                setattr(cls, algorithm_cls.get_algorithm_name(), algorithm_cls)
+                setattr(cls, algorithm_cls._get_algorithm_name(), algorithm_cls)
 
 
 class PipelineComponent(metaclass=PipelineComponentType):
 
-    _algorithm_to_class_map: Optional[Mapping[str, Type]] = None
+    _algorithm_to_class_map_int: Optional[Mapping[str, Type]] = None
 
     @classmethod
-    def get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
+    def _get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
         """
         Get the base class that algorithms which implement this pipeline stage must extend.
         Pipeline components must provide this method.
@@ -44,9 +44,9 @@ class PipelineComponent(metaclass=PipelineComponentType):
         raise NotImplementedError()
 
     @classmethod
-    def algorithm_to_class_map(cls):
+    def _algorithm_to_class_map(cls):
         """Returns a mapping from algorithm names to the classes that implement them."""
-        return cls._algorithm_to_class_map
+        return cls._algorithm_to_class_map_int
 
     @classmethod
     def _cli(cls, args: argparse.Namespace):

--- a/starfish/spots/_decoder/__init__.py
+++ b/starfish/spots/_decoder/__init__.py
@@ -14,7 +14,7 @@ class Decoder(PipelineComponent):
     decoder_group: argparse.ArgumentParser
 
     @classmethod
-    def get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
+    def _get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
         return _base.DecoderAlgorithmBase
 
     @classmethod
@@ -27,10 +27,10 @@ class Decoder(PipelineComponent):
         decoder_group.set_defaults(starfish_command=Decoder._cli)
         decoder_subparsers = decoder_group.add_subparsers(dest="decoder_algorithm_class")
 
-        for algorithm_cls in cls.algorithm_to_class_map().values():
-            group_parser = decoder_subparsers.add_parser(algorithm_cls.get_algorithm_name())
+        for algorithm_cls in cls._algorithm_to_class_map().values():
+            group_parser = decoder_subparsers.add_parser(algorithm_cls._get_algorithm_name())
             group_parser.set_defaults(decoder_algorithm_class=algorithm_cls)
-            algorithm_cls.add_arguments(group_parser)
+            algorithm_cls._add_arguments(group_parser)
 
         cls.decoder_group = decoder_group
 

--- a/starfish/spots/_decoder/per_round_max_channel_decoder.py
+++ b/starfish/spots/_decoder/per_round_max_channel_decoder.py
@@ -9,7 +9,7 @@ class PerRoundMaxChannelDecoder(DecoderAlgorithmBase):
         pass
 
     @classmethod
-    def add_arguments(cls, group_parser):
+    def _add_arguments(cls, group_parser):
         pass
 
     def run(self, intensities: IntensityTable, codebook: Codebook) -> IntensityTable:

--- a/starfish/spots/_detector/__init__.py
+++ b/starfish/spots/_detector/__init__.py
@@ -16,7 +16,7 @@ class SpotFinder(PipelineComponent):
     spot_finder_group: argparse.ArgumentParser
 
     @classmethod
-    def get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
+    def _get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
         return _base.SpotFinderAlgorithmBase
 
     @classmethod
@@ -43,10 +43,10 @@ class SpotFinder(PipelineComponent):
         spot_finder_subparsers = spot_finder_group.add_subparsers(
             dest="spot_finder_algorithm_class")
 
-        for algorithm_cls in cls.algorithm_to_class_map().values():
-            group_parser = spot_finder_subparsers.add_parser(algorithm_cls.get_algorithm_name())
+        for algorithm_cls in cls._algorithm_to_class_map().values():
+            group_parser = spot_finder_subparsers.add_parser(algorithm_cls._get_algorithm_name())
             group_parser.set_defaults(spot_finder_algorithm_class=algorithm_cls)
-            algorithm_cls.add_arguments(group_parser)
+            algorithm_cls._add_arguments(group_parser)
 
         cls.spot_finder_group = spot_finder_group
 

--- a/starfish/spots/_detector/gaussian.py
+++ b/starfish/spots/_detector/gaussian.py
@@ -147,7 +147,7 @@ class GaussianSpotDetector(SpotFinderAlgorithmBase):
         return intensity_table
 
     @classmethod
-    def add_arguments(cls, group_parser):
+    def _add_arguments(cls, group_parser):
         group_parser.add_argument(
             "--min-sigma", default=4, type=int, help="Minimum spot size (in standard deviation)")
         group_parser.add_argument(

--- a/starfish/spots/_detector/local_max_peak_finder.py
+++ b/starfish/spots/_detector/local_max_peak_finder.py
@@ -161,7 +161,7 @@ class LocalMaxPeakFinder(SpotFinderAlgorithmBase):
         return intensity_table
 
     @classmethod
-    def add_arguments(cls, group_parser):
+    def _add_arguments(cls, group_parser):
         group_parser.add_argument("--spot-diameter", type=str, help='expected spot size')
         group_parser.add_argument(
             "--min-mass", default=4, type=int, help="minimum integrated spot intensity")

--- a/starfish/spots/_detector/pixel_spot_detector.py
+++ b/starfish/spots/_detector/pixel_spot_detector.py
@@ -83,7 +83,7 @@ class PixelSpotDetector(SpotFinderAlgorithmBase):
         return decoded_spots, image_decoding_results
 
     @classmethod
-    def add_arguments(cls, group_parser):
+    def _add_arguments(cls, group_parser):
         group_parser.add_argument("--codebook-input", help="csv file containing a codebook")
         group_parser.add_argument("--metric", type=str, default='euclidean')
         group_parser.add_argument(

--- a/starfish/spots/_target_assignment/__init__.py
+++ b/starfish/spots/_target_assignment/__init__.py
@@ -15,7 +15,7 @@ class TargetAssignment(PipelineComponent):
     target_assignment_group: argparse.ArgumentParser
 
     @classmethod
-    def get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
+    def _get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
         return TargetAssignmentAlgorithm
 
     @classmethod
@@ -30,10 +30,10 @@ class TargetAssignment(PipelineComponent):
         target_assignment_group = target_assignment_group.add_subparsers(
             dest="target_assignment_algorithm_class")
 
-        for algorithm_cls in cls.algorithm_to_class_map().values():
-            group_parser = target_assignment_group.add_parser(algorithm_cls.get_algorithm_name())
+        for algorithm_cls in cls._algorithm_to_class_map().values():
+            group_parser = target_assignment_group.add_parser(algorithm_cls._get_algorithm_name())
             group_parser.set_defaults(target_assignment_algorithm_class=algorithm_cls)
-            algorithm_cls.add_arguments(group_parser)
+            algorithm_cls._add_arguments(group_parser)
 
         cls.target_assignment_group = target_assignment_group
 

--- a/starfish/spots/_target_assignment/point_in_poly.py
+++ b/starfish/spots/_target_assignment/point_in_poly.py
@@ -17,7 +17,7 @@ class PointInPoly2D(TargetAssignmentAlgorithm):
         """
 
     @classmethod
-    def add_arguments(cls, parser) -> None:
+    def _add_arguments(cls, parser) -> None:
         pass
 
     @staticmethod

--- a/starfish/starfish.py
+++ b/starfish/starfish.py
@@ -33,10 +33,10 @@ def build_parser():
 
     subparsers = parser.add_subparsers(dest="starfish_command")
 
-    Registration.add_to_parser(subparsers)
-    Filter.add_to_parser(subparsers)
+    Registration._add_to_parser(subparsers)
+    Filter._add_to_parser(subparsers)
     SpotFinder.add_to_parser(subparsers)
-    Segmentation.add_to_parser(subparsers)
+    Segmentation._add_to_parser(subparsers)
     TargetAssignment.add_to_parser(subparsers)
     Decoder.add_to_parser(subparsers)
 

--- a/starfish/test/pipeline/test_white_tophat.py
+++ b/starfish/test/pipeline/test_white_tophat.py
@@ -34,7 +34,7 @@ def test_white_tophat(is_volume: bool):
         big_spot_intensity = image[20, 20, 20]
 
         wth = WhiteTophat(masking_radius=2, is_volume=True)
-        filtered = wth.white_tophat(image)
+        filtered = wth._white_tophat(image)
 
         large_ratio = filtered[20, 20, 20] / big_spot_intensity
         small_ratio = filtered[80, 80, 80] / small_spot_intensity
@@ -46,7 +46,7 @@ def test_white_tophat(is_volume: bool):
         big_spot_intensity = image[20, 20]
 
         wth = WhiteTophat(masking_radius=2, is_volume=False)
-        filtered = wth.white_tophat(image)
+        filtered = wth._white_tophat(image)
 
         large_ratio = filtered[20, 20] / big_spot_intensity
         small_ratio = filtered[80, 80] / small_spot_intensity


### PR DESCRIPTION
All the methods that don't need to be seen get renamed with a _ prefix.

There is a wrinkle in PipelineComponent since the destination name already exists, so that gets further renamed.

Test plan: make -j run_notebooks all

Fixes #589