### PR TITLE
Rename split_by to group_by.

### DIFF
--- a/starfish/image/_filter/bandpass.py
+++ b/starfish/image/_filter/bandpass.py
@@ -7,7 +7,7 @@ from trackpy import bandpass
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Number
 from ._base import FilterAlgorithmBase
-from .util import determine_axes_to_split_by, preserve_float_range
+from .util import determine_axes_to_group_by, preserve_float_range
 
 
 class Bandpass(FilterAlgorithmBase):
@@ -112,11 +112,11 @@ class Bandpass(FilterAlgorithmBase):
             lshort=self.lshort, llong=self.llong, threshold=self.threshold, truncate=self.truncate
         )
 
-        split_by = determine_axes_to_split_by(self.is_volume)
+        group_by = determine_axes_to_group_by(self.is_volume)
 
         result = stack.apply(
             bandpass_,
-            split_by=split_by,
+            group_by=group_by,
             in_place=in_place,
             n_processes=n_processes,
         )

--- a/starfish/image/_filter/clip.py
+++ b/starfish/image/_filter/clip.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from starfish.imagestack.imagestack import ImageStack
 from ._base import FilterAlgorithmBase
-from .util import determine_axes_to_split_by
+from .util import determine_axes_to_group_by
 
 
 class Clip(FilterAlgorithmBase):
@@ -89,10 +89,10 @@ class Clip(FilterAlgorithmBase):
             original stack.
 
         """
-        split_by = determine_axes_to_split_by(self.is_volume)
+        group_by = determine_axes_to_group_by(self.is_volume)
         clip = partial(self._clip, p_min=self.p_min, p_max=self.p_max)
         result = stack.apply(
             clip,
-            split_by=split_by, verbose=verbose, in_place=in_place, n_processes=n_processes
+            group_by=group_by, verbose=verbose, in_place=in_place, n_processes=n_processes
         )
         return result

--- a/starfish/image/_filter/gaussian_high_pass.py
+++ b/starfish/image/_filter/gaussian_high_pass.py
@@ -10,7 +10,7 @@ from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Number
 from ._base import FilterAlgorithmBase
 from .util import (
-    determine_axes_to_split_by,
+    determine_axes_to_group_by,
     preserve_float_range,
     validate_and_broadcast_kernel_size,
 )
@@ -99,10 +99,10 @@ class GaussianHighPass(FilterAlgorithmBase):
             original stack.
 
         """
-        split_by = determine_axes_to_split_by(self.is_volume)
+        group_by = determine_axes_to_group_by(self.is_volume)
         high_pass: Callable = partial(self._high_pass, sigma=self.sigma)
         result = stack.apply(
             high_pass,
-            split_by=split_by, verbose=verbose, in_place=in_place, n_processes=n_processes
+            group_by=group_by, verbose=verbose, in_place=in_place, n_processes=n_processes
         )
         return result

--- a/starfish/image/_filter/gaussian_low_pass.py
+++ b/starfish/image/_filter/gaussian_low_pass.py
@@ -9,7 +9,7 @@ from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Number
 from ._base import FilterAlgorithmBase
 from .util import (
-    determine_axes_to_split_by,
+    determine_axes_to_group_by,
     preserve_float_range,
     validate_and_broadcast_kernel_size,
 )
@@ -102,10 +102,10 @@ class GaussianLowPass(FilterAlgorithmBase):
             original stack.
 
         """
-        split_by = determine_axes_to_split_by(self.is_volume)
+        group_by = determine_axes_to_group_by(self.is_volume)
         low_pass: Callable = partial(self._low_pass, sigma=self.sigma)
         result = stack.apply(
             low_pass,
-            split_by=split_by, verbose=verbose, in_place=in_place, n_processes=n_processes
+            group_by=group_by, verbose=verbose, in_place=in_place, n_processes=n_processes
         )
         return result

--- a/starfish/image/_filter/laplace.py
+++ b/starfish/image/_filter/laplace.py
@@ -8,7 +8,7 @@ from scipy.ndimage import gaussian_laplace
 
 from starfish.image._filter._base import FilterAlgorithmBase
 from starfish.image._filter.util import (
-    determine_axes_to_split_by,
+    determine_axes_to_group_by,
     preserve_float_range,
     validate_and_broadcast_kernel_size,
 )
@@ -124,9 +124,9 @@ class Laplace(FilterAlgorithmBase):
         ImageStack :
             if in-place is False, return the results of filter as a new stack
         """
-        split_by = determine_axes_to_split_by(self.is_volume)
+        group_by = determine_axes_to_group_by(self.is_volume)
         apply_filtering: Callable = partial(self._gaussian_laplace, sigma=self.sigma)
         return stack.apply(
             apply_filtering,
-            split_by=split_by, verbose=verbose, in_place=in_place, n_processes=n_processes,
+            group_by=group_by, verbose=verbose, in_place=in_place, n_processes=n_processes,
         )

--- a/starfish/image/_filter/mean_high_pass.py
+++ b/starfish/image/_filter/mean_high_pass.py
@@ -9,7 +9,7 @@ from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Number
 from ._base import FilterAlgorithmBase
 from .util import (
-    determine_axes_to_split_by, preserve_float_range, validate_and_broadcast_kernel_size
+    determine_axes_to_group_by, preserve_float_range, validate_and_broadcast_kernel_size
 )
 
 
