### PR TITLE
Nuke a bunch of references to hyb.

### DIFF
--- a/examples/get_iss_breast_data.py
+++ b/examples/get_iss_breast_data.py
@@ -51,14 +51,14 @@ class ISSCroppedBreastPrimaryTileFetcher(TileFetcher):
         return ch_dict
 
     @property
-    def hyb_dict(self):
-        hyb_str = ['1st', '2nd', '3rd', '4th']
-        hyb_dict = dict(enumerate(hyb_str))
-        return hyb_dict
+    def round_dict(self):
+        round_str = ['1st', '2nd', '3rd', '4th']
+        round_dict = dict(enumerate(round_str))
+        return round_dict
 
-    def get_tile(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
+    def get_tile(self, fov: int, r: int, ch: int, z: int) -> FetchedTile:
         filename = 'slideA_{}_{}_{}.TIF'.format(str(fov + 1),
-                                                self.hyb_dict[hyb],
+                                                self.round_dict[r],
                                                 self.ch_dict[ch]
                                                 )
         file_path = os.path.join(self.input_dir, filename)
@@ -70,7 +70,7 @@ class ISSCroppedBreastAuxTileFetcher(TileFetcher):
         self.input_dir = input_dir
         self.aux_type = aux_type
 
-    def get_tile(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
+    def get_tile(self, fov: int, r: int, ch: int, z: int) -> FetchedTile:
         if self.aux_type == 'nuclei':
             filename = 'slideA_{}_DO_DAPI.TIF'.format(str(fov + 1))
         elif self.aux_type == 'dots':

--- a/examples/get_iss_data.py
+++ b/examples/get_iss_data.py
@@ -48,15 +48,15 @@ class ISSPrimaryTileFetcher(TileFetcher):
     def __init__(self, input_dir):
         self.input_dir = input_dir
 
-    def get_tile(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
-        return ISSTile(os.path.join(self.input_dir, str(hyb + 1), "c{}.TIF".format(ch + 2)))
+    def get_tile(self, fov: int, r: int, ch: int, z: int) -> FetchedTile:
+        return ISSTile(os.path.join(self.input_dir, str(r + 1), "c{}.TIF".format(ch + 2)))
 
 
 class ISSAuxTileFetcher(TileFetcher):
     def __init__(self, path):
         self.path = path
 
-    def get_tile(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
+    def get_tile(self, fov: int, r: int, ch: int, z: int) -> FetchedTile:
         return ISSTile(self.path)
 
 

--- a/examples/get_merfish_u20s_data.py
+++ b/examples/get_merfish_u20s_data.py
@@ -14,7 +14,7 @@ SHAPE = 2048, 2048
 
 
 class MERFISHTile(FetchedTile):
-    def __init__(self, file_path, hyb, ch):
+    def __init__(self, file_path, r, ch):
         self.file_path = file_path
         # how to index tiles from indices into multi-page tiff
         # key is a tuple of round, chan. val is the index
@@ -34,7 +34,7 @@ class MERFISHTile(FetchedTile):
                     (6, 1): 13,
                     (7, 0): 15,
                     (7, 1): 14}
-        self.hyb = hyb
+        self.r = r
         self.ch = ch
 
     @property
@@ -56,7 +56,7 @@ class MERFISHTile(FetchedTile):
 
     def tile_data(self) -> IO:
         im = imread(self.file_path)
-        return im[self.map[(self.hyb, self.ch)], :, :]
+        return im[self.map[(self.r, self.ch)], :, :]
 
 
 class MERFISHAuxTile(FetchedTile):
@@ -81,13 +81,13 @@ class MERFISHTileFetcher(TileFetcher):
         self.input_dir = input_dir
         self.is_dapi = is_dapi
 
-    def get_tile(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
+    def get_tile(self, fov: int, r: int, ch: int, z: int) -> FetchedTile:
         filename = os.path.join(self.input_dir, 'fov_{}.tif'.format(fov))
         file_path = os.path.join(self.input_dir, filename)
         if self.is_dapi:
             return MERFISHAuxTile(file_path)
         else:
-            return MERFISHTile(file_path, hyb, ch)
+            return MERFISHTile(file_path, r, ch)
 
 
 def format_data(input_dir, output_dir):

--- a/starfish/experiment/builder/defaultproviders.py
+++ b/starfish/experiment/builder/defaultproviders.py
@@ -80,10 +80,10 @@ def tile_fetcher_factory(
     `fetched_tile_constructor_args` and keyword arguments from `fetched_tile_constructor_kwargs`.
     """
     class ResultingClass(TileFetcher):
-        def get_tile(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
+        def get_tile(self, fov: int, r: int, ch: int, z: int) -> FetchedTile:
             args = list()
             if pass_tile_indices:
-                args.extend([fov, hyb, ch, z])
+                args.extend([fov, r, ch, z])
             args.extend(fetched_tile_constructor_args)
 
             return fetched_tile_cls(*args, **fetched_tile_constructor_kwargs)

--- a/starfish/experiment/builder/providers.py
+++ b/starfish/experiment/builder/providers.py
@@ -79,9 +79,9 @@ class TileFetcher:
     This is the contract for providing the image data for constructing a
     :class:`slicedimage.Collection`.
     """
-    def get_tile(self, fov: int, hyb: int, ch: int, z: int) -> FetchedTile:
+    def get_tile(self, fov: int, r: int, ch: int, z: int) -> FetchedTile:
         """
-        Given fov, hyb, ch, and z, return an instance of a :class:`.FetchedImage` that can be
+        Given fov, r, ch, and z, return an instance of a :class:`.FetchedImage` that can be
         queried for the image data.
         """
         raise NotImplementedError()

--- a/starfish/spots/_detector/detect.py
+++ b/starfish/spots/_detector/detect.py
@@ -178,7 +178,7 @@ def detect_spots(
         additional keyword arguments to pass to spot_finding_method
     reference_image : xr.DataArray
         (Optional) a reference image. If provided, spots will be found in this image, and then
-        the locations that correspond to these spots will be measured across each channel and hyb,
+        the locations that correspond to these spots will be measured across each channel and round,
         filling in the values in the IntensityTable
     reference_image_from_max_projection : Tuple[Indices]
         (Optional) if True, create a reference image by max-projecting the channels and imaging

--- a/starfish/test/dataset_fixtures.py
+++ b/starfish/test/dataset_fixtures.py
@@ -172,7 +172,7 @@ def synthetic_two_spot_3d():
 
 
 def synthetic_two_spot_3d_2round_2ch() -> ImageStack:
-    """produce a 2-channel 2-hyb ImageStack
+    """produce a 2-round 2-channel ImageStack
 
     Notes
     -----

--- a/starfish/test/image/test_imagestack_metadata.py
+++ b/starfish/test/image/test_imagestack_metadata.py
@@ -45,14 +45,14 @@ def test_missing_extras():
     If the extras are not present on some of the tiles, it should still work.
     """
     class OnesTilesWithExtrasMostly(OnesTile):
-        def __init__(self, round, hyb, ch, z, extras: dict) -> None:
+        def __init__(self, fov, r, ch, z, extras: dict) -> None:
             super().__init__((10, 10))
-            self._round = round
+            self.fov = fov
             self._extras = extras
 
         @property
         def extras(self):
-            if self._round == 0:
+            if self.fov == 0:
                 return None
             return self._extras
 

--- a/starfish/test/spots/detector/test_spot_detection.py
+++ b/starfish/test/spots/detector/test_spot_detection.py
@@ -37,7 +37,7 @@ local_max_spot_detector = simple_local_max_spot_detector()
 
 
 def synthetic_two_spot_3d_2round_2ch() -> ImageStack:
-    """produce a 2-channel 2-hyb ImageStack
+    """produce a 2-channel 2-round ImageStack
 
     Notes
     -----


### PR DESCRIPTION
hyb, as a dimension, should be round/r.

Note that I did not change 'hybridization', which is a reference to the primary image(s), pending the discussion of singular vs plural. :)

Test plan: `make -j fast run_notebooks`