### PR TITLE
Improvements to starfish.data

### DIFF
--- a/notebooks/DARTFISH_Pipeline_-_Human_Occipital_Cortex_-_1_FOV.ipynb
+++ b/notebooks/DARTFISH_Pipeline_-_Human_Occipital_Cortex_-_1_FOV.ipynb
@@ -50,8 +50,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test = os.getenv(\"USE_TEST_DATA\") is not None\n",
-    "exp = data.DARTFISH(test_data=test)\n",
+    "use_test_data = os.getenv(\"USE_TEST_DATA\") is not None\n",
+    "exp = data.DARTFISH(use_test_data=use_test_data)\n",
     "\n",
     "stack = exp.fov().primary_image"
    ]

--- a/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.ipynb
+++ b/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.ipynb
@@ -38,8 +38,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test = os.getenv(\"USE_TEST_DATA\") is not None\n",
-    "experiment = data.ISS(test_data=test)\n",
+    "use_test_data = os.getenv(\"USE_TEST_DATA\") is not None\n",
+    "experiment = data.ISS(use_test_data=use_test_data)\n",
     "\n",
     "\n",
     "# s.image.squeeze() simply converts the 4D tensor H*C*X*Y into a list of len(H*C) image planes for rendering by 'tile'"

--- a/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
+++ b/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
@@ -46,8 +46,8 @@
    "outputs": [],
    "source": [
     "# load the data from cloudfront\n",
-    "test = os.getenv(\"USE_TEST_DATA\") is not None\n",
-    "experiment = data.MERFISH(test_data=test)"
+    "use_test_data = os.getenv(\"USE_TEST_DATA\") is not None\n",
+    "experiment = data.MERFISH(use_test_data=use_test_data)"
    ]
   },
   {
@@ -196,7 +196,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if test:\n",
+    "if use_test_data:\n",
     "    scale_factors = {\n",
     "        (t[Indices.ROUND], t[Indices.CH]): t['scale_factor']\n",
     "        for t in experiment.extras['scale_factors']\n",

--- a/notebooks/allen_smFISH.ipynb
+++ b/notebooks/allen_smFISH.ipynb
@@ -58,8 +58,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test = os.getenv(\"USE_TEST_DATA\") is not None\n",
-    "experiment = data.allen_smFISH(test_data=test)\n",
+    "use_test_data = os.getenv(\"USE_TEST_DATA\") is not None\n",
+    "experiment = data.allen_smFISH(use_test_data=use_test_data)\n",
     "primary_image = experiment.fov().primary_image"
    ]
   },

