### PR TITLE
Integrate REQUIREMENTS-NOTEBOOK into REQUIREMENTS-DEV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,12 +112,12 @@ help-integration:
 ### INSTALL ##################################################
 #
 install-src:
-	pip install --force-reinstall --upgrade -r REQUIREMENTS-DEV.txt -r REQUIREMENTS-NOTEBOOK.txt
+	pip install --force-reinstall --upgrade -r REQUIREMENTS-DEV.txt
 	pip install -e .
 	pip freeze
 
 install-pypi:
-	pip install -r REQUIREMENTS-NOTEBOOK.txt starfish
+	pip install -r REQUIREMENTS-DEV.txt starfish
 
 help-install:
 	$(call print_help, install-src, pip install the current directory)

--- a/REQUIREMENTS-DEV.txt
+++ b/REQUIREMENTS-DEV.txt
@@ -28,6 +28,7 @@ idna==2.7
 imagesize==1.1.0
 ipython==6.5.0
 ipython-genutils==0.2.0
+ipywidgets==7.4.2
 jedi==0.12.1
 Jinja2==2.10
 jsonpath-rw==1.4.0

--- a/REQUIREMENTS-DEV.txt.in
+++ b/REQUIREMENTS-DEV.txt.in
@@ -1,5 +1,6 @@
 flake8
 flake8-import-order
+ipywidgets
 jsonpath_rw
 pytest-cov>=2.5.1
 pytest-xdist

--- a/REQUIREMENTS-NOTEBOOK.txt
+++ b/REQUIREMENTS-NOTEBOOK.txt
@@ -1,1 +1,0 @@
-ipywidgets


### PR DESCRIPTION
Since we slurp in the notebook code for unit testing as of #583, we actually need the notebook requirements to develop.  This brings in the only requirement in REQUIREMENTS-NOTEBOOK.txt into REQUIREMENTS-DEV.txt.in and REQUIREMENTS-DEV.txt.