### PR TITLE
Apply to save results in-place

### DIFF
--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -732,13 +732,21 @@ class ImageStack:
                 func,
                 group_by=group_by, in_place=True, verbose=verbose, n_processes=n_processes, **kwargs
             )
+        bound_func = partial(ImageStack._in_place_apply, func)
 
-        results = self.transform(func, group_by=group_by, verbose=verbose,
-                                 n_processes=n_processes, **kwargs)
+        self.transform(
+            bound_func,
+            group_by=group_by,
+            verbose=verbose,
+            n_processes=n_processes,
+            **kwargs)
 
-        for r, inds in results:
-            self.set_slice(inds, r)
         return self
+
+    @staticmethod
+    def _in_place_apply(apply_func: Callable[..., np.ndarray], data: np.ndarray, **kwargs) -> None:
+        result = apply_func(data, **kwargs)
+        data[:] = result
 
     def transform(
             self,


### PR DESCRIPTION
Rather than have apply calculate the output, and pass it back to the parent process, we merge the results back into the original tensor.  This is possible because all the child processes use a shared memory construct provided by https://github.com/spacetx/starfish/pull/738.  This is done in the finalizer callable provided by https://github.com/spacetx/starfish/pull/754.

Depends on #736, #737, #738, #739, #740, #754 

Test plan: make -j fast run_notebooks