### PR TITLE
Fix assay_comparison and ISS notebooks

### DIFF
--- a/REQUIREMENTS-DEV.txt
+++ b/REQUIREMENTS-DEV.txt
@@ -82,7 +82,7 @@ semantic-version==2.6.0
 showit==1.1.4
 simplegeneric==0.8.1
 six==1.11.0
-slicedimage==1.0.0
+slicedimage==1.0.1
 snowballstemmer==1.2.1
 Sphinx==1.8.0
 sphinx-rtd-theme==0.4.1

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -37,7 +37,7 @@ seaborn==0.9.0
 semantic-version==2.6.0
 showit==1.1.4
 six==1.11.0
-slicedimage==1.0.0
+slicedimage==1.0.1
 toolz==0.9.0
 tqdm==4.26.0
 trackpy==0.4.1

--- a/REQUIREMENTS.txt.in
+++ b/REQUIREMENTS.txt.in
@@ -13,7 +13,7 @@ scikit-learn
 scipy
 seaborn
 showit >= 1.1.4
-slicedimage == 1.0.0
+slicedimage == 1.0.1
 scikit-learn
 tqdm
 trackpy

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [line.rstrip() for line in open(os.path.join(os.path.dirname(
 
 setuptools.setup(
     name="starfish",
-    version="0.0.25",
+    version="0.0.26",
     description="Pipelines and pipeline components for the analysis of image-based transcriptomics data",
     author="Deep Ganguli",
     author_email="dganguli@chanzuckerberg.com",


### PR DESCRIPTION
Both notebooks had datasets where the tile shapes were not consistently provided.  https://github.com/spacetx/slicedimage/pull/72 broke the recording of the tile shape, and https://github.com/spacetx/slicedimage/pull/73 fixes it.

Test plan: `make -j run__notebooks/py/ISS_Pipeline_-_Breast_-_1_FOV.py run__notebooks/py/assay_comparison.py`