### PR TITLE
Make tile_data _not_ a property.

### DIFF
--- a/examples/get_iss_breast_data.py
+++ b/examples/get_iss_breast_data.py
@@ -37,7 +37,6 @@ class IssCroppedBreastTile(FetchedTile):
         crp = img[40:1084, 20:1410]
         return crp
 
-    @property
     def tile_data(self) -> np.ndarray:
         return self.crop(imread(self.file_path))
 

--- a/examples/get_iss_data.py
+++ b/examples/get_iss_data.py
@@ -40,7 +40,6 @@ class ISSTile(FetchedTile):
     def format(self) -> ImageFormat:
         return ImageFormat.TIFF
 
-    @property
     def tile_data(self) -> np.ndarray:
         return imread(self.file_path)
 

--- a/examples/get_merfish_u20s_data.py
+++ b/examples/get_merfish_u20s_data.py
@@ -54,7 +54,6 @@ class MERFISHTile(FetchedTile):
     def format(self) -> ImageFormat:
         return ImageFormat.TIFF
 
-    @property
     def tile_data(self) -> IO:
         im = imread(self.file_path)
         return im[self.map[(self.hyb, self.ch)], :, :]
@@ -73,7 +72,6 @@ class MERFISHAuxTile(FetchedTile):
     def format(self) -> ImageFormat:
         return ImageFormat.TIFF
 
-    @property
     def tile_data(self) -> np.ndarray:
         return imread(self.file_path)[self.dapi_index, :, :]
 

--- a/starfish/experiment/builder/__init__.py
+++ b/starfish/experiment/builder/__init__.py
@@ -103,7 +103,7 @@ def build_image(
                         image.shape,
                         extras=image.extras,
                     )
-                    tile.numpy_array = image.tile_data
+                    tile.numpy_array = image.tile_data()
                     fov_images.add_tile(tile)
         collection.add_partition("fov_{:03}".format(fov_ix), fov_images)
     return collection

--- a/starfish/experiment/builder/defaultproviders.py
+++ b/starfish/experiment/builder/defaultproviders.py
@@ -34,7 +34,6 @@ class RandomNoiseTile(FetchedTile):
     def format(self) -> ImageFormat:
         return ImageFormat.TIFF
 
-    @property
     def tile_data(self) -> np.ndarray:
         return np.random.randint(0, 256, size=self.shape, dtype=np.uint8)
 
@@ -64,7 +63,6 @@ class OnesTile(FetchedTile):
     def format(self) -> ImageFormat:
         return ImageFormat.TIFF
 
-    @property
     def tile_data(self) -> np.ndarray:
         return np.full(shape=self.shape, fill_value=1.0, dtype=np.float32)
 

--- a/starfish/experiment/builder/providers.py
+++ b/starfish/experiment/builder/providers.py
@@ -63,7 +63,6 @@ class FetchedTile:
         """
         raise NotImplementedError()
 
-    @property
     def tile_data(self) -> np.ndarray:
         """Return the image data representing the tile.
 

--- a/starfish/test/image/test_slicedimage_dtype.py
+++ b/starfish/test/image/test_slicedimage_dtype.py
@@ -39,7 +39,6 @@ class OnesTilesByDtype(FetchedTile):
     def format(self) -> ImageFormat:
         return ImageFormat.TIFF
 
-    @property
     def tile_data(self) -> np.ndarray:
         return np.ones((HEIGHT, WIDTH), dtype=self._dtype)
 


### PR DESCRIPTION
This reverses what was done with #658 and partly done in #600 because this allows us to pass tile_data as a future.  This is necessary to prevent memory consumption from blowing up.

Note that this does not actually change how we load the data.  A newer version of slicedimage (one that includes #68) is required to actually take advantage of the future.

Test plan: travis.