### PR TITLE
Ajc experiment docs

### DIFF
--- a/docs/source/API/core_objects/codebook.rst
+++ b/docs/source/API/core_objects/codebook.rst
@@ -1,3 +1,5 @@
+.. _Codebook:
+
 Codebook
 ========
 

--- a/docs/source/API/core_objects/experiment.rst
+++ b/docs/source/API/core_objects/experiment.rst
@@ -1,0 +1,7 @@
+.. _Experiment:
+
+Experiment
+==========
+
+.. autoclass:: starfish.experiment.experiment.Experiment
+    :members:

--- a/docs/source/API/core_objects/field_of_view.rst
+++ b/docs/source/API/core_objects/field_of_view.rst
@@ -1,0 +1,7 @@
+.. _FieldOfView:
+
+Field of View
+=============
+
+.. autoclass:: starfish.experiment.experiment.FieldOfView
+    :members:

--- a/docs/source/API/core_objects/image_stack.rst
+++ b/docs/source/API/core_objects/image_stack.rst
@@ -1,3 +1,5 @@
+.. _ImageStack:
+
 ImageStack
 ==========
 

--- a/docs/source/API/core_objects/index.rst
+++ b/docs/source/API/core_objects/index.rst
@@ -11,7 +11,7 @@ to enable fine registration).
 
 Both Primary and Auxiliary Images are referenced by slicedimage_ TileSet_ objects, which map
 two dimensional image tiles stored on disk into a 5-dimensional Image Tensor that labels each
-``(z, y, z)`` tile with the ``round`` and ``channel`` that it corresponds to. When loaded into
+``(z, y, x)`` tile with the ``round`` and ``channel`` that it corresponds to. When loaded into
 memory, these Image Tensors are stored in :ref:`ImageStack` objects. The :ref:`ImageStack` is what
 starfish uses to execute image pre-processing, and serves as the substrate for spot finding.
 

--- a/docs/source/API/core_objects/index.rst
+++ b/docs/source/API/core_objects/index.rst
@@ -1,11 +1,47 @@
-.. _coreobjects
-
 Core Objects
 ============
+
+The top-level object in a starfish workflow is the :ref:`Experiment`. It is composed of one or more
+:ref:`FieldOfView` objects, and a :ref:`Codebook`, which maps detected spots to the entities they
+target.
+
+Each :ref:`FieldOfView` consists of a set of Primary Images and optionally, Auxiliary images that
+may contain information on nuclei (often used to seed segmentation) or fiduciary beads (often used
+to enable fine registration).
+
+Both Primary and Auxiliary Images are referenced by slicedimage_ TileSet_ objects, which map
+two dimensional image tiles stored on disk into a 5-dimensional Image Tensor that labels each
+``(z, y, z)`` tile with the ``round`` and ``channel`` that it corresponds to. When loaded into
+memory, these Image Tensors are stored in :ref:`ImageStack` objects. The :ref:`ImageStack` is what
+starfish uses to execute image pre-processing, and serves as the substrate for spot finding.
+
+Identified spots are stored in the :ref:`IntensityTable`, which stores the intensity of the spot
+across each of the rounds and channels that it is detected in. It also stores assigned genes when
+decoded with a :ref:`Codebook` and assigned cells when combined with a segmentation results.
+
+Finally, the :ref:`IntensityTable` can be converted into an :ref:`ExpressionMatrix` by summing all
+of the spots detected for each gene across each cell. The ExpressionMatrix provides conversion and
+serialization for use in single-cell analysis environments such as Seurat_ and Scanpy_.
+
+.. TODO ambrosejcarr: think about removing PipelineComponent to another part of the docs
+
+.. _slicedimage: https://github.com/spacetx/slicedimage
+
+.. _TileSet: https://github.com/spacetx/slicedimage/blob/master/slicedimage/_tileset.py
+
+.. _Seurat: https://satijalab.org/seurat/
+
+.. _Scanpy: https://scanpy.readthedocs.io/en/latest/
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
+
+.. toctree::
+   experiment.rst
+
+.. toctree::
+   field_of_view.rst
 
 .. toctree::
    image_stack.rst

--- a/docs/source/API/core_objects/intensity_table.rst
+++ b/docs/source/API/core_objects/intensity_table.rst
@@ -1,3 +1,5 @@
+.. _IntensityTable:
+
 IntensityTable
 ==============
 

