### PR TITLE
[osmFISH 3/5] Re-name LocalMaxPeakFinder -> TrackpyLocalMaxPeakFinder

### DIFF
--- a/starfish/spots/_detector/__init__.py
+++ b/starfish/spots/_detector/__init__.py
@@ -9,8 +9,8 @@ from starfish.types import Indices
 from starfish.util.argparse import FsExistsType
 from . import _base
 from . import gaussian
-from . import local_max_peak_finder
 from . import pixel_spot_detector
+from . import trackpy_local_max_peak_finder
 
 
 class SpotFinder(PipelineComponent):

--- a/starfish/spots/_detector/trackpy_local_max_peak_finder.py
+++ b/starfish/spots/_detector/trackpy_local_max_peak_finder.py
@@ -12,7 +12,7 @@ from ._base import SpotFinderAlgorithmBase
 from .detect import detect_spots
 
 
-class LocalMaxPeakFinder(SpotFinderAlgorithmBase):
+class TrackpyLocalMaxPeakFinder(SpotFinderAlgorithmBase):
 
     def __init__(
             self, spot_diameter, min_mass, max_size, separation, percentile=0,

--- a/starfish/test/full_pipelines/api/test_allen_smFISH.py
+++ b/starfish/test/full_pipelines/api/test_allen_smFISH.py
@@ -5,7 +5,7 @@ import starfish.data
 from starfish.image._filter.bandpass import Bandpass
 from starfish.image._filter.clip import Clip
 from starfish.image._filter.gaussian_low_pass import GaussianLowPass
-from starfish.spots._detector.local_max_peak_finder import LocalMaxPeakFinder
+from starfish.spots._detector.trackpy_local_max_peak_finder import TrackpyLocalMaxPeakFinder
 
 
 @pytest.mark.skip('issues with checksums prevent this data from working properly')
@@ -32,7 +32,7 @@ def test_allen_smFISH_cropped_data():
     glp = GaussianLowPass(sigma=sigma, is_volume=True)
     z_filtered_image = glp.run(clipped_bandpassed_image, in_place=False)
 
-    lmpf = LocalMaxPeakFinder(
+    lmpf = TrackpyLocalMaxPeakFinder(
         spot_diameter=3,
         min_mass=300,
         max_size=3,

--- a/starfish/test/spots/detector/test_spot_detection.py
+++ b/starfish/test/spots/detector/test_spot_detection.py
@@ -6,7 +6,7 @@ from starfish.imagestack.imagestack import ImageStack
 from starfish.spots._detector._base import SpotFinderAlgorithmBase
 from starfish.spots._detector.detect import detect_spots
 from starfish.spots._detector.gaussian import GaussianSpotDetector
-from starfish.spots._detector.local_max_peak_finder import LocalMaxPeakFinder
+from starfish.spots._detector.trackpy_local_max_peak_finder import TrackpyLocalMaxPeakFinder
 from starfish.types import Indices
 
 
@@ -21,9 +21,9 @@ def simple_gaussian_spot_detector() -> GaussianSpotDetector:
     )
 
 
-def simple_local_max_spot_detector() -> LocalMaxPeakFinder:
+def simple_local_max_spot_detector() -> TrackpyLocalMaxPeakFinder:
     """create a basic local max peak finder"""
-    return LocalMaxPeakFinder(
+    return TrackpyLocalMaxPeakFinder(
         spot_diameter=3,
         min_mass=0.01,
         max_size=10,


### PR DESCRIPTION
osmFISH uses a different peak finding algorithm implementation than the one we implemented for allensmFISH. To avoid confusion, I've re-named the Trackpy one to LocalMaxPeakFinder. 

[osmFISH 4/5] implements another local max peak finding algorithm that comes from skimage. I call that one LocalMaxPeakFinder instead such that we can differentiate.