@@ -102,10 +102,10 @@ class MeanHighPass(FilterAlgorithmBase):
             original stack.
 
         """
-        split_by = determine_axes_to_split_by(self.is_volume)
+        group_by = determine_axes_to_group_by(self.is_volume)
         high_pass: Callable = partial(self._high_pass, size=self.size)
         result = stack.apply(
             high_pass,
-            split_by=split_by, verbose=verbose, in_place=in_place, n_processes=n_processes
+            group_by=group_by, verbose=verbose, in_place=in_place, n_processes=n_processes
         )
         return result

--- a/starfish/image/_filter/richardson_lucy_deconvolution.py
+++ b/starfish/image/_filter/richardson_lucy_deconvolution.py
@@ -168,7 +168,9 @@ class DeconvolvePSF(FilterAlgorithmBase):
         )
         result = stack.apply(
             func,
-            split_by={Indices.Y.value, Indices.X.value}, verbose=verbose, n_processes=n_processes,
-            in_place=in_place
+            group_by={Indices.ROUND, Indices.CH, Indices.Z},
+            verbose=verbose,
+            n_processes=n_processes,
+            in_place=in_place,
         )
         return result

--- a/starfish/image/_filter/scale_by_percentile.py
+++ b/starfish/image/_filter/scale_by_percentile.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from starfish.imagestack.imagestack import ImageStack
 from ._base import FilterAlgorithmBase
-from .util import determine_axes_to_split_by, preserve_float_range
+from .util import determine_axes_to_group_by, preserve_float_range
 
 
 class ScaleByPercentile(FilterAlgorithmBase):
@@ -86,10 +86,10 @@ class ScaleByPercentile(FilterAlgorithmBase):
             original stack.
 
         """
-        split_by = determine_axes_to_split_by(self.is_volume)
+        group_by = determine_axes_to_group_by(self.is_volume)
         clip = partial(self._scale, p=self.p)
         result = stack.apply(
             clip,
-            split_by=split_by, verbose=verbose, in_place=in_place, n_processes=n_processes
+            group_by=group_by, verbose=verbose, in_place=in_place, n_processes=n_processes
         )
         return result

--- a/starfish/image/_filter/util.py
+++ b/starfish/image/_filter/util.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from typing import Set, Tuple, Union
 
 import numpy as np
 import xarray as xr
@@ -146,9 +146,10 @@ def preserve_float_range(
             data[array > 1] = 1
     return array.astype(np.float32)
 
-def determine_axes_to_split_by(is_volume: bool):
-    """map is_volume to axes to split by when applying a function over an ImageStack"""
+
+def determine_axes_to_group_by(is_volume: bool) -> Set[Indices]:
+    """map is_volume to axes to group by when applying a function over an ImageStack"""
     if is_volume:
-        return {Indices.Z.value, Indices.Y.value, Indices.X.value}
+        return {Indices.ROUND, Indices.CH}
     else:
-        return {Indices.Y.value, Indices.X.value}
+        return {Indices.ROUND, Indices.CH, Indices.Z}

--- a/starfish/image/_filter/white_tophat.py
+++ b/starfish/image/_filter/white_tophat.py
@@ -5,7 +5,7 @@ from skimage.morphology import ball, disk, white_tophat
 
 from starfish.imagestack.imagestack import ImageStack
 from ._base import FilterAlgorithmBase
-from .util import determine_axes_to_split_by
+from .util import determine_axes_to_group_by
 
 
 class WhiteTophat(FilterAlgorithmBase):
@@ -74,9 +74,9 @@ class WhiteTophat(FilterAlgorithmBase):
             original stack.
 
         """
-        split_by = determine_axes_to_split_by(self.is_volume)
+        group_by = determine_axes_to_group_by(self.is_volume)
         result = stack.apply(
             self._white_tophat,
-            split_by=split_by, verbose=verbose, in_place=in_place, n_processes=n_processes
+            group_by=group_by, verbose=verbose, in_place=in_place, n_processes=n_processes
         )
         return result

--- a/starfish/spots/_detector/detect.py
+++ b/starfish/spots/_detector/detect.py
@@ -222,9 +222,9 @@ def detect_spots(
         reference_image = data_stack.max_proj(Indices.CH, Indices.ROUND)
 
     if is_volume:
-        split_by = {Indices.Z.value, Indices.Y.value, Indices.X.value}
+        group_by = {Indices.ROUND, Indices.CH}
     else:
-        split_by = {Indices.Y.value, Indices.X.value}
+        group_by = {Indices.ROUND, Indices.CH, Indices.Z}
 
     if reference_image is not None:
         reference_spot_locations = spot_finding_method(reference_image, **spot_finding_kwargs)
@@ -238,7 +238,7 @@ def detect_spots(
         spot_finding_method = partial(spot_finding_method, **spot_finding_kwargs)
         spot_attributes_list = data_stack.transform(
             func=spot_finding_method,
-            split_by=split_by
+            group_by=group_by
         )
         intensity_table = concatenate_spot_attributes_to_intensities(spot_attributes_list)
 

--- a/starfish/test/image/test_apply.py
+++ b/starfish/test/image/test_apply.py
@@ -24,7 +24,7 @@ def test_apply_3d():
     stack = ImageStack.synthetic_stack()
     assert np.all(stack.xarray == 1)
     stack.apply(divide, in_place=True, value=4,
-                split_by={Indices.Z.value, Indices.Y.value, Indices.X.value})
+                group_by={Indices.ROUND.value, Indices.CH.value})
     assert (stack.xarray == 0.25).all()
 
 


### PR DESCRIPTION
Split by is ambiguous because it could be axes along which we are splitting the image, or it could be the dimensions that remain.  Right now, it means the latter.

Group by, however, is less ambiguous.

Updated all the callers in the process.

Depends on https://github.com/spacetx/starfish/pull/736

Test plan: make -j fast run_notebooks