--- a/notebooks/assay_comparison.ipynb
+++ b/notebooks/assay_comparison.ipynb
@@ -35,7 +35,7 @@
    "source": [
     "# science\n",
     "from starfish import IntensityTable, Experiment, ImageStack\n",
-    "from starfish.plot import histogram, decoded_spots, compare_copy_number\n",
+    "from starfish.plot import histogram, compare_copy_number\n",
     "from starfish.plot.decoded_spots import decoded_spots\n",
     "from starfish.types import Features, Indices\n",
     "import numpy as np\n",
@@ -107,9 +107,8 @@
    "outputs": [],
    "source": [
     "# construct background images for each assay\n",
-    "experiment = Experiment.from_json(\n",
-    "    'https://dmf0bdeheu4zf.cloudfront.net/20180919/DARTFISH/experiment.json'\n",
-    ")\n",
+    "import starfish.data\n",
+    "experiment = starfish.data.DARTFISH()\n",
     "\n",
     "dartfish_nuclei = experiment.fov()['nuclei'].max_proj(Indices.CH, Indices.ROUND, Indices.Z)\n",
     "dartfish_link = os.path.join(data_root, \"dartfish_dots_image.npy\")\n",
@@ -124,9 +123,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "experiment = Experiment.from_json(\n",
-    "    'https://dmf0bdeheu4zf.cloudfront.net/20180919/ISS/experiment.json'\n",
-    ")\n",
+    "experiment = starfish.data.ISS()\n",
     "\n",
     "iss_nuclei = experiment.fov()['nuclei'].max_proj(Indices.CH, Indices.ROUND, Indices.Z)\n",
     "iss_dots = experiment.fov()['dots'].max_proj(Indices.CH, Indices.ROUND, Indices.Z)"
@@ -138,9 +135,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stack = Experiment.from_json(\n",
-    "    'https://dmf0bdeheu4zf.cloudfront.net/20180924/MERFISH/experiment.json'\n",
-    ")\n",
+    "experiment = starfish.data.MERFISH()\n",
     "merfish_nuclei = experiment.fov()['nuclei'].max_proj(Indices.CH, Indices.ROUND, Indices.Z)\n",
     "\n",
     "# merfish doesn't have a dots image, and some of the channels are stronger than others.\n",

--- a/notebooks/osmFISH.ipynb
+++ b/notebooks/osmFISH.ipynb
@@ -31,8 +31,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test = os.getenv(\"USE_TEST_DATA\") is not None\n",
-    "experiment = data.osmFISH(test_data=test)"
+    "use_test_data = os.getenv(\"USE_TEST_DATA\") is not None\n",
+    "experiment = data.osmFISH(use_test_data=use_test_data)"
    ]
   },
   {

--- a/notebooks/py/DARTFISH_Pipeline_-_Human_Occipital_Cortex_-_1_FOV.py
+++ b/notebooks/py/DARTFISH_Pipeline_-_Human_Occipital_Cortex_-_1_FOV.py
@@ -37,8 +37,8 @@ sns.set_style('ticks')
 # EPY: END markdown
 
 # EPY: START code
-test = os.getenv("USE_TEST_DATA") is not None
-exp = data.DARTFISH(test_data=test)
+use_test_data = os.getenv("USE_TEST_DATA") is not None
+exp = data.DARTFISH(use_test_data=use_test_data)
 
 stack = exp.fov().primary_image
 # EPY: END code

--- a/notebooks/py/ISS_Pipeline_-_Breast_-_1_FOV.py
+++ b/notebooks/py/ISS_Pipeline_-_Breast_-_1_FOV.py
@@ -28,8 +28,8 @@ from starfish.types import Features, Indices
 # EPY: END code
 
 # EPY: START code
-test = os.getenv("USE_TEST_DATA") is not None
-experiment = data.ISS(test_data=test)
+use_test_data = os.getenv("USE_TEST_DATA") is not None
+experiment = data.ISS(use_test_data=use_test_data)
 
 
 # s.image.squeeze() simply converts the 4D tensor H*C*X*Y into a list of len(H*C) image planes for rendering by 'tile'

--- a/notebooks/py/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
+++ b/notebooks/py/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
@@ -31,8 +31,8 @@ from starfish.types import Features, Indices
 
 # EPY: START code
 # load the data from cloudfront
-test = os.getenv("USE_TEST_DATA") is not None
-experiment = data.MERFISH(test_data=test)
+use_test_data = os.getenv("USE_TEST_DATA") is not None
+experiment = data.MERFISH(use_test_data=use_test_data)
 # EPY: END code
 
 # EPY: START markdown
@@ -114,7 +114,7 @@ low_passed = glp.run(deconvolved, in_place=False, verbose=True)
 # EPY: END markdown
 
 # EPY: START code
-if test:
+if use_test_data:
     scale_factors = {
         (t[Indices.ROUND], t[Indices.CH]): t['scale_factor']
         for t in experiment.extras['scale_factors']

--- a/notebooks/py/allen_smFISH.py
+++ b/notebooks/py/allen_smFISH.py
@@ -37,8 +37,8 @@ from starfish.types import Indices
 # EPY: END markdown
 
 # EPY: START code
-test = os.getenv("USE_TEST_DATA") is not None
-experiment = data.allen_smFISH(test_data=test)
+use_test_data = os.getenv("USE_TEST_DATA") is not None
+experiment = data.allen_smFISH(use_test_data=use_test_data)
 primary_image = experiment.fov().primary_image
 # EPY: END code
 

--- a/notebooks/py/assay_comparison.py
+++ b/notebooks/py/assay_comparison.py
@@ -23,7 +23,7 @@ import tempfile
 # EPY: START code
 # science
 from starfish import IntensityTable, Experiment, ImageStack
-from starfish.plot import histogram, decoded_spots, compare_copy_number
+from starfish.plot import histogram, compare_copy_number
 from starfish.plot.decoded_spots import decoded_spots
 from starfish.types import Features, Indices
 import numpy as np
@@ -74,9 +74,8 @@ datasets = [iss_intensity_table, merfish_intensity_table, dartfish_intensity_tab
 
 # EPY: START code
 # construct background images for each assay
-experiment = Experiment.from_json(
-    'https://dmf0bdeheu4zf.cloudfront.net/20180919/DARTFISH/experiment.json'
-)
+import starfish.data
+experiment = starfish.data.DARTFISH()
 
 dartfish_nuclei = experiment.fov()['nuclei'].max_proj(Indices.CH, Indices.ROUND, Indices.Z)
 dartfish_link = os.path.join(data_root, "dartfish_dots_image.npy")
@@ -86,18 +85,14 @@ dartfish_dots = np.load(dartfish_npy)
 # EPY: END code
 
 # EPY: START code
-experiment = Experiment.from_json(
-    'https://dmf0bdeheu4zf.cloudfront.net/20180919/ISS/experiment.json'
-)
+experiment = starfish.data.ISS()
 
 iss_nuclei = experiment.fov()['nuclei'].max_proj(Indices.CH, Indices.ROUND, Indices.Z)
 iss_dots = experiment.fov()['dots'].max_proj(Indices.CH, Indices.ROUND, Indices.Z)
 # EPY: END code
 
 # EPY: START code
-stack = Experiment.from_json(
-    'https://dmf0bdeheu4zf.cloudfront.net/20180924/MERFISH/experiment.json'
-)
+experiment = starfish.data.MERFISH()
 merfish_nuclei = experiment.fov()['nuclei'].max_proj(Indices.CH, Indices.ROUND, Indices.Z)
 
 # merfish doesn't have a dots image, and some of the channels are stronger than others.

--- a/notebooks/py/osmFISH.py
+++ b/notebooks/py/osmFISH.py
@@ -18,8 +18,8 @@ import os
 # EPY: END markdown
 
 # EPY: START code
-test = os.getenv("USE_TEST_DATA") is not None
-experiment = data.osmFISH(test_data=test)
+use_test_data = os.getenv("USE_TEST_DATA") is not None
+experiment = data.osmFISH(use_test_data=use_test_data)
 # EPY: END code
 
 # EPY: START markdown

--- a/starfish/data/__init__.py
+++ b/starfish/data/__init__.py
@@ -1,35 +1,35 @@
 from starfish import Experiment
 
 
-def MERFISH(test_data: bool=False):
-    if test_data:
+def MERFISH(use_test_data: bool=False):
+    if use_test_data:
         return Experiment.from_json(
             'https://dmf0bdeheu4zf.cloudfront.net/20180919/MERFISH-TEST/experiment.json')
     return Experiment.from_json(
         'https://dmf0bdeheu4zf.cloudfront.net/20180924/MERFISH/experiment.json')
 
 
-def allen_smFISH(test_data: bool=False):
+def allen_smFISH(use_test_data: bool=False):
     return Experiment.from_json(
         'https://dmf0bdeheu4zf.cloudfront.net/20180919/allen_smFISH/experiment.json')
 
 
-def DARTFISH(test_data: bool=False):
-    if test_data:
+def DARTFISH(use_test_data: bool=False):
+    if use_test_data:
         return Experiment.from_json(
             'https://dmf0bdeheu4zf.cloudfront.net/20180919/DARTFISH-TEST/experiment.json')
     return Experiment.from_json(
         'https://dmf0bdeheu4zf.cloudfront.net/20180919/DARTFISH/experiment.json')
 
 
-def ISS(test_data: bool=False):
-    if test_data:
+def ISS(use_test_data: bool=False):
+    if use_test_data:
         return Experiment.from_json(
             'https://dmf0bdeheu4zf.cloudfront.net/20180919/ISS-TEST/experiment.json')
     return Experiment.from_json(
         'https://dmf0bdeheu4zf.cloudfront.net/20180919/ISS/experiment.json')
 
 
-def osmFISH(test_data: bool=False):
+def osmFISH(use_test_data: bool=False):
     return Experiment.from_json(
         'https://dmf0bdeheu4zf.cloudfront.net/20180924/osmFISH/experiment.json')

--- a/starfish/test/full_pipelines/api/test_allen_smFISH.py
+++ b/starfish/test/full_pipelines/api/test_allen_smFISH.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from starfish import Experiment
+import starfish.data
 from starfish.image._filter.bandpass import Bandpass
 from starfish.image._filter.clip import Clip
 from starfish.image._filter.gaussian_low_pass import GaussianLowPass
@@ -15,10 +15,7 @@ def test_allen_smFISH_cropped_data():
     np.random.seed(777)
 
     # load the experiment
-    experiment_json = (
-        "https://dmf0bdeheu4zf.cloudfront.net/20180919/allen_smFISH-TEST/experiment.json"
-    )
-    experiment = Experiment.from_json(experiment_json)
+    experiment = starfish.data.allen_smFISH(use_test_data=True)
 
     primary_image = experiment.fov().primary_image
 


### PR DESCRIPTION
1. `test_data` => `use_test_data` for clarity.
2. Use starfish.data for the assay comparison notebook.

Test plan: `python notebooks/py/assay_comparison.py`