### PR TITLE
Make MPDataArray actually shared-memory

### DIFF
--- a/starfish/imagestack/_mp_dataarray.py
+++ b/starfish/imagestack/_mp_dataarray.py
@@ -1,8 +1,12 @@
-import copy
-from typing import Sequence
+import functools
+import warnings
+from collections import OrderedDict
+from multiprocessing import Array as mp_array  # type: ignore
+from typing import Callable, Sequence, Tuple
 
 import numpy as np
 import xarray as xr
+from xarray import Variable
 
 from starfish.types import Number
 
@@ -19,18 +23,20 @@ class MPDataArray:
     multiprocessing.Array object back out of the numpy array or the xarray.  Therefore, we need to
     explicitly maintain a reference to it and keep the two items together.
     """
-    def __init__(self, data: xr.DataArray) -> None:
+    def __init__(self, data: xr.DataArray, backing_mp_array: mp_array) -> None:
         self._data = data
+        self._backing_mp_array = backing_mp_array
 
     @classmethod
     def from_shape_and_dtype(
             cls, shape: Sequence[int], dtype, initial_value: Number=None, *args, **kwargs
     ) -> "MPDataArray":
-        np_array = np.empty(shape=shape, dtype=dtype)
+        np_array, backing_mp_array = np_array_backed_by_mp_array(shape, dtype)
         if initial_value is not None:
             np_array.fill(initial_value)
         xarray = xr.DataArray(np_array, *args, **kwargs)
-        return MPDataArray(xarray)
+        xarray.copy = functools.partial(replacement_copy, xarray.copy)
+        return MPDataArray(xarray, backing_mp_array)
 
     @property
     def data(self) -> xr.DataArray:
@@ -46,4 +52,57 @@ class MPDataArray:
         self._data[key] = value
 
     def __deepcopy__(self, memodict={}):
-        return MPDataArray(copy.deepcopy(self._data, memodict))
+        xarray_copy, backing_mp_array_copy = xr_deepcopy(self._data)
+        return MPDataArray(xarray_copy, backing_mp_array_copy)
+
+
+def np_array_backed_by_mp_array(
+        shape: Sequence[int], dtype) -> Tuple[np.ndarray, mp_array]:
+    """Returns a np_array backed by a multiproceessing.Array buffer."""
+    ctype_type = np.ctypeslib.as_ctypes(np.empty((1,), dtype=np.dtype(dtype))).__class__
+    length = int(np.product(shape))  # the cast to int is required by multiprocessing.Array.
+    backing_array = mp_array(ctype_type, length)
+    unshaped_np_array = np.frombuffer(backing_array.get_obj(), dtype)
+    shaped_np_array = unshaped_np_array.reshape(shape)
+
+    return shaped_np_array, backing_array
+
+
+def xr_deepcopy(source: xr.DataArray) -> Tuple[xr.DataArray, mp_array]:
+    """Replacement for xr.DataArray's deepcopy method.  Returns a deep copy of the input xarray
+    backed by a multiprocessing.Array buffer.
+    """
+    shaped_np_array, backing_array = np_array_backed_by_mp_array(
+        source.variable.shape, source.variable.dtype)
+
+    shaped_np_array[:] = source.variable.data
+
+    variable = Variable(
+        # dims is an immutable tuple, so it doesn't need to be deep-copyied.  see implementation of
+        # Variable.__deepcopy__ for context.
+        source.variable.dims,
+        shaped_np_array,
+        # attrs and encoding are deep copied in the constructor.
+        source.variable.attrs,
+        source.variable.encoding,
+    )
+    coords = OrderedDict((k, v.copy(deep=True))
+                         for k, v in source._coords.items())
+
+    result = xr.DataArray(
+        variable,
+        coords=coords,
+        name=source.name,
+        fastpath=True,
+    )
+
+    return result, backing_array
+
+
+def replacement_copy(orig_copy: Callable, deep=True):
+    if deep:
+        warnings.warn(
+            "Calling deepcopy with ImageStack's xarrays results in arrays that cannot be shared "
+            "across processes.  Use mp_dataarray.xr_deepcopy if you need that behavior."
+        )
+    return orig_copy(deep)

--- a/starfish/test/test_multiprocessing.py
+++ b/starfish/test/test_multiprocessing.py
@@ -4,18 +4,21 @@ processes.  The data is shared such that any process can write to the array and 
 the other processes.  It is up to the developer that uses this mechanism to ensure data integrity is
 maintained.
 """
-
-
+import copy
 import ctypes
 import multiprocessing
+import warnings
 from functools import partial
 # Even though we import multiprocessing, mypy can't find the Array class.  To avoid sprinkling
 # ignore markers all over the file, we explicitly import the symbol and put the ignore marker here.
 from multiprocessing import Array as mp_array  # type: ignore
