### PR TITLE
Reimplement try_import as a decorator

### DIFF
--- a/starfish/expression_matrix/expression_matrix.py
+++ b/starfish/expression_matrix/expression_matrix.py
@@ -36,6 +36,7 @@ class ExpressionMatrix(xr.DataArray):
         """
         self.to_netcdf(filename)
 
+    @try_import({"loompy"})
     def save_loom(self, filename: str) -> None:
         """Save an ExpressionMatrix as a loom file
 
@@ -44,13 +45,14 @@ class ExpressionMatrix(xr.DataArray):
         filename : str
             Name of loom file
         """
-        loompy = try_import("loompy")
+        import loompy
 
         row_attrs = {k: self['cells'][k].values for k in self['cells'].coords}
         col_attrs = {k: self['genes'][k].values for k in self['genes'].coords}
 
         loompy.create(filename, self.data, row_attrs, col_attrs)
 
+    @try_import({"anndata"})
     def save_anndata(self, filename: str) -> None:
         """Save an ExpressionMatrix as an AnnData file
 
@@ -59,7 +61,7 @@ class ExpressionMatrix(xr.DataArray):
         filename : str
             Name of AnnData file
         """
-        anndata = try_import("anndata")
+        import anndata
 
         row_attrs = {k: self['cells'][k].values for k in self['cells'].coords}
         col_attrs = {k: self['genes'][k].values for k in self['genes'].coords}

--- a/starfish/util/try_import.py
+++ b/starfish/util/try_import.py
@@ -1,11 +1,29 @@
-import importlib
-from typing import Any
+import functools
+from typing import Callable, Optional, Set
 
-def try_import(module: str) -> Any:
-    try:
-        return importlib.import_module(module)
-    except ImportError:
-        raise ImportError(
-            f"{module} is an optional dependency of starfish. Please install {module} and its "
-            f"dependenciesto use this functionality."
-        )
+
+def try_import(allowable_module_names: Optional[Set[str]]=None) -> Callable:
+    """
+    Decorator to apply to a method.  If one of the modules in `allowable_module_names` fail to
+    import, raise a friendly error message.  If `allowable_module_names` is None, then all failed
+    imports raise a friendly error message.
+    """
+    def _try_import_decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                func(*args, **kwargs)
+            except ImportError as ex:
+                module_name = ex.name
+
+                if allowable_module_names is None or module_name in allowable_module_names:
+                    raise ImportError(
+                        f"{module_name} is an optional dependency of starfish. Please install "
+                        f"{module_name} and its dependenciesto use this functionality."
+                    ) from ex
+                else:
+                    raise
+
+        return wrapper
+
+    return _try_import_decorator


### PR DESCRIPTION
This allows us to maintain IDE compatibility, and provide nice error messages.

This is based on top of #684

Test plan:

```
In [7]: a.save_loom('/tmp/aobab')
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
~/microscopy/starfish/starfish/util/try_import.py in wrapper(*args, **kwargs)
     14             try:
---> 15                 func(*args, **kwargs)
     16             except ImportError as ex:

~/microscopy/starfish/starfish/expression_matrix/expression_matrix.py in save_loom(self, filename)
     47         """
---> 48         import loompy
     49 

ModuleNotFoundError: No module named 'loompy'

The above exception was the direct cause of the following exception:

ImportError                               Traceback (most recent call last)
<ipython-input-7-24377549ce82> in <module>()
----> 1 a.save_loom('/tmp/aobab')

~/microscopy/starfish/starfish/util/try_import.py in wrapper(*args, **kwargs)
     21                         f"{module_name} is an optional dependency of starfish. Please install "
     22                         f"{module_name} and its dependenciesto use this functionality."
---> 23                     ) from ex
     24                 else:
     25                     raise

ImportError: loompy is an optional dependency of starfish. Please install loompy and its dependenciesto use this functionality.
```