### PR TITLE
Expose ImageStack's data as an xarray.

### DIFF
--- a/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.ipynb
+++ b/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.ipynb
@@ -91,7 +91,7 @@
    "outputs": [],
    "source": [
     "# round, channel, x, y, z\n",
-    "primary_image.numpy_array.shape"
+    "primary_image.xarray.shape"
    ]
   },
   {

--- a/notebooks/py/ISS_Pipeline_-_Breast_-_1_FOV.py
+++ b/notebooks/py/ISS_Pipeline_-_Breast_-_1_FOV.py
@@ -60,7 +60,7 @@ images = [primary_image, nuclei, dots]
 
 # EPY: START code
 # round, channel, x, y, z
-primary_image.numpy_array.shape
+primary_image.xarray.shape
 # EPY: END code
 
 # EPY: START markdown

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -286,15 +286,9 @@ class ImageStack:
         return empty
 
     @property
-    def numpy_array(self):
-        """Retrieves the image data as a numpy array."""
-        result = self._data.values
-        return result
-
-    @numpy_array.setter
-    def numpy_array(self, data):
-        """Sets the image's data from a numpy array."""
-        self._data.values = data.view()
+    def xarray(self) -> xr.DataArray:
+        """Retrieves the image data as an xarray.DataArray"""
+        return self._data
 
     def get_slice(
             self,
@@ -1126,7 +1120,7 @@ class ImageStack:
         """
         first_dim = self.num_rounds * self.num_chs * self.num_zlayers
         new_shape = (first_dim,) + self.tile_shape
-        new_data = self.numpy_array.reshape(new_shape)
+        new_data = self.xarray.data.reshape(new_shape)
 
         return new_data
 

--- a/starfish/intensity_table.py
+++ b/starfish/intensity_table.py
@@ -303,12 +303,19 @@ class IntensityTable(xr.DataArray):
         zmax = image_stack.shape['z'] - crop_z
         ymax = image_stack.shape['y'] - crop_y
         xmax = image_stack.shape['x'] - crop_x
-        data = image_stack.numpy_array.transpose(2, 3, 4, 1, 0)  # (z, y, x, ch, round)
+        data = image_stack.xarray.transpose(
+            Indices.Z.value,
+            Indices.Y.value,
+            Indices.X.value,
+            Indices.CH.value,
+            Indices.ROUND.value,
+        )
 
         # crop and reshape imagestack to create IntensityTable data
         cropped_data = data[zmin:zmax, ymin:ymax, xmin:xmax, :, :]
         # (pixels, ch, round)
-        intensity_data = cropped_data.reshape(-1, image_stack.num_chs, image_stack.num_rounds)
+        intensity_data = cropped_data.values.reshape(
+            -1, image_stack.num_chs, image_stack.num_rounds)
 
         # IntensityTable pixel coordinates
         z = np.arange(zmin, zmax)

--- a/starfish/test/full_pipelines/api/test_dartfish.py
+++ b/starfish/test/full_pipelines/api/test_dartfish.py
@@ -56,10 +56,10 @@ def test_dartfish_pipeline_cropped_data():
         dtype=np.float32
     )
 
-    assert primary_image.numpy_array.dtype == np.float32
+    assert primary_image.xarray.dtype == np.float32
 
     assert np.allclose(
-        primary_image.numpy_array[0, 0, 0, 50:60, 60:70],
+        primary_image.xarray[0, 0, 0, 50:60, 60:70],
         expected_primary_image
     )
 
@@ -88,10 +88,10 @@ def test_dartfish_pipeline_cropped_data():
           0.01960784, 0.01960784, 0., 0., 0.]],
         dtype=np.float32,
     )
-    assert normalized_image.numpy_array.dtype == np.float32
+    assert normalized_image.xarray.dtype == np.float32
 
     assert np.allclose(
-        normalized_image.numpy_array[0, 0, 0, 50:60, 60:70],
+        normalized_image.xarray[0, 0, 0, 50:60, 60:70],
         expected_normalized_image
     )
 
@@ -123,7 +123,7 @@ def test_dartfish_pipeline_cropped_data():
 
     assert np.allclose(
         expected_zero_normalized_image,
-        zero_norm_stack.numpy_array[0, 0, 0, 50:60, 60:70]
+        zero_norm_stack.xarray[0, 0, 0, 50:60, 60:70]
     )
 
     spot_intensities = dartfish.initial_spot_intensities

--- a/starfish/test/full_pipelines/api/test_iss_api.py
+++ b/starfish/test/full_pipelines/api/test_iss_api.py
@@ -46,11 +46,11 @@ def test_iss_pipeline_cropped_data():
         dtype=np.float32
     )
 
-    assert white_top_hat_filtered_image.numpy_array.dtype == np.float32
+    assert white_top_hat_filtered_image.xarray.dtype == np.float32
 
     assert np.allclose(
         expected_filtered_values,
-        white_top_hat_filtered_image.numpy_array[2, 2, 0, 40:50, 40:50]
+        white_top_hat_filtered_image.xarray[2, 2, 0, 40:50, 40:50]
     )
 
     registered_image = iss.registered_image
@@ -91,7 +91,7 @@ def test_iss_pipeline_cropped_data():
     )
     assert np.allclose(
         expected_registered_values,
-        registered_image.numpy_array[2, 2, 0, 40:50, 40:50]
+        registered_image.xarray[2, 2, 0, 40:50, 40:50]
     )
 
     intensities = iss.intensities

--- a/starfish/test/full_pipelines/api/test_merfish.py
+++ b/starfish/test/full_pipelines/api/test_merfish.py
@@ -46,7 +46,7 @@ def test_merfish_pipeline_cropped_data():
     )
     assert np.allclose(
         expected_primary_image,
-        primary_image.numpy_array[5, 0, 0, 40:50, 45:55]
+        primary_image.xarray[5, 0, 0, 40:50, 45:55]
     )
 
     high_passed = merfish.high_passed
@@ -87,7 +87,7 @@ def test_merfish_pipeline_cropped_data():
 
     assert np.allclose(
         expected_high_passed,
-        high_passed.numpy_array[5, 0, 0, 40:50, 45:55]
+        high_passed.xarray[5, 0, 0, 40:50, 45:55]
     )
 
     deconvolved = merfish.deconvolved
@@ -129,7 +129,7 @@ def test_merfish_pipeline_cropped_data():
 
     assert np.allclose(
         expected_deconvolved_values,
-        deconvolved.numpy_array[5, 0, 0, 40:50, 45:55]
+        deconvolved.xarray[5, 0, 0, 40:50, 45:55]
     )
 
     low_passed = merfish.low_passed
@@ -169,7 +169,7 @@ def test_merfish_pipeline_cropped_data():
     )
     assert np.allclose(
         expected_low_passed,
-        low_passed.numpy_array[5, 0, 0, 40:50, 45:55]
+        low_passed.xarray[5, 0, 0, 40:50, 45:55]
     )
 
     scaled_image = merfish.scaled_image
@@ -210,7 +210,7 @@ def test_merfish_pipeline_cropped_data():
     )
     assert np.allclose(
         expected_scaled_low_passed,
-        scaled_image.numpy_array[5, 0, 0, 40:50, 45:55]
+        scaled_image.xarray[5, 0, 0, 40:50, 45:55]
     )
 
     spot_intensities = merfish.initial_spot_intensities

--- a/starfish/test/image/test_apply.py
+++ b/starfish/test/image/test_apply.py
@@ -13,17 +13,17 @@ def divide(array, value):
 def test_apply():
     """test that apply correctly applies a simple function across 2d tiles of a Stack"""
     stack = ImageStack.synthetic_stack()
-    assert (stack.numpy_array == 1).all()
+    assert (stack.xarray == 1).all()
     output = stack.apply(divide, value=2)
-    assert (output.numpy_array == 0.5).all()
+    assert (output.xarray == 0.5).all()
 
 
 def test_apply_3d():
     """test that apply correctly applies a simple function across 3d volumes of a Stack"""
     stack = ImageStack.synthetic_stack()
-    assert np.all(stack.numpy_array == 1)
+    assert np.all(stack.xarray == 1)
     output = stack.apply(divide, value=4, is_volume=True)
-    assert (output.numpy_array == 0.25).all()
+    assert (output.xarray == 0.25).all()
 
 
 def test_apply_labeled_dataset():
@@ -32,7 +32,7 @@ def test_apply_labeled_dataset():
     """
     original = SyntheticData().spots()
     image = original.apply(divide, value=2)
-    assert np.all(image.numpy_array == original.numpy_array / 2)
+    assert np.all(image.xarray == original.xarray / 2)
 
 
 def test_apply_in_place():
@@ -43,4 +43,4 @@ def test_apply_in_place():
     image = SyntheticData().spots()
     original = copy.deepcopy(image)
     image.apply(divide, value=2, in_place=True)
-    assert np.all(image.numpy_array == original.numpy_array / 2)
+    assert np.all(image.xarray == original.xarray / 2)

--- a/starfish/test/image/test_imagestack.py
+++ b/starfish/test/image/test_imagestack.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import xarray as xr
 
 from starfish.imagestack.imagestack import ImageStack
 from starfish.intensity_table import IntensityTable
@@ -161,7 +162,7 @@ def test_from_numpy_array_raises_error_when_incorrect_dims_passed():
 def test_from_numpy_array_automatically_handles_float_conversions():
     x = np.zeros((1, 1, 1, 20, 20), dtype=np.uint16)
     stack = ImageStack.from_numpy_array(x)
-    assert stack.numpy_array.dtype == np.float32
+    assert stack.xarray.dtype == np.float32
 
 
 def test_max_projection_preserves_dtype():
@@ -210,10 +211,16 @@ def test_synthetic_spot_creation_produces_an_imagestack_with_correct_spot_locati
         z[breaks[i]: breaks[i + 1]] = true_intensities.coords[Indices.Z.value][i]
 
     # only 8 values should be set, since there are only 8 locations across the tensor
-    assert np.sum(image.numpy_array != 0) == 8
+    assert np.sum(image.xarray != 0) == 8
 
+    intensities = image.xarray.isel(
+        x=xr.DataArray(x, dims=['intensity']),
+        y=xr.DataArray(y, dims=['intensity']),
+        z=xr.DataArray(z, dims=['intensity']),
+        r=xr.DataArray(r, dims=['intensity']),
+        c=xr.DataArray(c, dims=['intensity']))
     assert np.allclose(
-        image.numpy_array[r, c, z, y, x],
+        intensities,
         true_intensities.values[np.where(true_intensities)])
 
 

--- a/starfish/test/image/test_slicedimage_dtype.py
+++ b/starfish/test/image/test_slicedimage_dtype.py
@@ -90,7 +90,7 @@ def test_multiple_tiles_of_same_dtype():
          NUM_Z,
          HEIGHT,
          WIDTH), dtype=np.uint32)