--- a/starfish/experiment/experiment.py
+++ b/starfish/experiment/experiment.py
@@ -20,12 +20,15 @@ class FieldOfView:
 
     Auxiliary images can be accessed using a key, i.e., FOV[aux_image_type].
 
-    Properties
+    Attributes
     ----------
-    name                   The name of the FOV.  In an experiment with only a single FOV, this may
-                           be None.
-    primary_image          The primary image for this field of view.
-    auxiliary_image_types  A set of all the auxiliary image types.
+    name : str
+        The name of the FOV.  In an experiment with only a single FOV, this may be None.
+    primary_image : ImageStack
+        The primary image for this field of view. Calling this property will load the data into
+        memory
+    auxiliary_image_types : Mapping[str, TileSet]
+        A set of all the auxiliary image types.
 
     """
     def __init__(
@@ -102,24 +105,27 @@ class Experiment:
     This encapsulates an experiment, with one or more fields of view and a codebook.  An individual
     FOV can be retrieved using a key, i.e., experiment[fov_name].
 
-    Constructors
-    ------------
-    from_json     Given a URL or a path to an experiment.json document, return an Experiment object
-                  corresponding to the document.
-
     Methods
     -------
-    fov           Given a callable that accepts a FOV, return the first FOVs that the callable
-                  returns True when passed the FOV.  Because there is no guaranteed sorting for the
-                  FOVs, use this cautiously.
-    fovs          Given a callable that accepts a FOV, return all the FOVs that the callable returns
-                  True when passed the FOV.
-    fovs_by_name  Given one or more FOV names, return the FOVs that match those names.
+    from_json()
+        Given a URL or a path to an experiment.json document, return an Experiment object
+        corresponding to the document.
+    fov()
+        Given a callable that accepts a FOV, return the first FOVs that the callable returns True
+        when passed the FOV.  Because there is no guaranteed sorting for the FOVs, use this
+        cautiously.
+    fovs()
+        Given a callable that accepts a FOV, return all the FOVs that the callable returns True when
+        passed the FOV.
+    fovs_by_name()
+        Given one or more FOV names, return the FOVs that match those names.
 
-    Properties
+    Attributes
     ----------
-    codebook      Returns the codebook associated with this experiment.
-    extras        Returns the extras dictionary associated with this experiment.
+    codebook : Codebook
+        Returns the codebook associated with this experiment.
+    extras : Dict
+        Returns the extras dictionary associated with this experiment.
     """
     def __init__(
             self,
@@ -165,19 +171,15 @@ class Experiment:
         strict : bool
             if true, then all JSON loaded by this method will be
             passed to the appropriate validator
+        STARFISH_STRICT_LOADING :
+             This parameter is read from the environment. If set, then all JSON loaded by this
+             method will be passed to the appropriate validator. The `strict` parameter to this
+             method has priority over the environment variable.
 
         Returns
         -------
         Experiment :
             Experiment object serving the requested experiment data
-
-        Environment variables
-        ---------------------
-        STARFISH_STRICT_LOADING :
-             If set, then all JSON loaded by this method will be
-             passed to the appropriate validator. The `strict`
-             parameter to this method has priority over the
-             environment variable.
 
         """
         if strict is None:

--- a/starfish/experiment/experiment.py
+++ b/starfish/experiment/experiment.py
@@ -21,11 +21,12 @@ class FieldOfView:
     Auxiliary images can be accessed using a key, i.e., FOV[aux_image_type].
 
     Properties
-    -------
+    ----------
     name                   The name of the FOV.  In an experiment with only a single FOV, this may
                            be None.
     primary_image          The primary image for this field of view.
     auxiliary_image_types  A set of all the auxiliary image types.
+
     """
     def __init__(
             self,
@@ -102,7 +103,7 @@ class Experiment:
     FOV can be retrieved using a key, i.e., experiment[fov_name].
 
     Constructors
-    -------
+    ------------
     from_json     Given a URL or a path to an experiment.json document, return an Experiment object
                   corresponding to the document.
 
@@ -116,7 +117,7 @@ class Experiment:
     fovs_by_name  Given one or more FOV names, return the FOVs that match those names.
 
     Properties
-    -------
+    ----------
     codebook      Returns the codebook associated with this experiment.
     extras        Returns the extras dictionary associated with this experiment.
     """


### PR DESCRIPTION
- Links Experiment and Field of View to the docs. 
- Refactors some docstrings in the above files so sphinx doesn't choke on them (with some textual changes, please check my modifications). 

Also I discovered how to make internal links with ```:ref:`ReferenceName` ```. I'll start weaving those into the docs. 