### PR TITLE
Merge primary_image and auxiliary_images.

### DIFF
--- a/docs/source/debugging.rst
+++ b/docs/source/debugging.rst
@@ -18,8 +18,8 @@ data that was updated to work post-update:
 
 .. code-block:: diff
 
-    - http://czi.starfish.data.public.s3.amazonaws.com/browse/formatted/20180823/iss_breast/experiment.json
-    + http://czi.starfish.data.public.s3.amazonaws.com/browse/formatted/20180926/iss_breast/experiment.json
+    - http://spacetx.starfish.data.public.s3.amazonaws.com/browse/formatted/20180823/iss_breast/experiment.json
+    + http://spacetx.starfish.data.public.s3.amazonaws.com/browse/formatted/20180926/iss_breast/experiment.json
 
 If you're using your own data with starfish, you may need to re-run your data ingestion workflow
 based on :ref:`TileFetcher` and :ref:`FetchedTile` to generate up-to-date versions of spaceTx-format.

--- a/docs/source/usage/iss/iss_pipeline.py
+++ b/docs/source/usage/iss/iss_pipeline.py
@@ -9,7 +9,7 @@ test = os.getenv("TESTING") is not None
 
 
 def iss_pipeline(fov, codebook):
-    primary_image = fov.primary_image
+    primary_image = fov[starfish.FieldOfView.PRIMARY_IMAGES]
 
     # register the raw images
     registration = Registration.FourierShiftRegistration(
@@ -68,7 +68,12 @@ def process_experiment(experiment: starfish.Experiment):
 
 # run the script
 if test:
-    exp = starfish.Experiment.from_json("https://dmf0bdeheu4zf.cloudfront.net/browse/formatted/20180926/iss_breast/experiment.json", True)
+    # TODO: (ttung) Pending a fix for https://github.com/spacetx/starfish/issues/700, it's not
+    # possible to validate the schema for this experiment.
+    exp = starfish.Experiment.from_json(
+        "https://d2nhj9g34unfro.cloudfront.net/browse/formatted/20180926/iss_breast/experiment.json",
+        False,
+    )
 else:
     exp = starfish.Experiment.from_json("iss/formatted/experiment.json")
 decoded_intensities, regions = process_experiment(exp)

--- a/examples/get_cli_test_data.py
+++ b/examples/get_cli_test_data.py
@@ -5,7 +5,7 @@ import posixpath
 
 import requests
 
-from starfish import Experiment
+from starfish import Experiment, FieldOfView
 from starfish.util.argparse import FsExistsType
 
 
@@ -21,8 +21,10 @@ if __name__ == "__main__":
     for fov in exp.fovs():
         fov_dir = pathlib.Path(args.output_dir, fov.name)
         fov_dir.mkdir()
-        fov.primary_image.write(str(fov_dir / "hybridization.json"))
-        for image_type in fov.auxiliary_image_types:
+        fov[FieldOfView.PRIMARY_IMAGES].write(str(fov_dir / "hybridization.json"))
+        for image_type in fov.image_types:
+            if image_type == FieldOfView.PRIMARY_IMAGES:
+                continue
             fov[image_type].write(str(fov_dir / f"{image_type}.json"))
 
     # get codebook from url and save locally to tmp dir

--- a/notebooks/DARTFISH_Pipeline_-_Human_Occipital_Cortex_-_1_FOV.ipynb
+++ b/notebooks/DARTFISH_Pipeline_-_Human_Occipital_Cortex_-_1_FOV.ipynb
@@ -23,7 +23,7 @@
     "import seaborn as sns\n",
     "import os\n",
     "\n",
-    "from starfish import data\n",
+    "from starfish import data, FieldOfView\n",
     "from starfish.types import Features, Indices\n",
     "\n",
     "from starfish import IntensityTable\n",
@@ -53,7 +53,7 @@
     "use_test_data = os.getenv(\"USE_TEST_DATA\") is not None\n",
     "exp = data.DARTFISH(use_test_data=use_test_data)\n",
     "\n",
-    "stack = exp.fov().primary_image"
+    "stack = exp.fov()[FieldOfView.PRIMARY_IMAGES]"
    ]
   },
   {
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cnts_benchmark = pd.read_csv('https://dmf0bdeheu4zf.cloudfront.net/20180926/DARTFISH/fov_001/counts.csv')\n",
+    "cnts_benchmark = pd.read_csv('https://d2nhj9g34unfro.cloudfront.net/20181005/DARTFISH/fov_001/counts.csv')\n",
     "cnts_benchmark.head()"
    ]
   },

--- a/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.ipynb
+++ b/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.ipynb
@@ -28,7 +28,7 @@
     "from showit import image\n",
     "import pprint\n",
     "\n",
-    "from starfish import data\n",
+    "from starfish import data, FieldOfView\n",
     "from starfish.types import Features, Indices"
    ]
   },
@@ -78,7 +78,7 @@
    "outputs": [],
    "source": [
     "fov = experiment.fov()\n",
-    "primary_image = fov.primary_image\n",
+    "primary_image = fov[FieldOfView.PRIMARY_IMAGES]\n",
     "dots = fov['dots']\n",
     "nuclei = fov['nuclei']\n",
     "images = [primary_image, nuclei, dots]"

--- a/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
+++ b/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
@@ -35,7 +35,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "from showit import image as show_image\n",
-    "from starfish import data\n",
+    "from starfish import data, FieldOfView\n",
     "from starfish.types import Features, Indices"
    ]
   },
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "primary_image = experiment.fov().primary_image"
+    "primary_image = experiment.fov()[FieldOfView.PRIMARY_IMAGES]"
    ]
   },
   {
@@ -305,7 +305,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bench = pd.read_csv('https://dmf0bdeheu4zf.cloudfront.net/MERFISH/benchmark_results.csv',\n",
+    "bench = pd.read_csv('https://d2nhj9g34unfro.cloudfront.net/MERFISH/benchmark_results.csv',\n",
     "                    dtype = {'barcode':object})\n",
     "\n",
     "benchmark_counts = bench.groupby('gene')['gene'].count()\n",

--- a/notebooks/allen_smFISH.ipynb
+++ b/notebooks/allen_smFISH.ipynb
@@ -21,7 +21,7 @@
     "import numpy as np\n",
     "import os\n",
     "\n",
-    "from starfish import data\n",
+    "from starfish import data, FieldOfView\n",
     "from starfish.types import Indices"
    ]
   },