-from typing import Any, Callable
+from typing import Any, Callable, Tuple
 
 import numpy as np
+import xarray as xr
 
+from starfish import ImageStack
+from starfish.imagestack import _mp_dataarray
 from starfish.multiprocessing.shmem import SharedMemory
 
 
@@ -91,6 +94,67 @@ def test_wrapped_shmem_numpy_array(nitems: int=10):
 
 def _decode_wrapped_array_to_numpy_array(wrapped_array: TestWrappedArray) -> np.ndarray:
     return np.frombuffer(wrapped_array.array.get_obj(), dtype=np.uint8)
+
+
+def test_xr_deepcopy(nitems: int=10) -> None:
+    """
+    Instantiate an :py:class:`xarray.DataArray` and run
+    :py:method:`starfish.imagestack.mp_dataarray.xr_deepcopy` on it.  The copy is passed to worker
+    processes.  Worker processes reconstitute a numpy array from the buffer and attempts to writes
+    to the numpy array.  Writes in the worker process should be visible in the parent process in the
+    copy but not the original.
+    """
+    shape = (nitems, )
+    source = np.zeros(shape, dtype=np.uint8)
+    dataarray = xr.DataArray(source)
+    copy, buffer = _mp_dataarray.xr_deepcopy(dataarray)
+    _start_process_to_test_shmem(
+        array_holder=buffer,
+        decoder=_decode_array_to_numpy_array,
+        nitems=nitems)
+    for ix in range(nitems):
+        assert dataarray[ix] == 0
+        assert copy[ix] == ix
+
+
+def test_imagestack_deepcopy(nitems: int=10) -> None:
+    """
+    Instantiate an :py:class:`ImageStack` and deepcopy it.  Worker processes reconstitute a numpy
+    array from the buffer and attempts to writes to the numpy array.  Writes in the worker process
+    should be visible in the parent process.
+    """
+    shape = (nitems, 3, 4, 5, 6)
+    dtype = np.float32
+    source = np.zeros(shape, dtype=np.float32)
+    imagestack = ImageStack.from_numpy_array(source)
+    imagestack_copy = copy.deepcopy(imagestack)
+    _start_process_to_test_shmem(
+        array_holder=imagestack_copy._data._backing_mp_array,
+        decoder=partial(_decode_imagestack_array_to_numpy_array, shape, dtype),
+        nitems=nitems)
+    for ix in range(nitems):
+        assert (imagestack.xarray[ix] == 0).all()
+        assert np.allclose(imagestack_copy.xarray[ix], ix)
+
+
+def _decode_imagestack_array_to_numpy_array(
+        shape: Tuple[int, ...], dtype, buffer) -> np.ndarray:
+    unshaped_np_array = np.frombuffer(buffer.get_obj(), dtype=dtype)
+    return unshaped_np_array.reshape(shape)
+
+
+def test_imagestack_xarray_deepcopy(nitems: int=10) -> None:
+    """
+    Instantiate an :py:class:`ImageStack` and deepcopy the xarray directly.  This should work, but
+    prompt a warning.
+    """
+    shape = (nitems, 3, 4, 5, 6)
+    dtype = np.float32
+    source = np.zeros(shape, dtype=dtype)
+    imagestack = ImageStack.from_numpy_array(source)
+    with warnings.catch_warnings(record=True) as warnings_:
+        copy.deepcopy(imagestack.xarray)
+        assert len(warnings_) == 1  # type: ignore
 
 
 def _write_to_shared_memory_array(decoder: Callable[[Any], np.ndarray], position: int) -> None:


### PR DESCRIPTION
https://github.com/spacetx/starfish/pull/737 created the wrapper class for xr.DataArray, but fundamentally, it was still a copy-on-write construct that did not allow multiple writers across processes to operate on it.  This swaps out the underpinnings with the constructs introduced and tested in https://github.com/spacetx/starfish/pull/738, such that processes that we fork out in `ImageStack` can cooperatively work on multiple parts of the tensor concurrently.

Whenever we construct a `MPDataArray`, we now construct a `multiprocessing.Array`, and layer a `numpy` object on top of that memory.  Then we construct a `xr.DataArray` around that `numpy` object.  Fun, right?

We freely copy xr.DataArray around when we want to run `ImageStack.apply` not in-place, so we have a `__deepcopy__` method in `MPDataArray` to copy correctly (i.e., create a new `multiprocessing.Array`, and layer everything on top of that).

We also intercept `xr.DataArray``s copy method, such that if someone attempts to deepcopy the xarray directly, we warn them that it has consequences.

Test plan: Added a few tests:
1. a test that exercises `xr_deepcopy`
2. a test that exercises `copy.deepcopy(..)` on an ImageStack.
3. a test that exercises `copy.deepcopy(..)` on an ImageStack's xarray (which will work but will trigger a warning).

Depends on #737, #738 