### PR TITLE
Updated test_api_contract.py to use .xarray instead of .numpy_array

### DIFF
--- a/starfish/test/image/filter/test_api_contract.py
+++ b/starfish/test/image/filter/test_api_contract.py
@@ -84,8 +84,8 @@ def test_all_methods_adhere_to_contract(filter_class):
         raise AssertionError(f'{filter_class} must accept verbose parameter')
 
     # output is dtype float and within the expected interval of [0, 1]
-    assert filtered.numpy_array.dtype == np.float32, f'{filter_class} must output float32 data'
-    assert np.all(filtered.numpy_array >= 0), \
+    assert filtered.xarray.dtype == np.float32, f'{filter_class} must output float32 data'
+    assert np.all(filtered.xarray >= 0), \
         f'{filter_class} must output a result where all values are >= 0'
-    assert np.all(filtered.numpy_array <= 1), \
+    assert np.all(filtered.xarray <= 1), \
         f'{filter_class} must output a result where all values are <= 1'

--- a/starfish/test/image/filter/test_zero_by_channel_magnitude.py
+++ b/starfish/test/image/filter/test_zero_by_channel_magnitude.py
@@ -18,4 +18,4 @@ def test_zero_by_channel_magnitude_produces_accurate_results():
 
     zcm = ZeroByChannelMagnitude(thresh=np.inf, normalize=False, is_volume=False)
     filtered = zcm.run(imagestack, in_place=False, n_processes=1)
-    assert np.all(filtered.numpy_array == 0)
+    assert np.all(filtered.xarray == 0)

--- a/starfish/test/image/test_imagestack_coordinates.py
+++ b/starfish/test/image/test_imagestack_coordinates.py
@@ -48,7 +48,6 @@ class OffsettedTiles(FetchedTile):
     def format(self) -> ImageFormat:
         return ImageFormat.TIFF
 
-    @property
     def tile_data(self) -> np.ndarray:
         return np.ones((HEIGHT, WIDTH), dtype=np.float32)
 
@@ -113,7 +112,6 @@ class OffsettedScalarTiles(FetchedTile):
     def format(self) -> ImageFormat:
         return ImageFormat.TIFF
 
-    @property
     def tile_data(self) -> np.ndarray:
         return np.ones((HEIGHT, WIDTH), dtype=np.float32)
 


### PR DESCRIPTION
Test plan: `pytest starfish/test/image/filter/test_api_contract.py`