### PR TITLE
fixing float bug

### DIFF
--- a/starfish/image/_filter/bandpass.py
+++ b/starfish/image/_filter/bandpass.py
@@ -81,7 +81,7 @@ class Bandpass(FilterAlgorithmBase):
             image, lshort=lshort, llong=llong, threshold=threshold,
             truncate=truncate
         )
-        return bandpassed
+        return bandpassed.astype(np.float32)
 
     def run(
             self, stack: ImageStack, in_place: bool=False, verbose: bool=False,


### PR DESCRIPTION
I discovered this bug while trying to test something else. But the preprocessing library used by the bandpass filter returns results in float64. 