@@ -49,7 +49,7 @@
    "source": [
     "use_test_data = os.getenv(\"USE_TEST_DATA\") is not None\n",
     "experiment = data.allen_smFISH(use_test_data=use_test_data)\n",
-    "primary_image = experiment.fov().primary_image"
+    "primary_image = experiment.fov()[FieldOfView.PRIMARY_IMAGES]"
    ]
   },
   {

--- a/notebooks/assay_comparison.ipynb
+++ b/notebooks/assay_comparison.ipynb
@@ -34,7 +34,7 @@
    "outputs": [],
    "source": [
     "# science\n",
-    "from starfish import IntensityTable, Experiment, ImageStack\n",
+    "from starfish import IntensityTable, Experiment, FieldOfView, ImageStack\n",
     "from starfish.plot import histogram, compare_copy_number\n",
     "from starfish.plot.decoded_spots import decoded_spots\n",
     "from starfish.types import Features, Indices\n",
@@ -59,7 +59,7 @@
    "source": [
     "# IntensityTable can't download from directories without list privileges\n",
     "\n",
-    "data_root = \"https://dmf0bdeheu4zf.cloudfront.net/assay_comparison/\"\n",
+    "data_root = \"https://d2nhj9g34unfro.cloudfront.net/assay_comparison/\"\n",
     "iss_link = os.path.join(data_root, \"iss.nc\")\n",
     "merfish_link = os.path.join(data_root, \"merfish.nc\")\n",
     "dartfish_link = os.path.join(data_root, \"dartfish.nc\")\n",
@@ -140,7 +140,7 @@
     "\n",
     "# merfish doesn't have a dots image, and some of the channels are stronger than others.\n",
     "# We can use the scale factors to get the right levels\n",
-    "merfish_background = experiment.fov().primary_image.max_proj(Indices.CH, Indices.ROUND)\n",
+    "merfish_background = experiment.fov()[FieldOfView.PRIMARY_IMAGES].max_proj(Indices.CH, Indices.ROUND)\n",
     "merfish_background = np.reshape(merfish_background, (1, 1, *merfish_background.shape))\n",
     "merfish_background = ImageStack.from_numpy_array(merfish_background)\n",
     "\n",
@@ -349,7 +349,7 @@
    "outputs": [],
    "source": [
     "dartfish_copy_number = pd.read_csv(\n",
-    "    'https://dmf0bdeheu4zf.cloudfront.net/20180926/DARTFISH/fov_001/counts.csv',\n",
+    "    'https://d2nhj9g34unfro.cloudfront.net/20181005/DARTFISH/fov_001/counts.csv',\n",
     "    index_col=0,\n",
     "    squeeze=True\n",
     ")\n",

--- a/notebooks/osmFISH.ipynb
+++ b/notebooks/osmFISH.ipynb
@@ -13,7 +13,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from starfish import data\n",
+    "from starfish import data, FieldOfView\n",
     "from starfish.types import Indices\n",
     "import os"
    ]
@@ -48,7 +48,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "image = experiment.fov().primary_image\n",
+    "image = experiment.fov()[FieldOfView.PRIMARY_IMAGES]\n",
     "image.show_stack({Indices.CH: 0})"
    ]
   }

--- a/notebooks/py/DARTFISH_Pipeline_-_Human_Occipital_Cortex_-_1_FOV.py
+++ b/notebooks/py/DARTFISH_Pipeline_-_Human_Occipital_Cortex_-_1_FOV.py
@@ -18,7 +18,7 @@ import matplotlib.pyplot as plt
 import seaborn as sns
 import os
 
-from starfish import data
+from starfish import data, FieldOfView
 from starfish.types import Features, Indices
 
 from starfish import IntensityTable
@@ -40,7 +40,7 @@ sns.set_style('ticks')
 use_test_data = os.getenv("USE_TEST_DATA") is not None
 exp = data.DARTFISH(use_test_data=use_test_data)
 
-stack = exp.fov().primary_image
+stack = exp.fov()[FieldOfView.PRIMARY_IMAGES]
 # EPY: END code
 
 # EPY: START code
@@ -64,7 +64,7 @@ exp.codebook
 # EPY: END markdown
 
 # EPY: START code
-cnts_benchmark = pd.read_csv('https://dmf0bdeheu4zf.cloudfront.net/20180926/DARTFISH/fov_001/counts.csv')
+cnts_benchmark = pd.read_csv('https://d2nhj9g34unfro.cloudfront.net/20181005/DARTFISH/fov_001/counts.csv')
 cnts_benchmark.head()
 # EPY: END code
 

--- a/notebooks/py/ISS_Pipeline_-_Breast_-_1_FOV.py
+++ b/notebooks/py/ISS_Pipeline_-_Breast_-_1_FOV.py
@@ -23,7 +23,7 @@ import matplotlib.pyplot as plt
 from showit import image
 import pprint
 
-from starfish import data
+from starfish import data, FieldOfView
 from starfish.types import Features, Indices
 # EPY: END code
 
@@ -52,7 +52,7 @@ pp.pprint(experiment._src_doc)
 
 # EPY: START code
 fov = experiment.fov()
-primary_image = fov.primary_image
+primary_image = fov[FieldOfView.PRIMARY_IMAGES]
 dots = fov['dots']
 nuclei = fov['nuclei']
 images = [primary_image, nuclei, dots]

--- a/notebooks/py/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
+++ b/notebooks/py/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
@@ -25,7 +25,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 
 from showit import image as show_image
-from starfish import data
+from starfish import data, FieldOfView
 from starfish.types import Features, Indices
 # EPY: END code
 
@@ -40,7 +40,7 @@ experiment = data.MERFISH(use_test_data=use_test_data)
 # EPY: END markdown
 
 # EPY: START code
-primary_image = experiment.fov().primary_image
+primary_image = experiment.fov()[FieldOfView.PRIMARY_IMAGES]
 # EPY: END code
 
 # EPY: START code
@@ -199,7 +199,7 @@ spot_intensities = initial_spot_intensities.loc[initial_spot_intensities[Feature
 # EPY: END markdown
 
 # EPY: START code
-bench = pd.read_csv('https://dmf0bdeheu4zf.cloudfront.net/MERFISH/benchmark_results.csv',
+bench = pd.read_csv('https://d2nhj9g34unfro.cloudfront.net/MERFISH/benchmark_results.csv',
                     dtype = {'barcode':object})
 
 benchmark_counts = bench.groupby('gene')['gene'].count()

--- a/notebooks/py/allen_smFISH.py
+++ b/notebooks/py/allen_smFISH.py
@@ -16,7 +16,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import os
 
-from starfish import data
+from starfish import data, FieldOfView
 from starfish.types import Indices
 # EPY: END code
 
@@ -33,7 +33,7 @@ from starfish.types import Indices
 # EPY: START code
 use_test_data = os.getenv("USE_TEST_DATA") is not None
 experiment = data.allen_smFISH(use_test_data=use_test_data)
-primary_image = experiment.fov().primary_image
+primary_image = experiment.fov()[FieldOfView.PRIMARY_IMAGES]
 # EPY: END code
 
 # EPY: START code

--- a/notebooks/py/assay_comparison.py
+++ b/notebooks/py/assay_comparison.py
@@ -22,7 +22,7 @@ import tempfile
 
 # EPY: START code
 # science
-from starfish import IntensityTable, Experiment, ImageStack
+from starfish import IntensityTable, Experiment, FieldOfView, ImageStack
 from starfish.plot import histogram, compare_copy_number
 from starfish.plot.decoded_spots import decoded_spots
 from starfish.types import Features, Indices
@@ -39,7 +39,7 @@ from showit import image
 # EPY: START code
 # IntensityTable can't download from directories without list privileges
 
-data_root = "https://dmf0bdeheu4zf.cloudfront.net/assay_comparison/"
+data_root = "https://d2nhj9g34unfro.cloudfront.net/assay_comparison/"
 iss_link = os.path.join(data_root, "iss.nc")
 merfish_link = os.path.join(data_root, "merfish.nc")
 dartfish_link = os.path.join(data_root, "dartfish.nc")
@@ -97,7 +97,7 @@ merfish_nuclei = experiment.fov()['nuclei'].max_proj(Indices.CH, Indices.ROUND, 
 
 # merfish doesn't have a dots image, and some of the channels are stronger than others.
 # We can use the scale factors to get the right levels
-merfish_background = experiment.fov().primary_image.max_proj(Indices.CH, Indices.ROUND)
+merfish_background = experiment.fov()[FieldOfView.PRIMARY_IMAGES].max_proj(Indices.CH, Indices.ROUND)
 merfish_background = np.reshape(merfish_background, (1, 1, *merfish_background.shape))
 merfish_background = ImageStack.from_numpy_array(merfish_background)
 
@@ -260,7 +260,7 @@ f.tight_layout()
 
 # EPY: START code
 dartfish_copy_number = pd.read_csv(
-    'https://dmf0bdeheu4zf.cloudfront.net/20180926/DARTFISH/fov_001/counts.csv',
+    'https://d2nhj9g34unfro.cloudfront.net/20181005/DARTFISH/fov_001/counts.csv',
     index_col=0,
     squeeze=True
 )

--- a/notebooks/py/osmFISH.py
+++ b/notebooks/py/osmFISH.py
@@ -8,7 +8,7 @@
 # EPY: END markdown
 
 # EPY: START code
-from starfish import data
+from starfish import data, FieldOfView
 from starfish.types import Indices
 import os
 # EPY: END code
@@ -27,6 +27,6 @@ experiment = data.osmFISH(use_test_data=use_test_data)
 # EPY: END markdown
 
 # EPY: START code
-image = experiment.fov().primary_image
+image = experiment.fov()[FieldOfView.PRIMARY_IMAGES]
 image.show_stack({Indices.CH: 0})
 # EPY: END code

--- a/sptx-format/README.md
+++ b/sptx-format/README.md
@@ -2,14 +2,14 @@
 
 ## Introduction
 
-This document describes the spaceTx file format specification for image-based biological assays. 
-The spaceTx format is designed to support the construction of a data tensor, which generalizes the approaches taken by sequential single-molecule FISH and assays that identify targets by building codes over multiple imaging rounds. 
+This document describes the spaceTx file format specification for image-based biological assays.
+The spaceTx format is designed to support the construction of a data tensor, which generalizes the approaches taken by sequential single-molecule FISH and assays that identify targets by building codes over multiple imaging rounds.
 Each of theses assays produce images that can form a data tensor.
 The data tensor contains a series of (x, y) planar image planes that represent specific z-planes, imaging channels (c), and imaging rounds (r).
-Together these form a 5-dimensional tensor (r, c, z, y, x) that serves as a general representation of an image-based transcriptomics or proteomics assay, and is the substrate of the starfish package. 
+Together these form a 5-dimensional tensor (r, c, z, y, x) that serves as a general representation of an image-based transcriptomics or proteomics assay, and is the substrate of the starfish package.
 
-The goal of this repository is to define a self-describing data format that specifies how a set of 2-d images form a field of view, and specifies how multiple fields of view interact to form a larger experiment. 
-The spaceTx format accomplishes this by combining these images, stored in 2-dimensional TIFF format, with a series of JSON files that describe how to organize each TIFF file into the 5-dimensional imaging tensor. 
+The goal of this repository is to define a self-describing data format that specifies how a set of 2-d images form a field of view, and specifies how multiple fields of view interact to form a larger experiment.
+The spaceTx format accomplishes this by combining these images, stored in 2-dimensional TIFF format, with a series of JSON files that describe how to organize each TIFF file into the 5-dimensional imaging tensor.
 Combined with imaging metadata and a pipeline recipe, both of which are defined elsewhere, these files enable a pipeline to generate the desired outputs of a spatial assay: a gene expression matrix augmented with spatial locations of transcripts and cells.
 
 ## Format Specification
@@ -24,19 +24,19 @@ Here, we tabulate the minimum set of required json files that can describe the i
 | field_of_view.json   | describes how individual 2-d image planes form an image tensor                                           |
 | codebook.json        | maps patterns of intensity in the channels and rounds of a field of view to target molecules |
 
-Each of these input types and their file formats are described in detail in the following sections. 
+Each of these input types and their file formats are described in detail in the following sections.
 
 ## Experiment
 
-The data manifest is a JSON file that ties together all information about the data images, auxiliary images (like nuclear stains), and the codebook needed to decode the experiment. 
-It is the file read by starfish to load data into the analysis environment. 
+The data manifest is a JSON file that ties together all information about the data images, auxiliary images (like nuclear stains), and the codebook needed to decode the experiment.
+It is the file read by starfish to load data into the analysis environment.
 
 Example:
 ```json
 {
   "version": "0.0.0",
-  "primary_images": "primary_images.json",
-  "auxiliary_images": {
+  "images": {
+    "primary": "primary_images.json",
     "nuclei": "nuclei.json"
   },
   "codebook": "codebook.json",
@@ -48,10 +48,10 @@ Example:
 
 ## Manifest
 
-Both the `primary_images.json` and `nuclei.json` files referenced by the above `experiment.json` may contain links to Field of View Manifests (for simple experiments with only one field of view, these fields may also directly reference a field of view). 
-The Manifest is a simple association of a field of view name with the json file that defines the field of view. 
-In this example, we demonstrate a primary images manifest with three fields of view. 
-Such an experiment would likely also have a nuclei manifest, which would _also_ contain three fields of view. 
+Both the `primary_images.json` and `nuclei.json` files referenced by the above `experiment.json` may contain links to Field of View Manifests (for simple experiments with only one field of view, these fields may also directly reference a field of view).
+The Manifest is a simple association of a field of view name with the json file that defines the field of view.
+In this example, we demonstrate a primary images manifest with three fields of view.
+Such an experiment would likely also have a nuclei manifest, which would _also_ contain three fields of view.
 
 ```json
 {
@@ -67,19 +67,19 @@ Such an experiment would likely also have a nuclei manifest, which would _also_ 
 
 ## Field of View
 
-The field of view is the most complex file in the spaceTx format, and must be created for each data tensor and auxiliary image tensor in an experiment. 
-It provides two key types of information: information about the field of view, and information about each tile contained in it. 
+The field of view is the most complex file in the spaceTx format, and must be created for each data tensor and auxiliary image tensor in an experiment.
+It provides two key types of information: information about the field of view, and information about each tile contained in it.
 
-The field_of_view.json file specifies the shape of the image tensor, including the size of the (X, Y) image in pixels, and the number of z-planes, imaging channels, and imaging rounds in the experiment. 
+The field_of_view.json file specifies the shape of the image tensor, including the size of the (X, Y) image in pixels, and the number of z-planes, imaging channels, and imaging rounds in the experiment.
 Thus, an image tensor has shape (r, c, z, y, x).
 For experiments that do not leverage all of these concepts, the values can simply be set to one, and that dimension of the tensor will be ignored.
 For example, barcoded experiments do not leverage z, and as such, the shape of these experiments will be (r, c, 1, y, x)
-In contrast, smFISH experiments may not leverage multiple imaging rounds, but often take optical sections of the tissue through multiple z-planes, and might have shape (1, c, z, y, z). 
+In contrast, smFISH experiments may not leverage multiple imaging rounds, but often take optical sections of the tissue through multiple z-planes, and might have shape (1, c, z, y, z).
 
 
-For each individual tile, the Field of View specifies the portion of the tensor the tile corresponds to by providing the indicies of the tile in (r, c, z), the location of the tile, and the sha256 hash of the file data, to guard against corruption. 
+For each individual tile, the Field of View specifies the portion of the tensor the tile corresponds to by providing the indicies of the tile in (r, c, z), the location of the tile, and the sha256 hash of the file data, to guard against corruption.
 
-Finally, each tile also specifies the coordinates of the image in physical space, relative to some experiment-wide reference point. 
+Finally, each tile also specifies the coordinates of the image in physical space, relative to some experiment-wide reference point.
 
 The below example describes a 2-channel, 8-round coded experiment that samples a tissue section using 45 discrete z-planes. For conciseness, the tile data is truncated, and shows only the information for two tiles, while in practice there would be 2 * 8 * 45 tiles.
 
@@ -147,11 +147,11 @@ The below example describes a 2-channel, 8-round coded experiment that samples a
 
 ## Codebook
 
-The final part of the spaceTx specification, the codebook describes how intensities detected in the image tensor correspond to the targets of the assay. 
-The codebook is an array, where each object in the array lists a codeword and the target it corresponds to. 
-Each codeword is made up of one or more json objects, each of which describe the expected intensity value for tiles of specific (channel, round) combinations. 
+The final part of the spaceTx specification, the codebook describes how intensities detected in the image tensor correspond to the targets of the assay.
+The codebook is an array, where each object in the array lists a codeword and the target it corresponds to.
+Each codeword is made up of one or more json objects, each of which describe the expected intensity value for tiles of specific (channel, round) combinations.
 
-For smFISH experiments where each channel corresponds to a different target and there is only one imaging round, the codebook is very simple: 
+For smFISH experiments where each channel corresponds to a different target and there is only one imaging round, the codebook is very simple:
 
 ```json
 [
@@ -176,7 +176,7 @@ For smFISH experiments where each channel corresponds to a different target and 
 ]
 ```
 In this example, channels 0, 1, and 2 correspond to `SCUBE2`, `BRCA`, and `ACTB`, respectively.
-In contrast, a coded experiment may have a more complex codebook: 
+In contrast, a coded experiment may have a more complex codebook:
 
 ```json
 [
@@ -204,6 +204,5 @@ In contrast, a coded experiment may have a more complex codebook:
 ]
 ```
 
-The above example describes the coding scheme of an experiment with 2 rounds and 2 channels, where each code expects exactly two images out of four to produce signal for a given target. 
-In the above example, a spot in the image tensor would decode to `SCUBE2` if the spot was detected in (round=0, channel=0) and (round=0, channel=1). 
-
+The above example describes the coding scheme of an experiment with 2 rounds and 2 channels, where each code expects exactly two images out of four to produce signal for a given target.
+In the above example, a spot in the image tensor would decode to `SCUBE2` if the spot was detected in (round=0, channel=0) and (round=0, channel=1).

--- a/starfish/__init__.py
+++ b/starfish/__init__.py
@@ -11,7 +11,7 @@ from . import image
 from . import spots
 # top-level objects
 from .codebook.codebook import Codebook
-from .experiment.experiment import Experiment
+from .experiment.experiment import Experiment, FieldOfView
 from .imagestack.imagestack import ImageStack
 from .intensity_table.intensity_table import IntensityTable
 from .starfish import starfish

--- a/starfish/data/__init__.py
+++ b/starfish/data/__init__.py
@@ -4,32 +4,32 @@ from starfish import Experiment
 def MERFISH(use_test_data: bool=False):
     if use_test_data:
         return Experiment.from_json(
-            'https://dmf0bdeheu4zf.cloudfront.net/20180926/MERFISH-TEST/experiment.json')
+            'https://d2nhj9g34unfro.cloudfront.net/20181005/MERFISH-TEST/experiment.json')
     return Experiment.from_json(
-        'https://dmf0bdeheu4zf.cloudfront.net/20180926/MERFISH/experiment.json')
+        'https://d2nhj9g34unfro.cloudfront.net/20181005/MERFISH/experiment.json')
 
 
 def allen_smFISH(use_test_data: bool=False):
     return Experiment.from_json(
-        'https://dmf0bdeheu4zf.cloudfront.net/20180926/allen_smFISH/experiment.json')
+        'https://d2nhj9g34unfro.cloudfront.net/20181005/allen_smFISH/experiment.json')
 
 
 def DARTFISH(use_test_data: bool=False):
     if use_test_data:
         return Experiment.from_json(
-            'https://dmf0bdeheu4zf.cloudfront.net/20180926/DARTFISH-TEST/experiment.json')
+            'https://d2nhj9g34unfro.cloudfront.net/20181005/DARTFISH-TEST/experiment.json')
     return Experiment.from_json(
-        'https://dmf0bdeheu4zf.cloudfront.net/20180926/DARTFISH/experiment.json')
+        'https://d2nhj9g34unfro.cloudfront.net/20181005/DARTFISH/experiment.json')
 
 
 def ISS(use_test_data: bool=False):
     if use_test_data:
         return Experiment.from_json(
-            'https://dmf0bdeheu4zf.cloudfront.net/20180926/ISS-TEST/experiment.json')
+            'https://d2nhj9g34unfro.cloudfront.net/20181005/ISS-TEST/experiment.json')
     return Experiment.from_json(
-        'https://dmf0bdeheu4zf.cloudfront.net/20180926/ISS/experiment.json')
+        'https://d2nhj9g34unfro.cloudfront.net/20181005/ISS/experiment.json')
 
 
 def osmFISH(use_test_data: bool=False):
     return Experiment.from_json(
-        'https://dmf0bdeheu4zf.cloudfront.net/20180926/osmFISH/experiment.json')
+        'https://d2nhj9g34unfro.cloudfront.net/20181005/osmFISH/experiment.json')

