### PR TITLE
Fix get_iss_breast_data.py

### DIFF
--- a/examples/get_iss_breast_data.py
+++ b/examples/get_iss_breast_data.py
@@ -91,7 +91,7 @@ def format_data(input_dir, output_dir, num_fovs):
         experiment_json_doc['codebook'] = "codebook.json"
         return experiment_json_doc
 
-    hyb_dimensions = {
+    primary_image_dimensions = {
         Indices.ROUND: 4,
         Indices.CH: 4,
         Indices.Z: 1,
@@ -113,7 +113,7 @@ def format_data(input_dir, output_dir, num_fovs):
     write_experiment_json(
         path=output_dir,
         fov_count=num_fovs,
-        hyb_dimensions=hyb_dimensions,
+        primary_image_dimensions=primary_image_dimensions,
         aux_name_to_dimensions=aux_name_to_dimensions,
         primary_tile_fetcher=ISSCroppedBreastPrimaryTileFetcher(input_dir),
         aux_tile_fetcher={


### PR DESCRIPTION
#572 fixes some of the vocabulary such that we avoid `hybridization`, but I didn't fix `get_iss_breast_data.py`.

Test plan: successfully run `python examples/get_iss_breast_data.py /Users/ttung/Downloads/starfish_data/mignardi_breast_1/raw/ ../starfish-formatted-data/breast/ 16`

Fixes #649