### PR TITLE
pin certifi in docker env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ channels:
 - conda-forge
 dependencies:
 - python>=3.6
+- certifi==2018.8.24
 - click
 - flake8
 - jsonschema


### PR DESCRIPTION
Docker resolves to a different version than what is in requirements.txt, and then pip install conflicts and is unable to uninstall what docker installed.

Test plan: https://travis-ci.org/spacetx/starfish/jobs/442465711