--- a/starfish/experiment/builder/__init__.py
+++ b/starfish/experiment/builder/__init__.py
@@ -157,7 +157,7 @@ def write_experiment_json(
 
     experiment_doc: Dict[str, Any] = {
         'version': str(CURRENT_VERSION),
-        'auxiliary_images': {},
+        'images': {},
         'extras': {},
     }
     primary_image = build_image(
@@ -176,7 +176,7 @@ def write_experiment_json(
         tile_opener=_tile_opener,
         tile_format=ImageFormat.TIFF,
     )
-    experiment_doc['primary_images'] = "primary_image.json"
+    experiment_doc['images']['primary'] = "primary_image.json"
 
     for aux_name, aux_dimensions in aux_name_to_dimensions.items():
         if aux_dimensions is None:
@@ -195,7 +195,7 @@ def write_experiment_json(
             tile_opener=_tile_opener,
             tile_format=ImageFormat.TIFF,
         )
-        experiment_doc['auxiliary_images'][aux_name] = "{}.json".format(aux_name)
+        experiment_doc['images'][aux_name] = "{}.json".format(aux_name)
 
     experiment_doc = postprocess_func(experiment_doc)
     experiment_doc["codebook"] = "codebook.json"

--- a/starfish/experiment/experiment.py
+++ b/starfish/experiment/experiment.py
@@ -1,6 +1,15 @@
 import json
 import os
-from typing import Callable, MutableMapping, MutableSequence, Optional, Sequence, Set, Union
+from typing import (
+    Callable,
+    MutableMapping,
+    MutableSequence,
+    MutableSet,
+    Optional,
+    Sequence,
+    Set,
+    Union,
+)
 
 from semantic_version import Version
 from slicedimage import Collection, TileSet
@@ -18,26 +27,24 @@ class FieldOfView:
     This encapsulates a field of view.  It contains the primary image and auxiliary images that are
     associated with the field of view.
 
-    Auxiliary images can be accessed using a key, i.e., FOV[aux_image_type].
+    All images can be accessed using a key, i.e., FOV[aux_image_type].  The primary image is
+    accessed using the key :py:attr:`starfish.experiment.experiment.FieldOFView.PRIMARY_IMAGES`.
 
     Attributes
     ----------
     name : str
-        The name of the FOV.  In an experiment with only a single FOV, this may be None.
-    primary_image : ImageStack
-        The primary image for this field of view. Calling this property will load the data into
-        memory
-    auxiliary_image_types : Mapping[str, TileSet]
-        A set of all the auxiliary image types.
-
+        The name of the FOV.
+    image_types : Set[str]
+        A set of all the image types.
     """
+
+    PRIMARY_IMAGES = 'primary'
+
     def __init__(
             self,
             name: str,
-            primary_image: Optional[ImageStack]=None,
-            auxiliary_images: Optional[MutableMapping[str, ImageStack]]=None,
-            primary_image_tileset: Optional[TileSet]=None,
-            auxiliary_image_tilesets: Optional[MutableMapping[str, TileSet]]=None,
+            images: Optional[MutableMapping[str, ImageStack]]=None,
+            image_tilesets: Optional[MutableMapping[str, TileSet]]=None,
     ) -> None:
         """
         Fields of views can obtain their primary image from either an ImageStack or a TileSet (but
@@ -50,34 +57,28 @@ class FieldOfView:
         accessed.
         """
         self._name = name
-        self._primary_image: Union[ImageStack, TileSet]
-        self._auxiliary_images: MutableMapping[str, Union[ImageStack, TileSet]]
-        if primary_image is not None:
-            self._primary_image = primary_image
-            if primary_image_tileset is not None:
+        self._images: MutableMapping[str, Union[ImageStack, TileSet]]
+        if images is not None:
+            self._images = images
+            if image_tilesets is not None:
                 raise ValueError(
-                    "Only one of (primary_image, primary_image_tileset) should be set.")
-        elif primary_image_tileset is not None:
-            self._primary_image = primary_image_tileset
+                    "Only one of (images, image_tilesets) should be set.")
+        elif image_tilesets is not None:
+            self._images = image_tilesets
         else:
-            raise ValueError("Field of view must have a primary image")
-        if auxiliary_images is not None:
-            self._auxiliary_images = auxiliary_images
-            if auxiliary_image_tilesets is not None:
-                raise ValueError(
-                    "Only one of (auxiliary_images, auxiliary_image_tilesets) should be set.")
-        elif auxiliary_image_tilesets is not None:
-            self._auxiliary_images = auxiliary_image_tilesets
-        else:
-            self._auxiliary_images = dict()
+            self._images = dict()
 
     def __repr__(self):
-        auxiliary_images = '\n    '.join(f'{k}: {v}' for k, v in self._auxiliary_images.items())
+        images = '\n    '.join(
+            f'{k}: {v}'
+            for k, v in self._images.items()
+            if k != FieldOfView.PRIMARY_IMAGES
+        )
         return (
             f"<starfish.FieldOfView>\n"
-            f"  Primary Image: {self._primary_image}\n"
+            f"  Primary Image: {self._image[FieldOfView.PRIMARY_IMAGES]}\n"
             f"  Auxiliary Images:\n"
-            f"    {auxiliary_images}"
+            f"    {images}"
         )
 
     @property
@@ -85,19 +86,13 @@ class FieldOfView:
         return self._name
 
     @property
-    def primary_image(self) -> ImageStack:
-        if isinstance(self._primary_image, TileSet):
-            self._primary_image = ImageStack(self._primary_image)
-        return self._primary_image
-
-    @property
-    def auxiliary_image_types(self) -> Set[str]:
-        return set(self._auxiliary_images.keys())
+    def image_types(self) -> Set[str]:
+        return set(self._images.keys())
 
     def __getitem__(self, item) -> ImageStack:
-        if isinstance(self._auxiliary_images[item], TileSet):
-            self._auxiliary_images[item] = ImageStack(self._auxiliary_images[item])
-        return self._auxiliary_images[item]
+        if isinstance(self._images[item], TileSet):
+            self._images[item] = ImageStack(self._images[item])
+        return self._images[item]
 
 
 class Experiment:
@@ -193,7 +188,7 @@ class Experiment:
         with backend.read_contextmanager(name) as fh:
             experiment_document = json.load(fh)
 
-        cls.verify_version(experiment_document['version'])
+        version = cls.verify_version(experiment_document['version'])
 
         _, codebook_name, codebook_baseurl = resolve_url(experiment_document['codebook'], baseurl)
         codebook_absolute_url = pathjoin(codebook_baseurl, codebook_name)
@@ -201,36 +196,53 @@ class Experiment:
 
         extras = experiment_document['extras']
 
-        primary_image: Collection = Reader.parse_doc(experiment_document['primary_images'], baseurl)
-        auxiliary_images: MutableMapping[str, Collection] = dict()
-        for aux_image_type, aux_image_url in experiment_document['auxiliary_images'].items():
-            auxiliary_images[aux_image_type] = Reader.parse_doc(aux_image_url, baseurl)
-
         fovs: MutableSequence[FieldOfView] = list()
-        for fov_name, primary_tileset in primary_image.all_tilesets():
-            aux_image_tilesets_for_fov: MutableMapping[str, TileSet] = dict()
-            for aux_image_type, aux_image_collection in auxiliary_images.items():
-                aux_image_tileset = aux_image_collection.find_tileset(fov_name)
-                if aux_image_tileset is not None:
-                    aux_image_tilesets_for_fov[aux_image_type] = aux_image_tileset
+        fov_tilesets: MutableMapping[str, TileSet] = dict()
+        if version < Version("5.0.0"):
+            primary_image: Collection = Reader.parse_doc(experiment_document['primary_images'],
+                                                         baseurl)
+            auxiliary_images: MutableMapping[str, Collection] = dict()
+            for aux_image_type, aux_image_url in experiment_document['auxiliary_images'].items():
+                auxiliary_images[aux_image_type] = Reader.parse_doc(aux_image_url, baseurl)
 
-            fov = FieldOfView(
-                fov_name,
-                primary_image_tileset=primary_tileset,
-                auxiliary_image_tilesets=aux_image_tilesets_for_fov,
-            )
-            fovs.append(fov)
+            for fov_name, primary_tileset in primary_image.all_tilesets():
+                fov_tilesets[FieldOfView.PRIMARY_IMAGES] = primary_tileset
+                for aux_image_type, aux_image_collection in auxiliary_images.items():
+                    aux_image_tileset = aux_image_collection.find_tileset(fov_name)
+                    if aux_image_tileset is not None:
+                        fov_tilesets[aux_image_type] = aux_image_tileset
+
+                fov = FieldOfView(fov_name, image_tilesets=fov_tilesets)
+                fovs.append(fov)
+        else:
+            images: MutableMapping[str, Collection] = dict()
+            all_fov_names: MutableSet[str] = set()
+            for image_type, image_url in experiment_document['images'].items():
+                image = Reader.parse_doc(image_url, baseurl)
+                images[image_type] = image
+                for fov_name, _ in image.all_tilesets():
+                    all_fov_names.add(fov_name)
+
+            for fov_name in all_fov_names:
+                for image_type, image_collection in images.items():
+                    image_tileset = image_collection.find_tileset(fov_name)
+                    if image_tileset is not None:
+                        fov_tilesets[image_type] = image_tileset
+
+                fov = FieldOfView(fov_name, image_tilesets=fov_tilesets)
+                fovs.append(fov)
 
         return Experiment(fovs, codebook, extras, src_doc=experiment_document)
 
     @classmethod
-    def verify_version(cls, semantic_version_str: str) -> None:
+    def verify_version(cls, semantic_version_str: str) -> Version:
         version = Version(semantic_version_str)
         if not (MIN_SUPPORTED_VERSION <= version <= MAX_SUPPORTED_VERSION):
             raise ValueError(
                 f"version {version} not supported.  This version of the starfish library only "
                 f"supports formats from {MIN_SUPPORTED_VERSION} to "
                 f"{MAX_SUPPORTED_VERSION}")
+        return version
 
     def fov(
             self,

--- a/starfish/experiment/version.py
+++ b/starfish/experiment/version.py
@@ -1,5 +1,5 @@
 from semantic_version import Version
 
-CURRENT_VERSION = Version("4.0.0")
+CURRENT_VERSION = Version("5.0.0")
 MIN_SUPPORTED_VERSION = Version("4.0.0")
-MAX_SUPPORTED_VERSION = Version("4.0.0")
+MAX_SUPPORTED_VERSION = Version("5.0.0")

--- a/starfish/test/full_pipelines/api/test_allen_smFISH.py
+++ b/starfish/test/full_pipelines/api/test_allen_smFISH.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import starfish.data
+from starfish import FieldOfView
 from starfish.image._filter.bandpass import Bandpass
 from starfish.image._filter.clip import Clip
 from starfish.image._filter.gaussian_low_pass import GaussianLowPass
@@ -17,7 +18,7 @@ def test_allen_smFISH_cropped_data():
     # load the experiment
     experiment = starfish.data.allen_smFISH(use_test_data=True)
 
-    primary_image = experiment.fov().primary_image
+    primary_image = experiment.fov()[FieldOfView.PRIMARY_IMAGES]
 
     clip = Clip(p_min=10, p_max=100)
     clipped_image = clip.run(primary_image, in_place=False)

--- a/starfish/test/full_pipelines/api/test_dartfish.py
+++ b/starfish/test/full_pipelines/api/test_dartfish.py
@@ -139,7 +139,7 @@ def test_dartfish_pipeline_cropped_data():
     # compare to benchmark data -- note that this particular part of the dataset appears completely
     # uncorrelated
     cnts_benchmark = pd.read_csv(
-        'https://dmf0bdeheu4zf.cloudfront.net/20180905/DARTFISH/fov_001/counts.csv')
+        'https://d2nhj9g34unfro.cloudfront.net/20181005/DARTFISH/fov_001/counts.csv')
 
     min_dist = 0.6
     cnts_starfish = spots_df[spots_df.distance <= min_dist].groupby('target').count()['area']

--- a/starfish/test/full_pipelines/api/test_merfish.py
+++ b/starfish/test/full_pipelines/api/test_merfish.py
@@ -220,7 +220,7 @@ def test_merfish_pipeline_cropped_data():
     assert spots_passing_filters == 1410
 
     # compare to paper results
-    bench = pd.read_csv('https://dmf0bdeheu4zf.cloudfront.net/MERFISH/benchmark_results.csv',
+    bench = pd.read_csv('https://d2nhj9g34unfro.cloudfront.net/MERFISH/benchmark_results.csv',
                         dtype={'barcode': object})
     benchmark_counts = bench.groupby('gene')['gene'].count()
 

--- a/starfish/test/full_pipelines/cli/test_allen_smFISH_cli.py
+++ b/starfish/test/full_pipelines/cli/test_allen_smFISH_cli.py
@@ -22,7 +22,7 @@ class TestAllenData(CLITest, unittest.TestCase):
             [
                 sys.executable,
                 "examples/get_cli_test_data.py",
-                "https://dmf0bdeheu4zf.cloudfront.net/20180828/" +
+                "https://d2nhj9g34unfro.cloudfront.net/20180828/" +
                 "allen_smFISH-TEST/allen_smFISH_test_data.zip",
                 lambda tempdir, *args, **kwargs: os.path.join(tempdir, "registered")
             ],

--- a/starfish/test/full_pipelines/cli/test_dartfish_cli.py
+++ b/starfish/test/full_pipelines/cli/test_dartfish_cli.py
@@ -26,7 +26,7 @@ class TestWithDartfishData(CLITest, unittest.TestCase):
             [
                 sys.executable,
                 "examples/get_cli_test_data.py",
-                "https://dmf0bdeheu4zf.cloudfront.net/20180926/DARTFISH-TEST/",
+                "https://d2nhj9g34unfro.cloudfront.net/20181005/DARTFISH-TEST/",
                 lambda tempdir, *args, **kwargs: os.path.join(tempdir, "registered")
             ],
             [
@@ -78,7 +78,7 @@ class TestWithDartfishData(CLITest, unittest.TestCase):
         # compare to benchmark data -- note that this particular part of the dataset
         # appears completely uncorrelated
         cnts_benchmark = pd.read_csv(
-            'https://dmf0bdeheu4zf.cloudfront.net/20180813/DARTFISH/fov_001/counts.csv')
+            'https://d2nhj9g34unfro.cloudfront.net/20181005/DARTFISH/fov_001/counts.csv')
 
         min_dist = 0.6
         cnts_starfish = spots_df[spots_df.distance <= min_dist].groupby('target').count()['area']

--- a/starfish/test/full_pipelines/cli/test_iss.py
+++ b/starfish/test/full_pipelines/cli/test_iss.py
@@ -37,7 +37,7 @@ class TestWithIssData(CLITest, unittest.TestCase):
             [
                 sys.executable,
                 "examples/get_cli_test_data.py",
-                "https://dmf0bdeheu4zf.cloudfront.net/20180926/ISS-TEST/",
+                "https://d2nhj9g34unfro.cloudfront.net/20181005/ISS-TEST/",
                 lambda tempdir, *args, **kwargs: os.path.join(tempdir, "formatted")
             ],
             [

--- a/starfish/test/full_pipelines/cli/test_merfish_cli.py
+++ b/starfish/test/full_pipelines/cli/test_merfish_cli.py
@@ -24,7 +24,7 @@ class TestWithMerfishData(CLITest, unittest.TestCase):
             [
                 sys.executable,
                 "examples/get_cli_test_data.py",
-                "https://dmf0bdeheu4zf.cloudfront.net/20180926/MERFISH-TEST/experiment.json",
+                "https://d2nhj9g34unfro.cloudfront.net/20181005/MERFISH-TEST/experiment.json",
                 lambda tempdir, *args, **kwargs: os.path.join(tempdir, "registered")
             ],
             [

--- a/validate_sptx/examples/experiment/dartfish_experiment.json
+++ b/validate_sptx/examples/experiment/dartfish_experiment.json
@@ -1,6 +1,8 @@
 {
   "version": "1.0.0",
-  "primary_images": "dartfish_field_of_view.json",
-  "auxiliary_images": {"nuclei": "dartfish_nuclei.json"},
+  "images": {
+    "primary": "dartfish_field_of_view.json",
+    "nuclei": "dartfish_nuclei.json"
+  },
   "codebook": "codebook.json"
 }

--- a/validate_sptx/examples/experiment/experiment.json
+++ b/validate_sptx/examples/experiment/experiment.json
@@ -1,7 +1,7 @@
 {
-  "version": "0.0.0",
-  "primary_images": "primary_images.json",
-  "auxiliary_images": {
+  "version": "5.0.0",
+  "images": {
+    "primary": "primary_images.json",
     "nuclei": "nuclei.json"
   },
   "codebook": "codebook.json",

--- a/validate_sptx/schema/experiment.json
+++ b/validate_sptx/schema/experiment.json
@@ -5,19 +5,13 @@
   "description": "An image-based transcriptomics or proteomics experiment.",
   "required": [
     "version",
-    "primary_images",
-    "codebook"
+    "codebook",
+    "images"
   ],
   "additionalProperties": false,
   "properties": {
     "version": {
       "$ref": "schema/version.json"
-    },
-    "primary_images": {
-      "type": "string",
-      "description": "Images that measure transcript or protein targets in one or more fields of view.",
-      "example": "primary_images.json",
-      "pattern": "^.*?.json$"
     },
     "codebook": {
       "type": "string",
@@ -25,11 +19,17 @@
       "example": "codebook.json",
       "pattern": "^.*?.json$"
     },
-    "auxiliary_images": {
+    "images": {
       "type": "object",
       "additionalProperties": false,
       "description": "Images of non-target data such as nuclei or morphological structures.",
       "properties": {
+        "primary": {
+          "type": "string",
+          "description": "An fov_manifest containing primary images.",
+          "example": "primary_images.json",
+          "pattern": "^.*?.json$"
+        },
         "nuclei": {
           "type": "string",
           "description": "An fov_manifest containing nuclei images.",
@@ -42,7 +42,10 @@
           "example": "dots.json",
           "pattern": "^.*?.json$"
         }
-      }
+      },
+      "required": [
+        "primary"
+      ]
     },
     "extras": {
       "$ref": "schema/extras.json"

--- a/validate_sptx/test_fuzz.py
+++ b/validate_sptx/test_fuzz.py
@@ -123,9 +123,9 @@ def test_fuzz_experiment():
     """
     experiment = {
         "version": "0.0.0",
-        "primary_images": "primary_images.json",
-        "auxiliary_images": {
-            "nuclei": "nuclei.json"
+        "images": {
+            "primary": "primary_images.json",
+            "nuclei": "nuclei.json",
         },
         "codebook": "codebook.json",
         "extras": {
@@ -139,9 +139,9 @@ A D I S M L	If the letter is present, mutation is valid!
 -----------	--------------------------------------------
 . . . . . .	version:
 . . . . . .	   0.0.0
-. . . . . .	primary_images:
-. . . . . .	   primary_images.json
-. D . . M .	auxiliary_images:
+. . . . . .	images:
+. . . . . .	   primary:
+. . . . . .	      primary_images.json
 . D . . . .	   nuclei:
 . D . . . .	      nuclei.json
 . . . . . .	codebook:

--- a/validate_sptx/validate_sptx.py
+++ b/validate_sptx/validate_sptx.py
@@ -56,12 +56,10 @@ def validate(experiment_json: str, fuzz: bool=False) -> bool:
     # validate manifests that it links to.
     possible_manifests = []
     manifest_validator = SpaceTxValidator(_get_absolute_schema_path('fov_manifest.json'))
-    with backend.read_contextmanager(experiment['primary_images']) as fh:
-        possible_manifests.append((json.load(fh), experiment['primary_images']))
 
-    # loop over all the manifests that are stored in auxiliary images. Disallowed names will
-    # have already been excluded by experiment validation.
-    for manifest in experiment['auxiliary_images'].values():
+    # loop over all the manifests that are stored in images. Disallowed names will have already been
+    # excluded by experiment validation.
+    for manifest in experiment['images'].values():
         with backend.read_contextmanager(manifest) as fh:
             possible_manifests.append((json.load(fh), manifest))
 


### PR DESCRIPTION
1. There is a top-level field that is `images`, and that includes both primary images and auxiliary images.  Auxiliary images are addressed as <fov_object>[<image_name>].  The primary image is a special case, where the image name = "primary".
2. Updated the sptx-format schema and examples.
3. Updated the notebooks.
4. Of note is that we are _not_ deprecating 4.0.0.  The format is close enough I added a read path for it!  I did not convert the iss_breast full experiment data set to the new format.

Fixes #625
Depends on #698

Test plan: make -j tests run_notebooks