-    assert np.array_equal(stack.numpy_array, img_as_float32(expected))
+    assert np.array_equal(stack.xarray, img_as_float32(expected))
 
 
 def test_int_type_promotion():
@@ -113,7 +113,7 @@ def test_int_type_promotion():
         (HEIGHT,
          WIDTH), dtype=np.int8))
     expected[0, 0, 0] = corner
-    assert np.array_equal(stack.numpy_array, img_as_float32(expected))
+    assert np.array_equal(stack.xarray, img_as_float32(expected))
 
 
 def test_uint_type_promotion():
@@ -136,7 +136,7 @@ def test_uint_type_promotion():
         (HEIGHT,
          WIDTH), dtype=np.uint8))
     expected[0, 0, 0] = corner
-    assert np.array_equal(stack.numpy_array, img_as_float32(expected))
+    assert np.array_equal(stack.xarray, img_as_float32(expected))
 
 
 def test_float_type_demotion():
@@ -155,4 +155,4 @@ def test_float_type_demotion():
          NUM_Z,
          HEIGHT,
          WIDTH), dtype=np.float64)
-    assert np.array_equal(stack.numpy_array, expected)
+    assert np.array_equal(stack.xarray, expected)

--- a/starfish/test/pipeline/test_filter.py
+++ b/starfish/test/pipeline/test_filter.py
@@ -21,10 +21,10 @@ def random_data_image_stack_factory():
 def test_gaussian_high_pass(sigma: Union[Number, Tuple[Number]], is_volume: bool) -> None:
     """high pass is subtractive, sum of array should be less after running."""
     image_stack = random_data_image_stack_factory()
