### PR TITLE
Fix memory consumption issues with merfish formatter

### DIFF
--- a/REQUIREMENTS-DEV.txt
+++ b/REQUIREMENTS-DEV.txt
@@ -82,7 +82,7 @@ semantic-version==2.6.0
 showit==1.1.4
 simplegeneric==0.8.1
 six==1.11.0
-slicedimage==0.1.0
+slicedimage==1.0.0
 snowballstemmer==1.2.1
 Sphinx==1.8.0
 sphinx-rtd-theme==0.4.1

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -37,7 +37,7 @@ seaborn==0.9.0
 semantic-version==2.6.0
 showit==1.1.4
 six==1.11.0
-slicedimage==0.1.0
+slicedimage==1.0.0
 toolz==0.9.0
 tqdm==4.26.0
 trackpy==0.4.1

--- a/REQUIREMENTS.txt.in
+++ b/REQUIREMENTS.txt.in
@@ -13,7 +13,7 @@ scikit-learn
 scipy
 seaborn
 showit >= 1.1.4
-slicedimage == 0.1.0
+slicedimage == 1.0.0
 scikit-learn
 tqdm
 trackpy

--- a/starfish/experiment/builder/__init__.py
+++ b/starfish/experiment/builder/__init__.py
@@ -103,7 +103,7 @@ def build_image(
                         image.shape,
                         extras=image.extras,
                     )
-                    tile.numpy_array = image.tile_data()
+                    tile.set_numpy_array_future(image.tile_data)
                     fov_images.add_tile(tile)
         collection.add_partition("fov_{:03}".format(fov_ix), fov_images)
     return collection


### PR DESCRIPTION
Use `set_numpy_array_future` to avoid loading the tile data until we start writing out to disk.

Depends on #667 

Fixes https://github.com/spacetx/starfish/issues/666