-    sum_before = np.sum(image_stack.numpy_array)
+    sum_before = np.sum(image_stack.xarray)
     ghp = gaussian_high_pass.GaussianHighPass(sigma=sigma, is_volume=is_volume)
     result = ghp.run(image_stack)
-    assert np.sum(result.numpy_array) < sum_before
+    assert np.sum(result.xarray) < sum_before
 
 @pytest.mark.parametrize('size, is_volume', [
     (1, False),
@@ -34,7 +34,7 @@ def test_gaussian_high_pass(sigma: Union[Number, Tuple[Number]], is_volume: bool
 def test_mean_high_pass(size: Union[Number, Tuple[Number]], is_volume: bool) -> None:
     """high pass is subtractive, sum of array should be less after running."""
     image_stack = random_data_image_stack_factory()
-    sum_before = np.sum(image_stack.numpy_array)
+    sum_before = np.sum(image_stack.xarray)
     mhp = mean_high_pass.MeanHighPass(size=size, is_volume=is_volume)
     result = mhp.run(image_stack)
-    assert np.sum(result.numpy_array) < sum_before
+    assert np.sum(result.xarray) < sum_before

--- a/starfish/test/test_stack_intensity_table_reshaping.py
+++ b/starfish/test/test_stack_intensity_table_reshaping.py
@@ -17,7 +17,7 @@ def test_reshaping_between_stack_and_intensities():
     pixel_intensities = IntensityTable.from_image_stack(image, 0, 0, 0)
     image_shape = (image.shape['z'], image.shape['y'], image.shape['x'])
     image_from_pixels = pixel_intensities_to_imagestack(pixel_intensities, image_shape)
-    assert np.array_equal(image.numpy_array, image_from_pixels.numpy_array)
+    assert np.array_equal(image.xarray, image_from_pixels.xarray)
 
 
 def pixel_intensities_to_imagestack(

--- a/starfish/util/synthesize.py
+++ b/starfish/util/synthesize.py
@@ -114,5 +114,5 @@ class SyntheticData:
             intensities, self.n_z, self.height, self.width, self.n_photons_background,
             self.point_spread_function, self.camera_detection_efficiency,
             self.background_electrons, self.gray_level, self.ad_coversion_bits)
-        assert stack.numpy_array.dtype == np.float32
+        assert stack.xarray.dtype == np.float32
         return stack


### PR DESCRIPTION
Most of this is straightforward, except for `starfish/test/image/test_imagestack.py::test_synthetic_spot_creation_produces_an_imagestack_with_correct_spot_location`, which is complicated because advanced indexing is wonky in xarray.

Test plan: make -j fast run_notebooks

Fixes #673