### PR TITLE
Click migration

### DIFF
--- a/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
+++ b/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
@@ -271,6 +271,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# TODO this crop should be (x, y) = (40, 40) but it was getting eaten by kwargs\n",
     "from starfish.spots import SpotFinder\n",
     "psd = SpotFinder.PixelSpotDetector(\n",
     "    codebook=experiment.codebook,\n",
@@ -280,7 +281,9 @@
     "    min_area=2,\n",
     "    max_area=np.inf,\n",
     "    norm_order=2,\n",
-    "    crop_size=(0, 40, 40)\n",
+    "    crop_z=0,\n",
+    "    crop_y=0,\n",
+    "    crop_x=0\n",
     ")\n",
     "\n",
     "initial_spot_intensities, prop_results = psd.run(scaled_image)\n",

--- a/notebooks/py/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
+++ b/notebooks/py/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
@@ -173,6 +173,7 @@ for indices in primary_image._iter_indices():
 # EPY: END markdown
 
 # EPY: START code
+# TODO this crop should be (x, y) = (40, 40) but it was getting eaten by kwargs
 from starfish.spots import SpotFinder
 psd = SpotFinder.PixelSpotDetector(
     codebook=experiment.codebook,
@@ -182,7 +183,9 @@ psd = SpotFinder.PixelSpotDetector(
     min_area=2,
     max_area=np.inf,
     norm_order=2,
-    crop_size=(0, 40, 40)
+    crop_z=0,
+    crop_y=0,
+    crop_x=0
 )
 
 initial_spot_intensities, prop_results = psd.run(scaled_image)

--- a/sptx_format/cli.py
+++ b/sptx_format/cli.py
@@ -3,9 +3,7 @@ from sptx_format import validate_sptx
 
 
 @click.command()
-@click.option("--experiment-json",
-              required=True,
-              metavar="JSON_FILE_OR_URL")
+@click.option("--experiment-json", required=True, metavar="JSON_FILE_OR_URL")
 @click.option("--fuzz", is_flag=True)
 @click.pass_context
 def validate(ctx, experiment_json, fuzz):

--- a/sptx_format/cli.py
+++ b/sptx_format/cli.py
@@ -1,5 +1,5 @@
 import click
-from sptx_format.validate_sptx import validate as validate_
+from sptx_format import validate_sptx
 
 
 @click.command()
@@ -11,7 +11,7 @@ from sptx_format.validate_sptx import validate as validate_
 def validate(ctx, experiment_json, fuzz):
     """invokes validate with the parsed commandline arguments"""
     try:
-        valid = validate_(experiment_json, fuzz)
+        valid = validate_sptx.validate(experiment_json, fuzz)
         if valid:
             ctx.exit(0)
         else:

--- a/sptx_format/cli.py
+++ b/sptx_format/cli.py
@@ -1,31 +1,20 @@
-import sys
+import click
+from sptx_format.validate_sptx import validate as validate_
 
-from sptx_format.validate_sptx import validate
 
-
-class Cli:
-    parser_group = None
-
-    @staticmethod
-    def add_to_parser(parser):
-        """adds experiment-json and fuzz arguments to the given parser"""
-        parser.add_argument(
-            "--experiment-json",
-            required=True,
-            metavar="JSON_FILE_OR_URL")
-        parser.add_argument(
-            "--fuzz", action="store_true")
-        parser.set_defaults(starfish_command=Cli.run)
-        Cli.parser_group = parser
-
-    @staticmethod
-    def run(args, print_help=False):
-        """invokes validate with the parsed commandline arguments"""
-        try:
-            valid = validate(args.experiment_json, fuzz=args.fuzz)
-            if valid:
-                sys.exit(0)
-            else:
-                sys.exit(1)
-        except KeyboardInterrupt:
-            sys.exit(3)
+@click.command()
+@click.option("--experiment-json",
+              required=True,
+              metavar="JSON_FILE_OR_URL")
+@click.option("--fuzz", is_flag=True)
+@click.pass_context
+def validate(ctx, experiment_json, fuzz):
+    """invokes validate with the parsed commandline arguments"""
+    try:
+        valid = validate_(experiment_json, fuzz)
+        if valid:
+            ctx.exit(0)
+        else:
+            ctx.exit(1)
+    except KeyboardInterrupt:
+        ctx.exit(3)

--- a/starfish/__init__.py
+++ b/starfish/__init__.py
@@ -15,3 +15,6 @@ from .experiment.experiment import Experiment, FieldOfView
 from .imagestack.imagestack import ImageStack
 from .intensity_table.intensity_table import IntensityTable
 from .starfish import starfish
+
+if __name__ == "__main__":
+    starfish()

--- a/starfish/experiment/builder/cli.py
+++ b/starfish/experiment/builder/cli.py
@@ -48,7 +48,7 @@ for image_name in AUX_IMAGE_NAMES:
 def build(output_dir, fov_count, hybridization_dimensions, **kwargs):
     write_experiment_json(
         output_dir, fov_count, hybridization_dimensions,
-        kwargs  # FIXME
+        kwargs
     )
 
 for decorator in reversed(decorators):

--- a/starfish/experiment/builder/cli.py
+++ b/starfish/experiment/builder/cli.py
@@ -1,18 +1,20 @@
-import argparse
 import json
-from typing import MutableMapping
+
+import click
 
 from starfish.types import Indices
-from starfish.util.argparse import FsExistsType
 from . import AUX_IMAGE_NAMES, write_experiment_json
 
 
-class StarfishIndex:
-    def __call__(self, spec_json):
+class StarfishIndex(click.ParamType):
+
+    name = "starfish-index"
+
+    def convert(self, spec_json, param, ctx):
         try:
             spec = json.loads(spec_json)
         except json.decoder.JSONDecodeError:
-            raise argparse.ArgumentTypeError(
+            self.fail(
                 "Could not parse {} into a valid index specification.".format(spec_json))
 
         return {
@@ -21,54 +23,33 @@ class StarfishIndex:
             Indices.Z: spec.get(Indices.Z, 1),
         }
 
+def dimensions_option(name, required):
+    return click.option(
+        "--{}-dimensions".format(name),
+        type=StarfishIndex(), required=required,
+        help="Dimensions for the {} images.  Should be a json dict, with {}, {}, "
+             "and {} as the possible keys.  The value should be the shape along that "
+             "dimension.  If a key is not present, the value is assumed to be 0."
+             .format(
+             name,
+             Indices.ROUND.value,
+             Indices.CH.value,
+             Indices.Z.value))
 
-class Cli:
-    parser_group = None
+decorators = [
+    click.command(),
+    click.argument("output_dir", type=click.Path(exists=True, file_okay=False, writable=True)),
+    click.option("--fov-count", type=int, required=True, help="Number of FOVs in this experiment."),
+    dimensions_option("hybridization", True),
+]
+for image_name in AUX_IMAGE_NAMES:
+    decorators.append(dimensions_option(image_name, False))
 
-    """
-    Maps the name of an aux image to the name in the parsed arguments object.
-    """
-    name_arg_map: MutableMapping[str, str] = dict()
+def build(output_dir, fov_count, hybridization_dimensions, **kwargs):
+    write_experiment_json(
+        output_dir, fov_count, hybridization_dimensions,
+        kwargs  # FIXME
+    )
 
-    @staticmethod
-    def add_to_parser(parser):
-        parser.add_argument(
-            "output_dir",
-            type=FsExistsType())
-        parser.add_argument(
-            "--fov-count",
-            type=int,
-            required=True,
-            help="Number of FOVs in this experiment.")
-        parser.add_argument(
-            "--hybridization-dimensions",
-            type=StarfishIndex(),
-            required=True,
-            help="Dimensions for the hybridization images.  Should be a json dict, with {}, {}, "
-                 "and {} as the possible keys.  The value should be the shape along that "
-                 "dimension.  If a key is not present, the value is assumed to be 0.".format(
-                Indices.ROUND.value,
-                Indices.CH.value,
-                Indices.Z.value))
-        for aux_image_name in AUX_IMAGE_NAMES:
-            arg = parser.add_argument(
-                "--{}-dimensions".format(aux_image_name),
-                type=StarfishIndex(),
-                help="Dimensions for the {} images.  Should be a json dict, with {}, {}, and {} as "
-                     "the possible keys.  The value should be the shape along that dimension.  If "
-                     "a key is not present, the value is assumed to be 0.".format(
-                    aux_image_name, Indices.ROUND, Indices.CH, Indices.Z))
-            Cli.name_arg_map[aux_image_name] = arg.dest
-        parser.set_defaults(starfish_command=Cli.run)
-
-        Cli.parser_group = parser
-
-    @staticmethod
-    def run(args, print_help=False):
-        write_experiment_json(
-            args.output_dir, args.fov_count, args.hybridization_dimensions,
-            {
-                aux_image_name: getattr(args, Cli.name_arg_map[aux_image_name])
-                for aux_image_name in AUX_IMAGE_NAMES
-            }
-        )
+for decorator in reversed(decorators):
+    build = decorator(build)

--- a/starfish/image/_filter/__init__.py
+++ b/starfish/image/_filter/__init__.py
@@ -30,19 +30,19 @@ class Filter(PipelineComponent):
         filtered = instance.run(stack)
         filtered.write(output)
 
-@click.group("filter")
-@click.option("-i", "--input", type=click.Path(exists=True))
-@click.option("-o", "--output", required=True)
-@click.pass_context
-def _cli(ctx, input, output):
-    print("Filtering images...")
-    ctx.obj = dict(
-        component=Filter,
-        input=input,
-        output=output,
-        stack=ImageStack.from_path_or_url(input),
-    )
+    @staticmethod
+    @click.group("filter")
+    @click.option("-i", "--input", type=click.Path(exists=True))
+    @click.option("-o", "--output", required=True)
+    @click.pass_context
+    def _cli(ctx, input, output):
+        print("Filtering images...")
+        ctx.obj = dict(
+            component=Filter,
+            input=input,
+            output=output,
+            stack=ImageStack.from_path_or_url(input),
+        )
 
 
-Filter._cli = _cli  # type: ignore
 Filter._cli_register()

--- a/starfish/image/_filter/__init__.py
+++ b/starfish/image/_filter/__init__.py
@@ -1,9 +1,9 @@
-import argparse
 from typing import Type
+
+import click
 
 from starfish.imagestack.imagestack import ImageStack
 from starfish.pipeline import AlgorithmBase, PipelineComponent
-from starfish.util.argparse import FsExistsType
 from . import _base
 from . import bandpass
 from . import clip
@@ -19,38 +19,30 @@ from . import zero_by_channel_magnitude
 
 class Filter(PipelineComponent):
 
-    filter_group: argparse.ArgumentParser
-
     @classmethod
     def _get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
         return _base.FilterAlgorithmBase
 
     @classmethod
-    def _add_to_parser(cls, subparsers):
-        """Adds the filter component to the CLI argument parser."""
-        filter_group = subparsers.add_parser("filter")
-        filter_group.add_argument("-i", "--input", type=FsExistsType(), required=True)
-        filter_group.add_argument("-o", "--output", required=True)
-        filter_group.set_defaults(starfish_command=Filter._cli)
-        filter_subparsers = filter_group.add_subparsers(dest="filter_algorithm_class")
+    def _cli_run(cls, ctx, instance):
+        output = ctx.obj["output"]
+        stack = ctx.obj["stack"]
+        filtered = instance.run(stack)
+        filtered.write(output)
 
-        for algorithm_cls in cls._algorithm_to_class_map().values():
-            group_parser = filter_subparsers.add_parser(algorithm_cls._get_algorithm_name())
-            group_parser.set_defaults(filter_algorithm_class=algorithm_cls)
-            algorithm_cls._add_arguments(group_parser)
+@click.group("filter")
+@click.option("-i", "--input", type=click.Path(exists=True))
+@click.option("-o", "--output", required=True)
+@click.pass_context
+def _cli(ctx, input, output):
+    print("Filtering images...")
+    ctx.obj = dict(
+        component=Filter,
+        input=input,
+        output=output,
+        stack=ImageStack.from_path_or_url(input),
+    )
 
-        cls.filter_group = filter_group
 
-    @classmethod
-    def _cli(cls, args, print_help=False):
-        """Runs the filter component based on parsed arguments."""
-
-        if args.filter_algorithm_class is None or print_help:
-            cls.filter_group.print_help()
-            cls.filter_group.exit(status=2)
-
-        print('Filtering images ...')
-        stack = ImageStack.from_path_or_url(args.input)
-        instance = args.filter_algorithm_class(**vars(args))
-        output = instance.run(stack)
-        output.write(args.output)
+Filter._cli = _cli  # type: ignore
+Filter._cli_register()

--- a/starfish/image/_filter/bandpass.py
+++ b/starfish/image/_filter/bandpass.py
@@ -1,6 +1,7 @@
 from functools import partial
 from typing import Optional
 
+import click
 import numpy as np
 from trackpy import bandpass
 
@@ -14,7 +15,7 @@ class Bandpass(FilterAlgorithmBase):
 
     def __init__(
             self, lshort: Number, llong: int, threshold: Number, truncate: Number=4,
-            is_volume: bool=False, **kwargs) -> None:
+            is_volume: bool=False) -> None:
         """
 
         Parameters
@@ -30,7 +31,6 @@ class Bandpass(FilterAlgorithmBase):
             deviations
         is_volume : bool
             If True, 3d (z, y, x) volumes will be filtered. By default, filter 2-d (y, x) planes
-        kwargs
         """
         self.lshort = lshort
         self.llong = llong
@@ -39,18 +39,6 @@ class Bandpass(FilterAlgorithmBase):
         self.is_volume = is_volume
 
     _DEFAULT_TESTING_PARAMETERS = {"lshort": 1, "llong": 3, "threshold": 0.01}
-
-    @classmethod
-    def _add_arguments(cls, group_parser) -> None:
-        group_parser.add_argument(
-            "--lshort", type=float, help="filter signals below this frequency")
-        group_parser.add_argument(
-            "--llong", type=int, help="filter signals above this frequency")
-        group_parser.add_argument(
-            "--threshold", type=int, help="clip pixels below this intensity value")
-        group_parser.add_argument(
-            "--truncate", default=4, type=float,
-            help="truncate the filter at this many standard deviations")
 
     @staticmethod
     def _bandpass(
@@ -121,3 +109,20 @@ class Bandpass(FilterAlgorithmBase):
             n_processes=n_processes,
         )
         return result
+
+
+@click.command("Bandpass")
+@click.option(
+    "--lshort", type=float, help="filter signals below this frequency")
+@click.option(
+    "--llong", type=int, help="filter signals above this frequency")
+@click.option(
+    "--threshold", type=int, help="clip pixels below this intensity value")
+@click.option(
+    "--truncate", default=4, type=float,
+    help="truncate the filter at this many standard deviations")
+@click.pass_context
+def _cli(ctx, lshort, llong, threshold, truncate):
+    ctx.obj["component"]._cli_run(ctx, Bandpass(lshort, llong, threshold, truncate))
+
+Bandpass._cli = _cli  # type: ignore

--- a/starfish/image/_filter/bandpass.py
+++ b/starfish/image/_filter/bandpass.py
@@ -110,19 +110,17 @@ class Bandpass(FilterAlgorithmBase):
         )
         return result
 
-
-@click.command("Bandpass")
-@click.option(
-    "--lshort", type=float, help="filter signals below this frequency")
-@click.option(
-    "--llong", type=int, help="filter signals above this frequency")
-@click.option(
-    "--threshold", type=int, help="clip pixels below this intensity value")
-@click.option(
-    "--truncate", default=4, type=float,
-    help="truncate the filter at this many standard deviations")
-@click.pass_context
-def _cli(ctx, lshort, llong, threshold, truncate):
-    ctx.obj["component"]._cli_run(ctx, Bandpass(lshort, llong, threshold, truncate))
-
-Bandpass._cli = _cli  # type: ignore
+    @staticmethod
+    @click.command("Bandpass")
+    @click.option(
+        "--lshort", type=float, help="filter signals below this frequency")
+    @click.option(
+        "--llong", type=int, help="filter signals above this frequency")
+    @click.option(
+        "--threshold", type=int, help="clip pixels below this intensity value")
+    @click.option(
+        "--truncate", default=4, type=float,
+        help="truncate the filter at this many standard deviations")
+    @click.pass_context
+    def _cli(ctx, lshort, llong, threshold, truncate):
+        ctx.obj["component"]._cli_run(ctx, Bandpass(lshort, llong, threshold, truncate))

--- a/starfish/image/_filter/clip.py
+++ b/starfish/image/_filter/clip.py
@@ -89,14 +89,12 @@ class Clip(FilterAlgorithmBase):
         )
         return result
 
-
-@click.command("Clip")
-@click.option(
-    "--p-min", default=0, type=int, help="clip intensities below this percentile")
-@click.option(
-    "--p-max", default=100, type=int, help="clip intensities above this percentile")
-@click.pass_context
-def _cli(ctx, p_min, p_max):
-    ctx.obj["component"]._cli_run(ctx, Clip(p_min, p_max))
-
-Clip._cli = _cli  # type: ignore
+    @staticmethod
+    @click.command("Clip")
+    @click.option(
+        "--p-min", default=0, type=int, help="clip intensities below this percentile")
+    @click.option(
+        "--p-max", default=100, type=int, help="clip intensities above this percentile")
+    @click.pass_context
+    def _cli(ctx, p_min, p_max):
+        ctx.obj["component"]._cli_run(ctx, Clip(p_min, p_max))

--- a/starfish/image/_filter/clip.py
+++ b/starfish/image/_filter/clip.py
@@ -1,6 +1,7 @@
 from functools import partial
 from typing import Optional
 
+import click
 import numpy as np
 
 from starfish.imagestack.imagestack import ImageStack
@@ -10,7 +11,7 @@ from .util import determine_axes_to_split_by
 
 class Clip(FilterAlgorithmBase):
 
-    def __init__(self, p_min: int=0, p_max: int=100, is_volume: bool=False, **kwargs) -> None:
+    def __init__(self, p_min: int=0, p_max: int=100, is_volume: bool=False) -> None:
         """Image clipping filter
 
         Parameters
@@ -21,21 +22,12 @@ class Clip(FilterAlgorithmBase):
             values above this percentile are set to p_max (default 100)
         is_volume : bool
             If True, 3d (z, y, x) volumes will be filtered. By default, filter 2-d (y, x) tiles
-
-        kwargs
         """
         self.p_min = p_min
         self.p_max = p_max
         self.is_volume = is_volume
 
     _DEFAULT_TESTING_PARAMETERS = {"p_min": 0, "p_max": 100}
-
-    @classmethod
-    def _add_arguments(cls, group_parser) -> None:
-        group_parser.add_argument(
-            "--p-min", default=0, type=int, help="clip intensities below this percentile")
-        group_parser.add_argument(
-            "--p-max", default=100, type=int, help="clip intensities above this percentile")
 
     @staticmethod
     def _clip(image: np.ndarray, p_min: int, p_max: int) -> np.ndarray:
@@ -96,3 +88,15 @@ class Clip(FilterAlgorithmBase):
             split_by=split_by, verbose=verbose, in_place=in_place, n_processes=n_processes
         )
         return result
+
+
+@click.command("Clip")
+@click.option(
+    "--p-min", default=0, type=int, help="clip intensities below this percentile")
+@click.option(
+    "--p-max", default=100, type=int, help="clip intensities above this percentile")
+@click.pass_context
+def _cli(ctx, p_min, p_max):
+    ctx.obj["component"]._cli_run(ctx, Clip(p_min, p_max))
+
+Clip._cli = _cli  # type: ignore

--- a/starfish/image/_filter/gaussian_high_pass.py
+++ b/starfish/image/_filter/gaussian_high_pass.py
@@ -1,7 +1,7 @@
-import argparse
 from functools import partial
 from typing import Callable, Optional, Tuple, Union
 
+import click
 import numpy as np
 import xarray as xr
 
@@ -19,7 +19,7 @@ from .util import (
 class GaussianHighPass(FilterAlgorithmBase):
 
     def __init__(
-            self, sigma: Union[Number, Tuple[Number]], is_volume: bool=False, **kwargs
+            self, sigma: Union[Number, Tuple[Number]], is_volume: bool=False,
     ) -> None:
         """Gaussian high pass filter
 
@@ -36,14 +36,6 @@ class GaussianHighPass(FilterAlgorithmBase):
         self.is_volume = is_volume
 
     _DEFAULT_TESTING_PARAMETERS = {"sigma": 3}
-
-    @classmethod
-    def _add_arguments(cls, group_parser: argparse.ArgumentParser) -> None:
-        group_parser.add_argument(
-            "--sigma", type=float, help="standard deviation of gaussian kernel")
-        group_parser.add_argument(
-            "--is-volume", action="store_true",
-            help="indicates that the image stack should be filtered in 3d")
 
     @staticmethod
     def _high_pass(
@@ -106,3 +98,14 @@ class GaussianHighPass(FilterAlgorithmBase):
             split_by=split_by, verbose=verbose, in_place=in_place, n_processes=n_processes
         )
         return result
+
+
+@click.command("GaussianHighPass")
+@click.option("--sigma", type=float, help="standard deviation of gaussian kernel")
+@click.option("--is-volume", is_flag=True,
+              help="indicates that the image stack should be filtered in 3d")
+@click.pass_context
+def _cli(ctx, sigma, is_volume):
+    ctx.obj["component"]._cli_run(ctx, GaussianHighPass(sigma, is_volume))
+
+GaussianHighPass._cli = _cli  # type: ignore

--- a/starfish/image/_filter/gaussian_high_pass.py
+++ b/starfish/image/_filter/gaussian_high_pass.py
@@ -99,13 +99,11 @@ class GaussianHighPass(FilterAlgorithmBase):
         )
         return result
 
-
-@click.command("GaussianHighPass")
-@click.option("--sigma", type=float, help="standard deviation of gaussian kernel")
-@click.option("--is-volume", is_flag=True,
-              help="indicates that the image stack should be filtered in 3d")
-@click.pass_context
-def _cli(ctx, sigma, is_volume):
-    ctx.obj["component"]._cli_run(ctx, GaussianHighPass(sigma, is_volume))
-
-GaussianHighPass._cli = _cli  # type: ignore
+    @staticmethod
+    @click.command("GaussianHighPass")
+    @click.option("--sigma", type=float, help="standard deviation of gaussian kernel")
+    @click.option("--is-volume", is_flag=True,
+                  help="indicates that the image stack should be filtered in 3d")
+    @click.pass_context
+    def _cli(ctx, sigma, is_volume):
+        ctx.obj["component"]._cli_run(ctx, GaussianHighPass(sigma, is_volume))

--- a/starfish/image/_filter/gaussian_low_pass.py
+++ b/starfish/image/_filter/gaussian_low_pass.py
@@ -102,13 +102,11 @@ class GaussianLowPass(FilterAlgorithmBase):
         )
         return result
 
-
-@click.command("GaussianLowPass")
-@click.option("--sigma", type=float, help="standard deviation of gaussian kernel")
-@click.option("--is-volume", is_flag=True,
-              help="indicates that the image stack should be filtered in 3d")
-@click.pass_context
-def _cli(ctx, sigma, is_volume):
-    ctx.obj["component"]._cli_run(ctx, GaussianLowPass(sigma, is_volume))
-
-GaussianLowPass._cli = _cli  # type: ignore
+    @staticmethod
+    @click.command("GaussianLowPass")
+    @click.option("--sigma", type=float, help="standard deviation of gaussian kernel")
+    @click.option("--is-volume", is_flag=True,
+                  help="indicates that the image stack should be filtered in 3d")
+    @click.pass_context
+    def _cli(ctx, sigma, is_volume):
+        ctx.obj["component"]._cli_run(ctx, GaussianLowPass(sigma, is_volume))

--- a/starfish/image/_filter/gaussian_low_pass.py
+++ b/starfish/image/_filter/gaussian_low_pass.py
@@ -1,7 +1,7 @@
-import argparse
 from functools import partial
 from typing import Callable, Optional, Tuple, Union
 
+import click
 import numpy as np
 from skimage.filters import gaussian
 
@@ -18,7 +18,7 @@ from .util import (
 class GaussianLowPass(FilterAlgorithmBase):
 
     def __init__(
-            self, sigma: Union[Number, Tuple[Number]], is_volume: bool=False, **kwargs) -> None:
+            self, sigma: Union[Number, Tuple[Number]], is_volume: bool=False) -> None:
         """Multi-dimensional low-pass gaussian filter.
 
         Parameters
@@ -34,14 +34,6 @@ class GaussianLowPass(FilterAlgorithmBase):
         self.is_volume = is_volume
 
     _DEFAULT_TESTING_PARAMETERS = {"sigma": 1}
-
-    @classmethod
-    def _add_arguments(cls, group_parser: argparse.ArgumentParser) -> None:
-        group_parser.add_argument(
-            "--sigma", type=float, help="standard deviation of gaussian kernel")
-        group_parser.add_argument(
-            "--is-volume", action="store_true",
-            help="indicates that the image stack should be filtered in 3d")
 
     @staticmethod
     def _low_pass(
@@ -109,3 +101,14 @@ class GaussianLowPass(FilterAlgorithmBase):
             split_by=split_by, verbose=verbose, in_place=in_place, n_processes=n_processes
         )
         return result
+
+
+@click.command("GaussianLowPass")
+@click.option("--sigma", type=float, help="standard deviation of gaussian kernel")
+@click.option("--is-volume", is_flag=True,
+              help="indicates that the image stack should be filtered in 3d")
+@click.pass_context
+def _cli(ctx, sigma, is_volume):
+    ctx.obj["component"]._cli_run(ctx, GaussianLowPass(sigma, is_volume))
+
+GaussianLowPass._cli = _cli  # type: ignore

--- a/starfish/image/_filter/laplace.py
+++ b/starfish/image/_filter/laplace.py
@@ -116,23 +116,20 @@ class Laplace(FilterAlgorithmBase):
             split_by=split_by, verbose=verbose, in_place=in_place, n_processes=n_processes,
         )
 
-
-@click.command("Laplace")
-@click.option(
-    "--sigma", type=float,
-    help="Standard deviation of gaussian kernel for spot enhancement")
-@click.option(
-    "--mode", default="reflect",
-    help="How the input array is extended when the filter overlaps a border")
-@click.option(
-    "--cval", default=0.0,
-    help="Value to fill past edges of input if mode is ‘constant")
-@click.option(
-    "--is-volume", is_flag=True,
-    help="indicates that the image stack should be filtered in 3d")
-@click.pass_context
-def _cli(ctx, sigma, mode, cval, is_volume):
-    ctx.obj["component"]._cli_run(ctx, Laplace(sigma, mode, cval, is_volume))
-
-
-Laplace._cli = _cli  # type: ignore
+    @staticmethod
+    @click.command("Laplace")
+    @click.option(
+        "--sigma", type=float,
+        help="Standard deviation of gaussian kernel for spot enhancement")
+    @click.option(
+        "--mode", default="reflect",
+        help="How the input array is extended when the filter overlaps a border")
+    @click.option(
+        "--cval", default=0.0,
+        help="Value to fill past edges of input if mode is ‘constant")
+    @click.option(
+        "--is-volume", is_flag=True,
+        help="indicates that the image stack should be filtered in 3d")
+    @click.pass_context
+    def _cli(ctx, sigma, mode, cval, is_volume):
+        ctx.obj["component"]._cli_run(ctx, Laplace(sigma, mode, cval, is_volume))

--- a/starfish/image/_filter/laplace.py
+++ b/starfish/image/_filter/laplace.py
@@ -1,8 +1,8 @@
 # Definition of the processing class
-import argparse
 from functools import partial
 from typing import Callable, Optional, Tuple, Union
 
+import click
 import numpy as np
 from scipy.ndimage import gaussian_laplace
 
@@ -34,7 +34,7 @@ class Laplace(FilterAlgorithmBase):
     def __init__(
             self,
             sigma: Union[Number, Tuple[Number]], mode: str='reflect',
-            cval: float=0.0, is_volume: bool=False, **kwargs
+            cval: float=0.0, is_volume: bool=False,
     ) -> None:
         """Multi-dimensional gaussian-laplacian filter used to enhance dots against background
 
@@ -80,21 +80,6 @@ class Laplace(FilterAlgorithmBase):
 
     _DEFAULT_TESTING_PARAMETERS = {"sigma": 0.5}
 
-    @classmethod
-    def _add_arguments(cls, group_parser: argparse.ArgumentParser) -> None:
-        group_parser.add_argument(
-            "--sigma", type=float,
-            help="Standard deviation of gaussian kernel for spot enhancement")
-        group_parser.add_argument(
-            "--mode", default="reflect",
-            help="How the input array is extended when the filter overlaps a border")
-        group_parser.add_argument(
-            "--cval", default=0.0,
-            help="Value to fill past edges of input if mode is ‘constant")
-        group_parser.add_argument(
-            "--is-volume", action="store_true",
-            help="indicates that the image stack should be filtered in 3d")
-
     @staticmethod
     def _gaussian_laplace(image: np.ndarray, sigma: Union[Number, Tuple[Number]],
                           mode: str = 'reflect', cval: float = 0.0) -> np.ndarray:
@@ -130,3 +115,24 @@ class Laplace(FilterAlgorithmBase):
             apply_filtering,
             split_by=split_by, verbose=verbose, in_place=in_place, n_processes=n_processes,
         )
+
+
+@click.command("Laplace")
+@click.option(
+    "--sigma", type=float,
+    help="Standard deviation of gaussian kernel for spot enhancement")
+@click.option(
+    "--mode", default="reflect",
+    help="How the input array is extended when the filter overlaps a border")
+@click.option(
+    "--cval", default=0.0,
+    help="Value to fill past edges of input if mode is ‘constant")
+@click.option(
+    "--is-volume", is_flag=True,
+    help="indicates that the image stack should be filtered in 3d")
+@click.pass_context
+def _cli(ctx, sigma, mode, cval, is_volume):
+    ctx.obj["component"]._cli_run(ctx, Laplace(sigma, mode, cval, is_volume))
+
+
+Laplace._cli = _cli  # type: ignore

--- a/starfish/image/_filter/mean_high_pass.py
+++ b/starfish/image/_filter/mean_high_pass.py
@@ -1,7 +1,7 @@
-import argparse
 from functools import partial
 from typing import Callable, Optional, Tuple, Union
 
+import click
 import numpy as np
 from scipy.ndimage.filters import uniform_filter
 
@@ -16,7 +16,7 @@ from .util import (
 class MeanHighPass(FilterAlgorithmBase):
 
     def __init__(
-            self, size: Union[Number, Tuple[Number]], is_volume: bool=False, **kwargs) -> None:
+            self, size: Union[Number, Tuple[Number]], is_volume: bool=False) -> None:
         """Mean high pass filter.
 
         The mean high pass filter reduces low spatial frequency features by subtracting a
@@ -42,14 +42,6 @@ class MeanHighPass(FilterAlgorithmBase):
         self.is_volume = is_volume
 
     _DEFAULT_TESTING_PARAMETERS = {"size": 1}
-
-    @classmethod
-    def _add_arguments(cls, group_parser: argparse.ArgumentParser) -> None:
-        group_parser.add_argument(
-            "--size", type=float, help="width of the kernel")
-        group_parser.add_argument(
-            "--is-volume", action="store_true",
-            help="indicates that the image stack should be filtered in 3d")
 
     @staticmethod
     def _high_pass(image: np.ndarray, size: Number, rescale: bool=False) -> np.ndarray:
@@ -109,3 +101,17 @@ class MeanHighPass(FilterAlgorithmBase):
             split_by=split_by, verbose=verbose, in_place=in_place, n_processes=n_processes
         )
         return result
+
+
+@click.command("MeanHighPass")
+@click.option(
+    "--size", type=float, help="width of the kernel")
+@click.option(
+    "--is-volume", is_flag=True,
+    help="indicates that the image stack should be filtered in 3d")
+@click.pass_context
+def _cli(ctx, size, is_volume):
+    ctx.obj["component"]._cli_run(ctx, MeanHighPass(size, is_volume))
+
+
+MeanHighPass._cli = _cli  # type: ignore

--- a/starfish/image/_filter/mean_high_pass.py
+++ b/starfish/image/_filter/mean_high_pass.py
@@ -102,16 +102,13 @@ class MeanHighPass(FilterAlgorithmBase):
         )
         return result
 
-
-@click.command("MeanHighPass")
-@click.option(
-    "--size", type=float, help="width of the kernel")
-@click.option(
-    "--is-volume", is_flag=True,
-    help="indicates that the image stack should be filtered in 3d")
-@click.pass_context
-def _cli(ctx, size, is_volume):
-    ctx.obj["component"]._cli_run(ctx, MeanHighPass(size, is_volume))
-
-
-MeanHighPass._cli = _cli  # type: ignore
+    @staticmethod
+    @click.command("MeanHighPass")
+    @click.option(
+        "--size", type=float, help="width of the kernel")
+    @click.option(
+        "--is-volume", is_flag=True,
+        help="indicates that the image stack should be filtered in 3d")
+    @click.pass_context
+    def _cli(ctx, size, is_volume):
+        ctx.obj["component"]._cli_run(ctx, MeanHighPass(size, is_volume))

--- a/starfish/image/_filter/richardson_lucy_deconvolution.py
+++ b/starfish/image/_filter/richardson_lucy_deconvolution.py
@@ -1,7 +1,7 @@
-import argparse
 from functools import partial
 from typing import Optional
 
+import click
 import numpy as np
 from scipy.signal import convolve, fftconvolve
 
@@ -14,7 +14,7 @@ from .util import gaussian_kernel, preserve_float_range
 class DeconvolvePSF(FilterAlgorithmBase):
 
     def __init__(
-            self, num_iter: int, sigma: Number, clip: bool=True, **kwargs) -> None:
+            self, num_iter: int, sigma: Number, clip: bool=True) -> None:
         """Deconvolve a point spread function
 
         Parameters
@@ -39,16 +39,6 @@ class DeconvolvePSF(FilterAlgorithmBase):
         )
 
     _DEFAULT_TESTING_PARAMETERS = {"num_iter": 1, "sigma": 1}
-
-    @classmethod
-    def _add_arguments(cls, group_parser: argparse.ArgumentParser) -> None:
-        group_parser.add_argument(
-            '--num-iter', type=int, help='number of iterations to run')
-        group_parser.add_argument(
-            '--sigma', type=float, help='standard deviation of gaussian kernel')
-        group_parser.add_argument(
-            '--no-clip', action='store_false',
-            help='(default True) if True, clip values below 0 and above 1')
 
     # Here be dragons. This algorithm had a bug, but the results looked nice. Now we've "fixed" it
     # and the results look bad. #548 addresses this problem.
@@ -172,3 +162,19 @@ class DeconvolvePSF(FilterAlgorithmBase):
             in_place=in_place
         )
         return result
+
+
+@click.command("DeconvolvePSF")
+@click.option(
+    '--num-iter', type=int, help='number of iterations to run')
+@click.option(
+    '--sigma', type=float, help='standard deviation of gaussian kernel')
+@click.option(
+    '--no-clip', is_flag=True,
+    help='(default True) if True, clip values below 0 and above 1')
+@click.pass_context
+def _cli(ctx, num_iter, sigma, no_clip):
+    ctx.obj["component"]._cli_run(ctx, DeconvolvePSF(num_iter, sigma, no_clip))
+
+
+DeconvolvePSF._cli = _cli  # type: ignore

--- a/starfish/image/_filter/richardson_lucy_deconvolution.py
+++ b/starfish/image/_filter/richardson_lucy_deconvolution.py
@@ -163,18 +163,15 @@ class DeconvolvePSF(FilterAlgorithmBase):
         )
         return result
 
-
-@click.command("DeconvolvePSF")
-@click.option(
-    '--num-iter', type=int, help='number of iterations to run')
-@click.option(
-    '--sigma', type=float, help='standard deviation of gaussian kernel')
-@click.option(
-    '--no-clip', is_flag=True,
-    help='(default True) if True, clip values below 0 and above 1')
-@click.pass_context
-def _cli(ctx, num_iter, sigma, no_clip):
-    ctx.obj["component"]._cli_run(ctx, DeconvolvePSF(num_iter, sigma, no_clip))
-
-
-DeconvolvePSF._cli = _cli  # type: ignore
+    @staticmethod
+    @click.command("DeconvolvePSF")
+    @click.option(
+        '--num-iter', type=int, help='number of iterations to run')
+    @click.option(
+        '--sigma', type=float, help='standard deviation of gaussian kernel')
+    @click.option(
+        '--no-clip', is_flag=True,
+        help='(default True) if True, clip values below 0 and above 1')
+    @click.pass_context
+    def _cli(ctx, num_iter, sigma, no_clip):
+        ctx.obj["component"]._cli_run(ctx, DeconvolvePSF(num_iter, sigma, no_clip))

--- a/starfish/image/_filter/scale_by_percentile.py
+++ b/starfish/image/_filter/scale_by_percentile.py
@@ -1,6 +1,7 @@
 from functools import partial
 from typing import Optional
 
+import click
 import numpy as np
 
 from starfish.imagestack.imagestack import ImageStack
@@ -10,7 +11,7 @@ from .util import determine_axes_to_split_by, preserve_float_range
 
 class ScaleByPercentile(FilterAlgorithmBase):
 
-    def __init__(self, p: int=0, is_volume: bool=False, **kwargs) -> None:
+    def __init__(self, p: int=0, is_volume: bool=False) -> None:
         """Image scaling filter
 
         Parameters
@@ -19,18 +20,11 @@ class ScaleByPercentile(FilterAlgorithmBase):
             each image in the stack is scaled by this percentile. must be in [0, 100]
         is_volume : bool
             If True, 3d (z, y, x) volumes will be filtered. By default, filter 2-d (y, x) tiles
-
-        kwargs
         """
         self.p = p
         self.is_volume = is_volume
 
     _DEFAULT_TESTING_PARAMETERS = {"p": 0}
-
-    @classmethod
-    def _add_arguments(cls, group_parser) -> None:
-        group_parser.add_argument(
-            "--p", default=100, type=int, help="scale images by this percentile")
 
     @staticmethod
     def _scale(image: np.ndarray, p: int) -> np.ndarray:
@@ -93,3 +87,15 @@ class ScaleByPercentile(FilterAlgorithmBase):
             split_by=split_by, verbose=verbose, in_place=in_place, n_processes=n_processes
         )
         return result
+
+@click.command("ScaleByPercentile")
+@click.option(
+    "--p", default=100, type=int, help="scale images by this percentile")
+@click.option(  # FIXME: was this intentionally missed?
+    "--is-volume", is_flag=True, help="filter 3D volumes")
+@click.pass_context
+def _cli(ctx, p, is_volume):
+    ctx.obj["component"]._cli_run(ctx, ScaleByPercentile(p, is_volume))
+
+
+ScaleByPercentile._cli = _cli  # type: ignore

--- a/starfish/image/_filter/scale_by_percentile.py
+++ b/starfish/image/_filter/scale_by_percentile.py
@@ -88,14 +88,12 @@ class ScaleByPercentile(FilterAlgorithmBase):
         )
         return result
 
-@click.command("ScaleByPercentile")
-@click.option(
-    "--p", default=100, type=int, help="scale images by this percentile")
-@click.option(  # FIXME: was this intentionally missed?
-    "--is-volume", is_flag=True, help="filter 3D volumes")
-@click.pass_context
-def _cli(ctx, p, is_volume):
-    ctx.obj["component"]._cli_run(ctx, ScaleByPercentile(p, is_volume))
-
-
-ScaleByPercentile._cli = _cli  # type: ignore
+    @staticmethod
+    @click.command("ScaleByPercentile")
+    @click.option(
+        "--p", default=100, type=int, help="scale images by this percentile")
+    @click.option(  # FIXME: was this intentionally missed?
+        "--is-volume", is_flag=True, help="filter 3D volumes")
+    @click.pass_context
+    def _cli(ctx, p, is_volume):
+        ctx.obj["component"]._cli_run(ctx, ScaleByPercentile(p, is_volume))

--- a/starfish/image/_filter/white_tophat.py
+++ b/starfish/image/_filter/white_tophat.py
@@ -76,16 +76,13 @@ class WhiteTophat(FilterAlgorithmBase):
         )
         return result
 
-
-@click.command("WhiteTophat")
-@click.option(
-    "--masking-radius", default=15, type=int,
-    help="diameter of morphological masking disk in pixels")
-@click.option(  # FIXME: was this intentionally missed?
-    "--is-volume", is_flag=True, help="filter 3D volumes")
-@click.pass_context
-def _cli(ctx, masking_radius, is_volume):
-    ctx.obj["component"]._cli_run(ctx, WhiteTophat(masking_radius, is_volume))
-
-
-WhiteTophat._cli = _cli  # type: ignore
+    @staticmethod
+    @click.command("WhiteTophat")
+    @click.option(
+        "--masking-radius", default=15, type=int,
+        help="diameter of morphological masking disk in pixels")
+    @click.option(  # FIXME: was this intentionally missed?
+        "--is-volume", is_flag=True, help="filter 3D volumes")
+    @click.pass_context
+    def _cli(ctx, masking_radius, is_volume):
+        ctx.obj["component"]._cli_run(ctx, WhiteTophat(masking_radius, is_volume))

--- a/starfish/image/_filter/white_tophat.py
+++ b/starfish/image/_filter/white_tophat.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+import click
 import numpy as np
 from skimage.morphology import ball, disk, white_tophat
 
@@ -18,7 +19,7 @@ class WhiteTophat(FilterAlgorithmBase):
     https://en.wikipedia.org/wiki/Top-hat_transform
     """
 
-    def __init__(self, masking_radius: int, is_volume: bool=False, **kwargs) -> None:
+    def __init__(self, masking_radius: int, is_volume: bool=False) -> None:
         """
         Instance of a white top hat morphological masking filter which masks objects larger
         than `masking_radius`
@@ -36,12 +37,6 @@ class WhiteTophat(FilterAlgorithmBase):
         self.is_volume = is_volume
 
     _DEFAULT_TESTING_PARAMETERS = {"masking_radius": 3}
-
-    @classmethod
-    def _add_arguments(cls, group_parser) -> None:
-        group_parser.add_argument(
-            "--masking-radius", default=15, type=int,
-            help="diameter of morphological masking disk in pixels")
 
     def _white_tophat(self, image: np.ndarray) -> np.ndarray:
         if self.is_volume:
@@ -80,3 +75,17 @@ class WhiteTophat(FilterAlgorithmBase):
             split_by=split_by, verbose=verbose, in_place=in_place, n_processes=n_processes
         )
         return result
+
+
+@click.command("WhiteTophat")
+@click.option(
+    "--masking-radius", default=15, type=int,
+    help="diameter of morphological masking disk in pixels")
+@click.option(  # FIXME: was this intentionally missed?
+    "--is-volume", is_flag=True, help="filter 3D volumes")
+@click.pass_context
+def _cli(ctx, masking_radius, is_volume):
+    ctx.obj["component"]._cli_run(ctx, WhiteTophat(masking_radius, is_volume))
+
+
+WhiteTophat._cli = _cli  # type: ignore

--- a/starfish/image/_filter/zero_by_channel_magnitude.py
+++ b/starfish/image/_filter/zero_by_channel_magnitude.py
@@ -1,7 +1,7 @@
-import argparse
 from copy import deepcopy
 from typing import Optional
 
+import click
 import numpy as np
 from tqdm import tqdm
 
@@ -11,7 +11,7 @@ from ._base import FilterAlgorithmBase
 
 
 class ZeroByChannelMagnitude(FilterAlgorithmBase):
-    def __init__(self, thresh: int, normalize: bool, **kwargs) -> None:
+    def __init__(self, thresh: int, normalize: bool) -> None:
         """For assays in which we expect codewords to have explicit zero values,
         e.g., DARTFISH, SEQFISH, etc., this filter allows for the explicit zeroing
         out of pixels, for each round, where there is insufficient signal magnitude across channels.
@@ -30,15 +30,6 @@ class ZeroByChannelMagnitude(FilterAlgorithmBase):
         self.normalize = normalize
 
     _DEFAULT_TESTING_PARAMETERS = {"thresh": 0, "normalize": True}
-
-    @classmethod
-    def _add_arguments(cls, group_parser: argparse.ArgumentParser) -> None:
-        group_parser.add_argument(
-            '--thresh', type=float,
-            help='minimum magnitude threshold for pixels across channels')
-        group_parser.add_argument(
-            '--normalize', action="store_true",
-            help='Scales all rounds to have unit L2 norm across channels')
 
     def run(
             self, stack: ImageStack,
@@ -94,3 +85,18 @@ class ZeroByChannelMagnitude(FilterAlgorithmBase):
                                                  where=magnitude_mask
                                                  )
         return stack
+
+
+@click.command("ZeroByChannelMagnitude")
+@click.option(
+    '--thresh', type=float,
+    help='minimum magnitude threshold for pixels across channels')
+@click.option(
+    '--normalize', is_flag=True,
+    help='Scales all rounds to have unit L2 norm across channels')
+@click.pass_context
+def _cli(ctx, thresh, normalize):
+    ctx.obj["component"]._cli_run(ctx, ZeroByChannelMagnitude(thresh, normalize))
+
+
+ZeroByChannelMagnitude._cli = _cli  # type: ignore

--- a/starfish/image/_filter/zero_by_channel_magnitude.py
+++ b/starfish/image/_filter/zero_by_channel_magnitude.py
@@ -86,17 +86,14 @@ class ZeroByChannelMagnitude(FilterAlgorithmBase):
                                                  )
         return stack
 
-
-@click.command("ZeroByChannelMagnitude")
-@click.option(
-    '--thresh', type=float,
-    help='minimum magnitude threshold for pixels across channels')
-@click.option(
-    '--normalize', is_flag=True,
-    help='Scales all rounds to have unit L2 norm across channels')
-@click.pass_context
-def _cli(ctx, thresh, normalize):
-    ctx.obj["component"]._cli_run(ctx, ZeroByChannelMagnitude(thresh, normalize))
-
-
-ZeroByChannelMagnitude._cli = _cli  # type: ignore
+    @staticmethod
+    @click.command("ZeroByChannelMagnitude")
+    @click.option(
+        '--thresh', type=float,
+        help='minimum magnitude threshold for pixels across channels')
+    @click.option(
+        '--normalize', is_flag=True,
+        help='Scales all rounds to have unit L2 norm across channels')
+    @click.pass_context
+    def _cli(ctx, thresh, normalize):
+        ctx.obj["component"]._cli_run(ctx, ZeroByChannelMagnitude(thresh, normalize))

--- a/starfish/image/_registration/__init__.py
+++ b/starfish/image/_registration/__init__.py
@@ -21,19 +21,19 @@ class Registration(PipelineComponent):
         instance.run(stack)
         stack.write(output)
 
-@click.group("registration")
-@click.option("-i", "--input", type=click.Path(exists=True))
-@click.option("-o", "--output", required=True)
-@click.pass_context
-def _cli(ctx, input, output):
-    print("Registering...")
-    ctx.obj = dict(
-        component=Registration,
-        input=input,
-        output=output,
-        stack=ImageStack.from_path_or_url(input),
-    )
+    @staticmethod
+    @click.group("registration")
+    @click.option("-i", "--input", type=click.Path(exists=True))
+    @click.option("-o", "--output", required=True)
+    @click.pass_context
+    def _cli(ctx, input, output):
+        print("Registering...")
+        ctx.obj = dict(
+            component=Registration,
+            input=input,
+            output=output,
+            stack=ImageStack.from_path_or_url(input),
+        )
 
 
-Registration._cli = _cli  # type: ignore
 Registration._cli_register()

--- a/starfish/image/_registration/__init__.py
+++ b/starfish/image/_registration/__init__.py
@@ -1,47 +1,39 @@
-import argparse
 from typing import Type
+
+import click
 
 from starfish.imagestack.imagestack import ImageStack
 from starfish.pipeline import AlgorithmBase, PipelineComponent
-from starfish.util.argparse import FsExistsType
 from . import fourier_shift
 from ._base import RegistrationAlgorithmBase
 
 
 class Registration(PipelineComponent):
 
-    register_group: argparse.ArgumentParser
-
     @classmethod
     def _get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
         return RegistrationAlgorithmBase
 
     @classmethod
-    def _add_to_parser(cls, subparsers):
-        """Adds the registration component to the CLI argument parser."""
-        register_group = subparsers.add_parser("registration")
-        register_group.add_argument("-i", "--input", type=FsExistsType(), required=True)
-        register_group.add_argument("-o", "--output", required=True)
-        register_group.set_defaults(starfish_command=Registration._cli)
-        registration_subparsers = register_group.add_subparsers(dest="registration_algorithm_class")
-
-        for algorithm_cls in cls._algorithm_to_class_map().values():
-            group_parser = registration_subparsers.add_parser(algorithm_cls._get_algorithm_name())
-            group_parser.set_defaults(registration_algorithm_class=algorithm_cls)
-            algorithm_cls._add_arguments(group_parser)
-
-        cls.register_group = register_group
-
-    @classmethod
-    def _cli(cls, args, print_help=False):
-        """Runs the registration component based on parsed arguments."""
-        if args.registration_algorithm_class is None or print_help:
-            cls.register_group.print_help()
-            cls.register_group.exit(status=2)
-
-        print('Registering ...')
-        stack = ImageStack.from_path_or_url(args.input)
-        instance = args.registration_algorithm_class(**vars(args))
+    def _cli_run(cls, ctx, instance):
+        output = ctx.obj["output"]
+        stack = ctx.obj["stack"]
         instance.run(stack)
+        stack.write(output)
 
-        stack.write(args.output)
+@click.group("registration")
+@click.option("-i", "--input", type=click.Path(exists=True))
+@click.option("-o", "--output", required=True)
+@click.pass_context
+def _cli(ctx, input, output):
+    print("Registering...")
+    ctx.obj = dict(
+        component=Registration,
+        input=input,
+        output=output,
+        stack=ImageStack.from_path_or_url(input),
+    )
+
+
+Registration._cli = _cli  # type: ignore
+Registration._cli_register()

--- a/starfish/image/_registration/fourier_shift.py
+++ b/starfish/image/_registration/fourier_shift.py
@@ -87,6 +87,15 @@ class FourierShiftRegistration(RegistrationAlgorithmBase):
             return image
         return None
 
+    @staticmethod
+    @click.command("FourierShiftRegistration")
+    @click.option("--upsampling", default=1, type=int, help="Amount of up-sampling")
+    @click.option("--reference-stack", required=True, type=click.Path(exists=True),
+                  help="The image stack to align the input image stack to.")
+    @click.pass_context
+    def _cli(ctx, upsampling, reference_stack):
+        ctx.obj["component"]._cli_run(ctx, FourierShiftRegistration(upsampling, reference_stack))
+
 
 def compute_shift(
         im: np.ndarray, ref: np.ndarray, upsample_factor: int=1
@@ -118,15 +127,3 @@ def shift_im(im: np.ndarray, shift: np.ndarray) -> np.ndarray:
     fim_shift = fourier_shift(np.fft.fftn(im), shift * -1)
     im_shift = np.fft.ifftn(fim_shift)
     return im_shift.real
-
-
-@click.command("FourierShiftRegistration")
-@click.option("--upsampling", default=1, type=int, help="Amount of up-sampling")
-@click.option("--reference-stack", required=True, type=click.Path(exists=True),
-              help="The image stack to align the input image stack to.")
-@click.pass_context
-def _cli(ctx, upsampling, reference_stack):
-    ctx.obj["component"]._cli_run(ctx, FourierShiftRegistration(upsampling, reference_stack))
-
-
-FourierShiftRegistration._cli = _cli  # type: ignore

--- a/starfish/image/_registration/fourier_shift.py
+++ b/starfish/image/_registration/fourier_shift.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from typing import Optional, Tuple, Union
 
+import click
 import numpy as np
 from scipy.ndimage import fourier_shift
 from skimage.feature import register_translation
@@ -8,7 +9,6 @@ from skimage.feature import register_translation
 from starfish.image._filter.util import preserve_float_range
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Indices
-from starfish.util.argparse import FsExistsType
 from ._base import RegistrationAlgorithmBase
 
 
@@ -41,13 +41,6 @@ class FourierShiftRegistration(RegistrationAlgorithmBase):
             self.reference_stack = reference_stack
         else:
             self.reference_stack = ImageStack.from_path_or_url(reference_stack)
-
-    @classmethod
-    def _add_arguments(cls, group_parser) -> None:
-        group_parser.add_argument("--upsampling", default=1, type=int, help="Amount of up-sampling")
-        group_parser.add_argument(
-            "--reference-stack", type=FsExistsType(), required=True,
-            help="The image stack to align the input image stack to.")
 
     def run(self, image: ImageStack, in_place: bool=False) -> Optional[ImageStack]:
         """Register an ImageStack against a reference image.
@@ -125,3 +118,15 @@ def shift_im(im: np.ndarray, shift: np.ndarray) -> np.ndarray:
     fim_shift = fourier_shift(np.fft.fftn(im), shift * -1)
     im_shift = np.fft.ifftn(fim_shift)
     return im_shift.real
+
+
+@click.command("FourierShiftRegistration")
+@click.option("--upsampling", default=1, type=int, help="Amount of up-sampling")
+@click.option("--reference-stack", required=True, type=click.Path(exists=True),
+              help="The image stack to align the input image stack to.")
+@click.pass_context
+def _cli(ctx, upsampling, reference_stack):
+    ctx.obj["component"]._cli_run(ctx, FourierShiftRegistration(upsampling, reference_stack))
+
+
+FourierShiftRegistration._cli = _cli  # type: ignore

--- a/starfish/image/_segmentation/__init__.py
+++ b/starfish/image/_segmentation/__init__.py
@@ -1,54 +1,46 @@
-import argparse
-from typing import Type
+from typing import Any, Dict, List, Type
 
+import click
 from skimage.io import imsave
 
 from starfish.imagestack.imagestack import ImageStack
 from starfish.pipeline import AlgorithmBase, PipelineComponent
-from starfish.util.argparse import FsExistsType
 from . import watershed
 from ._base import SegmentationAlgorithmBase
 
 
 class Segmentation(PipelineComponent):
 
-    segmentation_group: argparse.ArgumentParser
-
     @classmethod
     def _get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
         return SegmentationAlgorithmBase
 
     @classmethod
-    def _add_to_parser(cls, subparsers) -> None:
-        """Adds the segmentation component to the CLI argument parser."""
-        segmentation_group = subparsers.add_parser("segment")
-        segmentation_group.add_argument("--hybridization-stack", type=FsExistsType(), required=True)
-        segmentation_group.add_argument("--nuclei-stack", type=FsExistsType(), required=True)
-        segmentation_group.add_argument("-o", "--output", required=True)
-        segmentation_group.set_defaults(starfish_command=Segmentation._cli)
-        segmentation_subparsers = segmentation_group.add_subparsers(
-            dest="segmentation_algorithm_class")
+    def _cli_run(cls, ctx, instance):
+        output = ctx.obj["output"]
+        pri_stack = ctx.obj["primary_images"]
+        nuc_stack = ctx.obj["nuclei"]
 
-        for algorithm_cls in cls._algorithm_to_class_map().values():
-            group_parser = segmentation_subparsers.add_parser(algorithm_cls._get_algorithm_name())
-            group_parser.set_defaults(segmentation_algorithm_class=algorithm_cls)
-            algorithm_cls._add_arguments(group_parser)
+        label_image = instance.run(pri_stack, nuc_stack)
 
-        cls.segmentation_group = segmentation_group
+        print(f"Writing label image to {output}")
+        imsave(output, label_image)
 
-    @classmethod
-    def _cli(cls, args, print_help=False) -> None:
-        """Runs the segmentation component based on parsed arguments."""
-        if args.segmentation_algorithm_class is None or print_help:
-            cls.segmentation_group.print_help()
-            cls.segmentation_group.exit(status=2)
 
-        instance = args.segmentation_algorithm_class(**vars(args))
+@click.group("segment")
+@click.option("--primary-images", required=True, type=click.Path(exists=True))
+@click.option("--nuclei", required=True, type=click.Path(exists=True))
+@click.option("-o", "--output", required=True)
+@click.pass_context
+def _cli(ctx, primary_images, nuclei, output):
+    print('Segmenting ...')
+    ctx.obj = dict(
+        component=Segmentation,
+        output=output,
+        primary_images=ImageStack.from_path_or_url(primary_images),
+        nuclei=ImageStack.from_path_or_url(nuclei),
+    )
 
-        print('Segmenting ...')
-        hybridization_stack = ImageStack.from_path_or_url(args.hybridization_stack)
-        nuclei_stack = ImageStack.from_path_or_url(args.nuclei_stack)
-        label_image = instance.run(hybridization_stack, nuclei_stack)
 
-        print(f"Writing label image to {args.output}")
-        imsave(args.output, label_image)
+Segmentation._cli = _cli  # type: ignore
+Segmentation._cli_register()

--- a/starfish/image/_segmentation/__init__.py
+++ b/starfish/image/_segmentation/__init__.py
@@ -26,21 +26,20 @@ class Segmentation(PipelineComponent):
         print(f"Writing label image to {output}")
         imsave(output, label_image)
 
+    @staticmethod
+    @click.group("segment")
+    @click.option("--primary-images", required=True, type=click.Path(exists=True))
+    @click.option("--nuclei", required=True, type=click.Path(exists=True))
+    @click.option("-o", "--output", required=True)
+    @click.pass_context
+    def _cli(ctx, primary_images, nuclei, output):
+        print('Segmenting ...')
+        ctx.obj = dict(
+            component=Segmentation,
+            output=output,
+            primary_images=ImageStack.from_path_or_url(primary_images),
+            nuclei=ImageStack.from_path_or_url(nuclei),
+        )
 
-@click.group("segment")
-@click.option("--primary-images", required=True, type=click.Path(exists=True))
-@click.option("--nuclei", required=True, type=click.Path(exists=True))
-@click.option("-o", "--output", required=True)
-@click.pass_context
-def _cli(ctx, primary_images, nuclei, output):
-    print('Segmenting ...')
-    ctx.obj = dict(
-        component=Segmentation,
-        output=output,
-        primary_images=ImageStack.from_path_or_url(primary_images),
-        nuclei=ImageStack.from_path_or_url(nuclei),
-    )
 
-
-Segmentation._cli = _cli  # type: ignore
 Segmentation._cli_register()

--- a/starfish/image/_segmentation/watershed.py
+++ b/starfish/image/_segmentation/watershed.py
@@ -94,6 +94,19 @@ class Watershed(SegmentationAlgorithmBase):
         else:
             raise RuntimeError('Run segmentation before attempting to show results.')
 
+    @staticmethod
+    @click.command("Watershed")
+    @click.option(
+        "--nuclei-threshold", default=.16, type=float, help="Nuclei threshold")
+    @click.option(
+        "--input-threshold", default=.22, type=float, help="Input threshold")
+    @click.option(
+        "--min-distance", default=57, type=int, help="Minimum distance between cells")
+    @click.pass_context
+    def _cli(ctx, nuclei_threshold, input_threshold, min_distance):
+        ctx.obj["component"]._cli_run(
+            ctx, Watershed(nuclei_threshold, input_threshold, min_distance))
+
 
 class _WatershedSegmenter:
     def __init__(self, nuclei_img: np.ndarray, stain_img: np.ndarray) -> None:
@@ -366,18 +379,3 @@ class _WatershedSegmenter:
         plt.title('Segmented Cells')
 
         return plt.gca()
-
-
-@click.command("Watershed")
-@click.option(
-    "--nuclei-threshold", default=.16, type=float, help="Nuclei threshold")
-@click.option(
-    "--input-threshold", default=.22, type=float, help="Input threshold")
-@click.option(
-    "--min-distance", default=57, type=int, help="Minimum distance between cells")
-@click.pass_context
-def _cli(ctx, nuclei_threshold, input_threshold, min_distance):
-    ctx.obj["component"]._cli_run(ctx, Watershed(nuclei_threshold, input_threshold, min_distance))
-
-
-Watershed._cli = _cli  # type: ignore

--- a/starfish/image/_segmentation/watershed.py
+++ b/starfish/image/_segmentation/watershed.py
@@ -1,5 +1,6 @@
 from typing import Optional, Tuple
 
+import click
 import numpy as np
 import scipy.ndimage.measurements as spm
 from scipy.ndimage import distance_transform_edt
@@ -48,15 +49,6 @@ class Watershed(SegmentationAlgorithmBase):
         self.input_threshold = input_threshold
         self.min_distance = min_distance
         self._segmentation_instance: Optional[_WatershedSegmenter] = None
-
-    @classmethod
-    def _add_arguments(cls, group_parser) -> None:
-        group_parser.add_argument(
-            "--nuclei-threshold", default=.16, type=float, help="nuclei threshold")
-        group_parser.add_argument(
-            "--input-threshold", default=.22, type=float, help="Input threshold")
-        group_parser.add_argument(
-            "--min-distance", default=57, type=int, help="Minimum distance between cells")
 
     def run(self, primary_images: ImageStack, nuclei: ImageStack) -> np.ndarray:
         """Segments nuclei in 2-d using a nuclei ImageStack
@@ -374,3 +366,18 @@ class _WatershedSegmenter:
         plt.title('Segmented Cells')
 
         return plt.gca()
+
+
+@click.command("Watershed")
+@click.option(
+    "--nuclei-threshold", default=.16, type=float, help="Nuclei threshold")
+@click.option(
+    "--input-threshold", default=.22, type=float, help="Input threshold")
+@click.option(
+    "--min-distance", default=57, type=int, help="Minimum distance between cells")
+@click.pass_context
+def _cli(ctx, nuclei_threshold, input_threshold, min_distance):
+    ctx.obj["component"]._cli_run(ctx, Watershed(nuclei_threshold, input_threshold, min_distance))
+
+
+Watershed._cli = _cli  # type: ignore

--- a/starfish/pipeline/algorithmbase.py
+++ b/starfish/pipeline/algorithmbase.py
@@ -1,4 +1,3 @@
-import argparse
 
 
 class AlgorithmBase:
@@ -9,8 +8,3 @@ class AlgorithmBase:
         https://docs.python.org/3/reference/lexical_analysis.html#identifiers
         """
         return cls.__name__
-
-    @classmethod
-    def _add_arguments(cls, group_parser: argparse.ArgumentParser):
-        """Adds the arguments for the algorithm."""
-        raise NotImplementedError()

--- a/starfish/pipeline/pipelinecomponent.py
+++ b/starfish/pipeline/pipelinecomponent.py
@@ -1,4 +1,3 @@
-import argparse
 import collections
 from typing import Mapping, Optional, Type
 
@@ -49,5 +48,10 @@ class PipelineComponent(metaclass=PipelineComponentType):
         return cls._algorithm_to_class_map_int
 
     @classmethod
-    def _cli(cls, args: argparse.Namespace):
+    def _cli_run(cls, ctx, instance, *args, **kwargs):
         raise NotImplementedError()
+
+    @classmethod
+    def _cli_register(cls):
+        for algorithm_cls in cls._algorithm_to_class_map().values():
+            cls._cli.add_command(algorithm_cls._cli)

--- a/starfish/spots/_decoder/__init__.py
+++ b/starfish/spots/_decoder/__init__.py
@@ -23,21 +23,20 @@ class Decoder(PipelineComponent):
         intensities = instance.run(table, codes)
         intensities.save(output)
 
+    @staticmethod
+    @click.group("decode")
+    @click.option("-i", "--input", required=True, type=click.Path(exists=True))
+    @click.option("-o", "--output", required=True)
+    @click.option("--codebook", required=True, type=click.Path(exists=True))
+    @click.pass_context
+    def _cli(ctx, input, output, codebook):
+        ctx.obj = dict(
+            component=Decoder,
+            input=input,
+            output=output,
+            intensities=IntensityTable.load(input),
+            codebook=Codebook.from_json(codebook),
+        )
 
-@click.group("decode")
-@click.option("-i", "--input", required=True, type=click.Path(exists=True))
-@click.option("-o", "--output", required=True)
-@click.option("--codebook", required=True, type=click.Path(exists=True))
-@click.pass_context
-def _cli(ctx, input, output, codebook):
-    ctx.obj = dict(
-        component=Decoder,
-        input=input,
-        output=output,
-        intensities=IntensityTable.load(input),
-        codebook=Codebook.from_json(codebook),
-    )
 
-
-Decoder._cli = _cli  # type: ignore
 Decoder._cli_register()

--- a/starfish/spots/_decoder/__init__.py
+++ b/starfish/spots/_decoder/__init__.py
@@ -1,53 +1,43 @@
-import argparse
 from typing import Type
+
+import click
 
 from starfish.codebook.codebook import Codebook
 from starfish.intensity_table.intensity_table import IntensityTable
 from starfish.pipeline import AlgorithmBase, PipelineComponent
-from starfish.util.argparse import FsExistsType
 from . import _base
 from . import per_round_max_channel_decoder
 
 
 class Decoder(PipelineComponent):
 
-    decoder_group: argparse.ArgumentParser
-
     @classmethod
     def _get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
         return _base.DecoderAlgorithmBase
 
     @classmethod
-    def add_to_parser(cls, subparsers):
-        """Adds the decoder component to the CLI argument parser."""
-        decoder_group = subparsers.add_parser("decode")
-        decoder_group.add_argument("-i", "--input", type=FsExistsType(), required=True)
-        decoder_group.add_argument("-o", "--output", required=True)
-        decoder_group.add_argument("--codebook", type=FsExistsType(), required=True)
-        decoder_group.set_defaults(starfish_command=Decoder._cli)
-        decoder_subparsers = decoder_group.add_subparsers(dest="decoder_algorithm_class")
+    def _cli_run(cls, ctx, instance):
+        table = ctx.obj["intensities"]
+        codes = ctx.obj["codebook"]
+        output = ctx.obj["output"]
+        intensities = instance.run(table, codes)
+        intensities.save(output)
 
-        for algorithm_cls in cls._algorithm_to_class_map().values():
-            group_parser = decoder_subparsers.add_parser(algorithm_cls._get_algorithm_name())
-            group_parser.set_defaults(decoder_algorithm_class=algorithm_cls)
-            algorithm_cls._add_arguments(group_parser)
 
-        cls.decoder_group = decoder_group
+@click.group("decode")
+@click.option("-i", "--input", required=True, type=click.Path(exists=True))
+@click.option("-o", "--output", required=True)
+@click.option("--codebook", required=True, type=click.Path(exists=True))
+@click.pass_context
+def _cli(ctx, input, output, codebook):
+    ctx.obj = dict(
+        component=Decoder,
+        input=input,
+        output=output,
+        intensities=IntensityTable.load(input),
+        codebook=Codebook.from_json(codebook),
+    )
 
-    @classmethod
-    def _cli(cls, args, print_help=False):
-        """Runs the decoder component based on parsed arguments."""
 
-        if args.decoder_algorithm_class is None or print_help:
-            cls.decoder_group.print_help()
-            cls.decoder_group.exit(status=2)
-
-        instance = args.decoder_algorithm_class(**vars(args))
-
-        # load intensities and codebook
-        intensities = IntensityTable.load(args.input)
-        codebook = Codebook.from_json(args.codebook)
-
-        # decode and save output
-        intensities = instance.run(intensities, codebook)
-        intensities.save(args.output)
+Decoder._cli = _cli  # type: ignore
+Decoder._cli_register()

--- a/starfish/spots/_decoder/per_round_max_channel_decoder.py
+++ b/starfish/spots/_decoder/per_round_max_channel_decoder.py
@@ -28,10 +28,8 @@ class PerRoundMaxChannelDecoder(DecoderAlgorithmBase):
         """
         return codebook.decode_per_round_max(intensities)
 
-@click.command("PerRoundMaxChannelDecoder")
-@click.pass_context
-def _cli(ctx):
-    ctx.obj["component"]._cli_run(ctx, PerRoundMaxChannelDecoder())
-
-
-PerRoundMaxChannelDecoder._cli = _cli  # type: ignore
+    @staticmethod
+    @click.command("PerRoundMaxChannelDecoder")
+    @click.pass_context
+    def _cli(ctx):
+        ctx.obj["component"]._cli_run(ctx, PerRoundMaxChannelDecoder())

--- a/starfish/spots/_decoder/per_round_max_channel_decoder.py
+++ b/starfish/spots/_decoder/per_round_max_channel_decoder.py
@@ -1,3 +1,5 @@
+import click
+
 from starfish.codebook.codebook import Codebook
 from starfish.intensity_table.intensity_table import IntensityTable
 from ._base import DecoderAlgorithmBase
@@ -5,11 +7,7 @@ from ._base import DecoderAlgorithmBase
 
 class PerRoundMaxChannelDecoder(DecoderAlgorithmBase):
 
-    def __init__(self, **kwargs):
-        pass
-
-    @classmethod
-    def _add_arguments(cls, group_parser):
+    def __init__(self):
         pass
 
     def run(self, intensities: IntensityTable, codebook: Codebook) -> IntensityTable:
@@ -29,3 +27,11 @@ class PerRoundMaxChannelDecoder(DecoderAlgorithmBase):
 
         """
         return codebook.decode_per_round_max(intensities)
+
+@click.command("PerRoundMaxChannelDecoder")
+@click.pass_context
+def _cli(ctx):
+    ctx.obj["component"]._cli_run(ctx, PerRoundMaxChannelDecoder())
+
+
+PerRoundMaxChannelDecoder._cli = _cli  # type: ignore

--- a/starfish/spots/_detector/__init__.py
+++ b/starfish/spots/_detector/__init__.py
@@ -42,44 +42,43 @@ class SpotFinder(PipelineComponent):
             intensities = intensities[0]
         intensities.save(output)
 
-
-@click.group("detect_spots")
-@click.option("-i", "--input", required=True, type=click.Path(exists=True))
-@click.option("-o", "--output", required=True)
-@click.option(
-    '--blobs-stack', default=None, required=False, help=(
-        'ImageStack that contains the blobs. Will be max-projected across imaging round '
-        'and channel to produce the blobs_image'
+    @staticmethod
+    @click.group("detect_spots")
+    @click.option("-i", "--input", required=True, type=click.Path(exists=True))
+    @click.option("-o", "--output", required=True)
+    @click.option(
+        '--blobs-stack', default=None, required=False, help=(
+            'ImageStack that contains the blobs. Will be max-projected across imaging round '
+            'and channel to produce the blobs_image'
+        )
     )
-)
-@click.option(
-    '--reference-image-from-max-projection', default=False, is_flag=True, help=(
-        'Construct a reference image by max projecting imaging rounds and channels. Spots '
-        'are found in this image and then measured across all images in the input stack.'
+    @click.option(
+        '--reference-image-from-max-projection', default=False, is_flag=True, help=(
+            'Construct a reference image by max projecting imaging rounds and channels. Spots '
+            'are found in this image and then measured across all images in the input stack.'
+        )
     )
-)
-@click.option(
-    '--codebook', default=None, required=False, help=(
-        'A spaceTx spec-compliant json file that describes a three dimensional tensor '
-        'whose values are the expected intensity of a spot for each code in each imaging '
-        'round and each color channel.'
+    @click.option(
+        '--codebook', default=None, required=False, help=(
+            'A spaceTx spec-compliant json file that describes a three dimensional tensor '
+            'whose values are the expected intensity of a spot for each code in each imaging '
+            'round and each color channel.'
+        )
     )
-)
-@click.pass_context
-def _cli(ctx, input, output, blobs_stack, reference_image_from_max_projection, codebook):
-    print('Detecting Spots ...')
-    ctx.obj = dict(
-        component=SpotFinder,
-        image_stack=ImageStack.from_path_or_url(input),
-        output=output,
-        blobs_stack=blobs_stack,
-        reference_image_from_max_projection=reference_image_from_max_projection,
-        codebook=None,
-    )
+    @click.pass_context
+    def _cli(ctx, input, output, blobs_stack, reference_image_from_max_projection, codebook):
+        print('Detecting Spots ...')
+        ctx.obj = dict(
+            component=SpotFinder,
+            image_stack=ImageStack.from_path_or_url(input),
+            output=output,
+            blobs_stack=blobs_stack,
+            reference_image_from_max_projection=reference_image_from_max_projection,
+            codebook=None,
+        )
 
-    if codebook is not None:
-        ctx.obj["codebook"] = Codebook.from_json(codebook)
+        if codebook is not None:
+            ctx.obj["codebook"] = Codebook.from_json(codebook)
 
 
-SpotFinder._cli = _cli  # type: ignore
 SpotFinder._cli_register()

--- a/starfish/spots/_detector/__init__.py
+++ b/starfish/spots/_detector/__init__.py
@@ -1,12 +1,12 @@
-import argparse
 import os
 from typing import Type
+
+import click
 
 from starfish.codebook.codebook import Codebook
 from starfish.imagestack.imagestack import ImageStack
 from starfish.pipeline import AlgorithmBase, PipelineComponent
 from starfish.types import Indices
-from starfish.util.argparse import FsExistsType
 from . import _base
 from . import gaussian
 from . import pixel_spot_detector
@@ -15,71 +15,24 @@ from . import trackpy_local_max_peak_finder
 
 class SpotFinder(PipelineComponent):
 
-    spot_finder_group: argparse.ArgumentParser
-
     @classmethod
     def _get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
         return _base.SpotFinderAlgorithmBase
 
     @classmethod
-    def add_to_parser(cls, subparsers):
-        """Adds the spot finder component to the CLI argument parser."""
-        spot_finder_group = subparsers.add_parser("detect_spots")
-        spot_finder_group.add_argument("-i", "--input", type=FsExistsType(), required=True)
-        spot_finder_group.add_argument("-o", "--output", required=True)
-        spot_finder_group.add_argument(
-            '--blobs-stack', default=None, required=False, help=(
-                'ImageStack that contains the blobs. Will be max-projected across imaging round '
-                'and channel to produce the blobs_image'
-            )
-        )
-        spot_finder_group.add_argument(
-            '--reference-image-from-max-projection', default=False, action='store_true', help=(
-                'Construct a reference image by max projecting imaging rounds and channels. Spots '
-                'are found in this image and then measured across all images in the input stack.'
-            )
-        )
-        spot_finder_group.add_argument(
-            '--codebook', default=None, required=False, help=(
-                'A spaceTx spec-compliant json file that describes a three dimensional tensor '
-                'whose values are the expected intensity of a spot for each code in each imaging '
-                'round and each color channel.'
-            )
-        )
-        spot_finder_group.set_defaults(starfish_command=SpotFinder._cli)
-        spot_finder_subparsers = spot_finder_group.add_subparsers(
-            dest="spot_finder_algorithm_class")
-
-        for algorithm_cls in cls._algorithm_to_class_map().values():
-            group_parser = spot_finder_subparsers.add_parser(algorithm_cls._get_algorithm_name())
-            group_parser.set_defaults(spot_finder_algorithm_class=algorithm_cls)
-            algorithm_cls._add_arguments(group_parser)
-
-        cls.spot_finder_group = spot_finder_group
-
-    @classmethod
-    def _cli(cls, args, print_help=False):
-        """Runs the spot finder component based on parsed arguments."""
-
-        if args.spot_finder_algorithm_class is None or print_help:
-            cls.spot_finder_group.print_help()
-            cls.spot_finder_group.exit(status=2)
-
-        print('Detecting Spots ...')
-        image_stack = ImageStack.from_path_or_url(args.input)
-
-        if args.codebook is not None:
-            args.codebook = Codebook.from_json(args.codebook)
-
-        instance = args.spot_finder_algorithm_class(**vars(args))
-
-        if args.blobs_stack is not None:
-            blobs_stack = ImageStack.from_path_or_url(args.blobs_stack)  # type: ignore
+    def _cli_run(cls, ctx, instance):
+        output = ctx.obj["output"]
+        blobs_stack = ctx.obj["blobs_stack"]
+        image_stack = ctx.obj["image_stack"]
+        ref_image = ctx.obj["reference_image_from_max_projection"]
+        if blobs_stack is not None:
+            blobs_stack = ImageStack.from_path_or_url(blobs_stack)  # type: ignore
             blobs_image = blobs_stack.max_proj(Indices.ROUND, Indices.CH)
+            #  TODO: this won't work for PixelSpotDectector
             intensities = instance.run(
                 image_stack,
                 blobs_image=blobs_image,
-                reference_image_from_max_projection=args.reference_image_from_max_projection
+                reference_image_from_max_projection=ref_image,
             )
         else:
             intensities = instance.run(image_stack)
@@ -87,4 +40,46 @@ class SpotFinder(PipelineComponent):
         # When PixelSpotDetector is used run() returns a tuple
         if isinstance(intensities, tuple):
             intensities = intensities[0]
-        intensities.save(args.output)
+        intensities.save(output)
+
+
+@click.group("detect_spots")
+@click.option("-i", "--input", required=True, type=click.Path(exists=True))
+@click.option("-o", "--output", required=True)
+@click.option(
+    '--blobs-stack', default=None, required=False, help=(
+        'ImageStack that contains the blobs. Will be max-projected across imaging round '
+        'and channel to produce the blobs_image'
+    )
+)
+@click.option(
+    '--reference-image-from-max-projection', default=False, is_flag=True, help=(
+        'Construct a reference image by max projecting imaging rounds and channels. Spots '
+        'are found in this image and then measured across all images in the input stack.'
+    )
+)
+@click.option(
+    '--codebook', default=None, required=False, help=(
+        'A spaceTx spec-compliant json file that describes a three dimensional tensor '
+        'whose values are the expected intensity of a spot for each code in each imaging '
+        'round and each color channel.'
+    )
+)
+@click.pass_context
+def _cli(ctx, input, output, blobs_stack, reference_image_from_max_projection, codebook):
+    print('Detecting Spots ...')
+    ctx.obj = dict(
+        component=SpotFinder,
+        image_stack=ImageStack.from_path_or_url(input),
+        output=output,
+        blobs_stack=blobs_stack,
+        reference_image_from_max_projection=reference_image_from_max_projection,
+        codebook=None,
+    )
+
+    if codebook is not None:
+        ctx.obj["codebook"] = Codebook.from_json(codebook)
+
+
+SpotFinder._cli = _cli  # type: ignore
+SpotFinder._cli_register()

--- a/starfish/spots/_detector/gaussian.py
+++ b/starfish/spots/_detector/gaussian.py
@@ -1,5 +1,6 @@
 from typing import Optional, Union
 
+import click
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -22,7 +23,7 @@ class GaussianSpotDetector(SpotFinderAlgorithmBase):
             threshold: Number,
             overlap: float=0.5,
             measurement_type='max',
-            is_volume: bool=True, **kwargs
+            is_volume: bool=True,
     ) -> None:
         """Multi-dimensional gaussian spot detector
 
@@ -146,17 +147,25 @@ class GaussianSpotDetector(SpotFinderAlgorithmBase):
 
         return intensity_table
 
-    @classmethod
-    def _add_arguments(cls, group_parser):
-        group_parser.add_argument(
-            "--min-sigma", default=4, type=int, help="Minimum spot size (in standard deviation)")
-        group_parser.add_argument(
-            "--max-sigma", default=6, type=int, help="Maximum spot size (in standard deviation)")
-        group_parser.add_argument(
-            "--num-sigma", default=20, type=int, help="Number of sigmas to try")
-        group_parser.add_argument("--threshold", default=.01, type=float, help="Dots threshold")
-        group_parser.add_argument(
-            "--overlap", default=0.5, type=float,
-            help="dots with overlap of greater than this fraction are combined")
-        group_parser.add_argument(
-            "--show", default=False, action='store_true', help="display results visually")
+@click.command("GaussianSpotDetector")
+@click.option(
+    "--min-sigma", default=4, type=int, help="Minimum spot size (in standard deviation)")
+@click.option(
+    "--max-sigma", default=6, type=int, help="Maximum spot size (in standard deviation)")
+@click.option(
+    "--num-sigma", default=20, type=int, help="Number of sigmas to try")
+@click.option(
+    "--threshold", default=.01, type=float, help="Dots threshold")
+@click.option(
+    "--overlap", default=0.5, type=float,
+    help="dots with overlap of greater than this fraction are combined")
+@click.option(
+    "--show", default=False, is_flag=True, help="display results visually")
+@click.pass_context
+def _cli(ctx, min_sigma, max_sigma, num_sigma, threshold, overlap, show):
+        instance = GaussianSpotDetector(min_sigma, max_sigma, num_sigma, threshold, overlap)
+        #  FIXME: measurement_type, is_volume missing as options; show missing as ctor args
+        ctx.obj["component"]._cli_run(ctx, instance)
+
+
+GaussianSpotDetector._cli = _cli  # type: ignore

--- a/starfish/spots/_detector/gaussian.py
+++ b/starfish/spots/_detector/gaussian.py
@@ -147,25 +147,23 @@ class GaussianSpotDetector(SpotFinderAlgorithmBase):
 
         return intensity_table
 
-@click.command("GaussianSpotDetector")
-@click.option(
-    "--min-sigma", default=4, type=int, help="Minimum spot size (in standard deviation)")
-@click.option(
-    "--max-sigma", default=6, type=int, help="Maximum spot size (in standard deviation)")
-@click.option(
-    "--num-sigma", default=20, type=int, help="Number of sigmas to try")
-@click.option(
-    "--threshold", default=.01, type=float, help="Dots threshold")
-@click.option(
-    "--overlap", default=0.5, type=float,
-    help="dots with overlap of greater than this fraction are combined")
-@click.option(
-    "--show", default=False, is_flag=True, help="display results visually")
-@click.pass_context
-def _cli(ctx, min_sigma, max_sigma, num_sigma, threshold, overlap, show):
-        instance = GaussianSpotDetector(min_sigma, max_sigma, num_sigma, threshold, overlap)
-        #  FIXME: measurement_type, is_volume missing as options; show missing as ctor args
-        ctx.obj["component"]._cli_run(ctx, instance)
-
-
-GaussianSpotDetector._cli = _cli  # type: ignore
+    @staticmethod
+    @click.command("GaussianSpotDetector")
+    @click.option(
+        "--min-sigma", default=4, type=int, help="Minimum spot size (in standard deviation)")
+    @click.option(
+        "--max-sigma", default=6, type=int, help="Maximum spot size (in standard deviation)")
+    @click.option(
+        "--num-sigma", default=20, type=int, help="Number of sigmas to try")
+    @click.option(
+        "--threshold", default=.01, type=float, help="Dots threshold")
+    @click.option(
+        "--overlap", default=0.5, type=float,
+        help="dots with overlap of greater than this fraction are combined")
+    @click.option(
+        "--show", default=False, is_flag=True, help="display results visually")
+    @click.pass_context
+    def _cli(ctx, min_sigma, max_sigma, num_sigma, threshold, overlap, show):
+            instance = GaussianSpotDetector(min_sigma, max_sigma, num_sigma, threshold, overlap)
+            #  FIXME: measurement_type, is_volume missing as options; show missing as ctor args
+            ctx.obj["component"]._cli_run(ctx, instance)

--- a/starfish/spots/_detector/local_max_peak_finder.py
+++ b/starfish/spots/_detector/local_max_peak_finder.py
@@ -1,5 +1,6 @@
 from typing import List, Optional, Tuple, Union
 
+import click
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -303,32 +304,41 @@ class LocalMaxPeakFinder(SpotFinderAlgorithmBase):
 
         return intensity_table
 
-    @classmethod
-    def _add_arguments(cls, group_parser):
-        group_parser.add_argument(
-            "--min-distance", default=4, type=int,
-            help="Minimum spot size (in number of pixels deviation)")
-        group_parser.add_argument(
-            "--min-obj-area", default=6, type=int,
-            help="Maximum spot size (in number of pixels")
-        group_parser.add_argument(
-            "--max_obj_area", default=300, type=int,
-            help="Maximum spot size (in number of pixels)")
-        group_parser.add_argument(
-            "--stringency", default=0, type=int,
-            help="Number of indices in threshold list to look past "
-                 "for the threhsold finding algorithm")
-        group_parser.add_argument("--threshold", default=None, type=float,
-                                  help="Threshold on which to threshold "
-                                       "image prior to spot detection")
-        group_parser.add_argument(
-            "--min-num-spots-detected", default=3, type=int,
-            help="Minimum number of spots detected at which to stop a"
-                 "utomatic thresholding algorithm")
-        group_parser.add_argument(
-            "--measurement-type", default='max', type=str,
-            help="How to aggregate pixel intensities in a spot")
-        group_parser.add_argument(
-            "--is-volume", default=False, action='store_false', help="Find spots in 3D or not")
-        group_parser.add_argument(
-            "--verbose", default=True, action='store_true', help="Verbosity flag")
+@click.command("LocalMaxPeakFinder")
+@click.option(
+    "--min-distance", default=4, type=int,
+    help="Minimum spot size (in number of pixels deviation)")
+@click.option(
+    "--min-obj-area", default=6, type=int,
+    help="Maximum spot size (in number of pixels")
+@click.option(
+    "--max_obj_area", default=300, type=int,
+    help="Maximum spot size (in number of pixels)")
+@click.option(
+    "--stringency", default=0, type=int,
+    help="Number of indices in threshold list to look past "
+         "for the threhsold finding algorithm")
+@click.option(
+    "--threshold", default=None, type=float,
+    help="Threshold on which to threshold "
+         "image prior to spot detection")
+@click.option(
+    "--min-num-spots-detected", default=3, type=int,
+    help="Minimum number of spots detected at which to stop a"
+         "utomatic thresholding algorithm")
+@click.option(
+    "--measurement-type", default='max', type=str,
+    help="How to aggregate pixel intensities in a spot")
+@click.option(
+    "--is-volume", default=False, action='store_false', help="Find spots in 3D or not")
+@click.option(
+    "--verbose", default=True, action='store_true', help="Verbosity flag")
+@click.pass_context
+def _cli(ctx, min_distance, min_obj_area, max_obj_area, stringency, threshold,
+         min_num_spots_detected, measurement_type, is_volume, verbose):
+    instance = LocalMaxPeakFinder(min_distance, min_obj_area, max_obj_area, stringency, threshold,
+                                  min_num_spots_detected, measurement_type, is_volume, verbose)
+    ctx.obj["component"]._cli_run(ctx, instance)
+
+
+LocalMaxPeakFinder._cli = _cli  # type: ignore

--- a/starfish/spots/_detector/local_max_peak_finder.py
+++ b/starfish/spots/_detector/local_max_peak_finder.py
@@ -304,41 +304,40 @@ class LocalMaxPeakFinder(SpotFinderAlgorithmBase):
 
         return intensity_table
 
-@click.command("LocalMaxPeakFinder")
-@click.option(
-    "--min-distance", default=4, type=int,
-    help="Minimum spot size (in number of pixels deviation)")
-@click.option(
-    "--min-obj-area", default=6, type=int,
-    help="Maximum spot size (in number of pixels")
-@click.option(
-    "--max_obj_area", default=300, type=int,
-    help="Maximum spot size (in number of pixels)")
-@click.option(
-    "--stringency", default=0, type=int,
-    help="Number of indices in threshold list to look past "
-         "for the threhsold finding algorithm")
-@click.option(
-    "--threshold", default=None, type=float,
-    help="Threshold on which to threshold "
-         "image prior to spot detection")
-@click.option(
-    "--min-num-spots-detected", default=3, type=int,
-    help="Minimum number of spots detected at which to stop a"
-         "utomatic thresholding algorithm")
-@click.option(
-    "--measurement-type", default='max', type=str,
-    help="How to aggregate pixel intensities in a spot")
-@click.option(
-    "--is-volume", default=False, action='store_false', help="Find spots in 3D or not")
-@click.option(
-    "--verbose", default=True, action='store_true', help="Verbosity flag")
-@click.pass_context
-def _cli(ctx, min_distance, min_obj_area, max_obj_area, stringency, threshold,
-         min_num_spots_detected, measurement_type, is_volume, verbose):
-    instance = LocalMaxPeakFinder(min_distance, min_obj_area, max_obj_area, stringency, threshold,
-                                  min_num_spots_detected, measurement_type, is_volume, verbose)
-    ctx.obj["component"]._cli_run(ctx, instance)
-
-
-LocalMaxPeakFinder._cli = _cli  # type: ignore
+    @staticmethod
+    @click.command("LocalMaxPeakFinder")
+    @click.option(
+        "--min-distance", default=4, type=int,
+        help="Minimum spot size (in number of pixels deviation)")
+    @click.option(
+        "--min-obj-area", default=6, type=int,
+        help="Maximum spot size (in number of pixels")
+    @click.option(
+        "--max_obj_area", default=300, type=int,
+        help="Maximum spot size (in number of pixels)")
+    @click.option(
+        "--stringency", default=0, type=int,
+        help="Number of indices in threshold list to look past "
+             "for the threhsold finding algorithm")
+    @click.option(
+        "--threshold", default=None, type=float,
+        help="Threshold on which to threshold "
+             "image prior to spot detection")
+    @click.option(
+        "--min-num-spots-detected", default=3, type=int,
+        help="Minimum number of spots detected at which to stop a"
+             "utomatic thresholding algorithm")
+    @click.option(
+        "--measurement-type", default='max', type=str,
+        help="How to aggregate pixel intensities in a spot")
+    @click.option(
+        "--is-volume", default=False, action='store_false', help="Find spots in 3D or not")
+    @click.option(
+        "--verbose", default=True, action='store_true', help="Verbosity flag")
+    @click.pass_context
+    def _cli(ctx, min_distance, min_obj_area, max_obj_area, stringency, threshold,
+             min_num_spots_detected, measurement_type, is_volume, verbose):
+        instance = LocalMaxPeakFinder(min_distance, min_obj_area, max_obj_area,
+                                      stringency, threshold,
+                                      min_num_spots_detected, measurement_type, is_volume, verbose)
+        ctx.obj["component"]._cli_run(ctx, instance)

--- a/starfish/spots/_detector/pixel_spot_detector.py
+++ b/starfish/spots/_detector/pixel_spot_detector.py
@@ -87,50 +87,47 @@ class PixelSpotDetector(SpotFinderAlgorithmBase):
 
         return decoded_spots, image_decoding_results
 
-
-@click.command("PixelSpotDetector")
-@click.option("--metric", type=str, default='euclidean')
-@click.option(
-    "--distance-threshold", type=float, default=0.5176,
-    help="maximum distance a pixel may be from a codeword before it is filtered"
-)
-@click.option(
-    "--magnitude-threshold", type=float, default=1,
-    help="minimum magnitude of a feature"
-)
-@click.option(
-    "--min-area", type=int, default=2,
-    help="minimum area of a feature"
-)
-@click.option(
-    "--max-area", type=int, default=np.inf,
-    help="maximum area of a feature"
-)
-@click.option(
-    "--norm-order", type=int, default=2,
-    help="order of L_p norm to apply to intensities "
-    "and codes when using metric_decode to pair each intensities to its closest target"
-)
-@click.option('--crop-x', type=int, default=0)
-@click.option('--crop-y', type=int, default=0)
-@click.option('--crop-z', type=int, default=0)
-@click.pass_context
-def _cli(ctx, metric, distance_threshold, magnitude_threshold,
-         min_area, max_area, norm_order, crop_x, crop_y, crop_z):
-    codebook = ctx.obj["codebook"]
-    instance = PixelSpotDetector(
-        codebook=codebook,
-        metric=metric,
-        distance_threshold=distance_threshold,
-        magnitude_threshold=magnitude_threshold,
-        min_area=min_area,
-        max_area=max_area,
-        norm_order=norm_order,
-        crop_x=crop_x,
-        crop_y=crop_y,
-        crop_z=crop_z
+    @staticmethod
+    @click.command("PixelSpotDetector")
+    @click.option("--metric", type=str, default='euclidean')
+    @click.option(
+        "--distance-threshold", type=float, default=0.5176,
+        help="maximum distance a pixel may be from a codeword before it is filtered"
     )
-    ctx.obj["component"]._cli_run(ctx, instance)
-
-
-PixelSpotDetector._cli = _cli  # type: ignore
+    @click.option(
+        "--magnitude-threshold", type=float, default=1,
+        help="minimum magnitude of a feature"
+    )
+    @click.option(
+        "--min-area", type=int, default=2,
+        help="minimum area of a feature"
+    )
+    @click.option(
+        "--max-area", type=int, default=np.inf,
+        help="maximum area of a feature"
+    )
+    @click.option(
+        "--norm-order", type=int, default=2,
+        help="order of L_p norm to apply to intensities "
+        "and codes when using metric_decode to pair each intensities to its closest target"
+    )
+    @click.option('--crop-x', type=int, default=0)
+    @click.option('--crop-y', type=int, default=0)
+    @click.option('--crop-z', type=int, default=0)
+    @click.pass_context
+    def _cli(ctx, metric, distance_threshold, magnitude_threshold,
+             min_area, max_area, norm_order, crop_x, crop_y, crop_z):
+        codebook = ctx.obj["codebook"]
+        instance = PixelSpotDetector(
+            codebook=codebook,
+            metric=metric,
+            distance_threshold=distance_threshold,
+            magnitude_threshold=magnitude_threshold,
+            min_area=min_area,
+            max_area=max_area,
+            norm_order=norm_order,
+            crop_x=crop_x,
+            crop_y=crop_y,
+            crop_z=crop_z
+        )
+        ctx.obj["component"]._cli_run(ctx, instance)

--- a/starfish/spots/_detector/pixel_spot_detector.py
+++ b/starfish/spots/_detector/pixel_spot_detector.py
@@ -1,5 +1,6 @@
 from typing import Tuple
 
+import click
 import numpy as np
 
 from starfish.codebook.codebook import Codebook
@@ -13,7 +14,7 @@ class PixelSpotDetector(SpotFinderAlgorithmBase):
     def __init__(
             self, codebook: Codebook, metric: str, distance_threshold: float,
             magnitude_threshold: int, min_area: int, max_area: int, norm_order: int=2,
-            crop_x: int=0, crop_y: int=0, crop_z: int=0, **kwargs) -> None:
+            crop_x: int=0, crop_y: int=0, crop_z: int=0) -> None:
         """Decode an image by first coding each pixel, then combining the results into spots
 
         Parameters
@@ -86,30 +87,50 @@ class PixelSpotDetector(SpotFinderAlgorithmBase):
 
         return decoded_spots, image_decoding_results
 
-    @classmethod
-    def _add_arguments(cls, group_parser):
-        group_parser.add_argument("--metric", type=str, default='euclidean')
-        group_parser.add_argument(
-            "--distance-threshold", type=float, default=0.5176,
-            help="maximum distance a pixel may be from a codeword before it is filtered"
-        )
-        group_parser.add_argument(
-            "--magnitude-threshold", type=float, default=1,
-            help="minimum magnitude of a feature"
-        )
-        group_parser.add_argument(
-            "--min-area", type=int, default=2,
-            help="minimum area of a feature"
-        )
-        group_parser.add_argument(
-            "--max-area", type=int, default=np.inf,
-            help="maximum area of a feature"
-        )
-        group_parser.add_argument(
-            "--norm-order", type=int, default=2,
-            help="order of L_p norm to apply to intensities "
-            "and codes when using metric_decode to pair each intensities to its closest target"
-        )
-        group_parser.add_argument('--crop-x', type=int, default=0)
-        group_parser.add_argument('--crop-y', type=int, default=0)
-        group_parser.add_argument('--crop-z', type=int, default=0)
+
+@click.command("PixelSpotDetector")
+@click.option("--metric", type=str, default='euclidean')
+@click.option(
+    "--distance-threshold", type=float, default=0.5176,
+    help="maximum distance a pixel may be from a codeword before it is filtered"
+)
+@click.option(
+    "--magnitude-threshold", type=float, default=1,
+    help="minimum magnitude of a feature"
+)
+@click.option(
+    "--min-area", type=int, default=2,
+    help="minimum area of a feature"
+)
+@click.option(
+    "--max-area", type=int, default=np.inf,
+    help="maximum area of a feature"
+)
+@click.option(
+    "--norm-order", type=int, default=2,
+    help="order of L_p norm to apply to intensities "
+    "and codes when using metric_decode to pair each intensities to its closest target"
+)
+@click.option('--crop-x', type=int, default=0)
+@click.option('--crop-y', type=int, default=0)
+@click.option('--crop-z', type=int, default=0)
+@click.pass_context
+def _cli(ctx, metric, distance_threshold, magnitude_threshold,
+         min_area, max_area, norm_order, crop_x, crop_y, crop_z):
+    codebook = ctx.obj["codebook"]
+    instance = PixelSpotDetector(
+        codebook=codebook,
+        metric=metric,
+        distance_threshold=distance_threshold,
+        magnitude_threshold=magnitude_threshold,
+        min_area=min_area,
+        max_area=max_area,
+        norm_order=norm_order,
+        crop_x=crop_x,
+        crop_y=crop_y,
+        crop_z=crop_z
+    )
+    ctx.obj["component"]._cli_run(ctx, instance)
+
+
+PixelSpotDetector._cli = _cli  # type: ignore

--- a/starfish/spots/_detector/trackpy_local_max_peak_finder.py
+++ b/starfish/spots/_detector/trackpy_local_max_peak_finder.py
@@ -161,43 +161,40 @@ class TrackpyLocalMaxPeakFinder(SpotFinderAlgorithmBase):
 
         return intensity_table
 
+    @staticmethod
+    @click.command("TrackpyLocalMaxPeakFinder")
+    @click.option("--spot-diameter", type=str, help='expected spot size')
+    @click.option(
+        "--min-mass", default=4, type=int, help="minimum integrated spot intensity")
+    @click.option(
+        "--max-size", default=6, type=int, help="maximum radius of gyration of brightness")
+    @click.option(
+        "--separation", default=5, type=float, help="minimum distance between spots")
+    @click.option(
+        "--noise-size", default=None, type=int,
+        help="width of gaussian blurring kernel, in pixels")
+    @click.option(
+        "--smoothing-size", default=None, type=int,
+        help="odd integer. Size of boxcar (moving average) filter in pixels. Default is the "
+             "Diameter"
+    )
+    @click.option(
+        "--preprocess", is_flag=True,
+        help="if passed, gaussian and boxcar filtering are applied")
+    @click.option(
+        "--show", default=False, is_flag=True, help="display results visually")
+    @click.option(
+        "--percentile", default=None, type=float,
+        help="clip bandpass below this value. Thresholding is done on already background-"
+             "subtracted images. Default 1 for integer images and 1/255 for float")
+    @click.option(
+        "--is-volume", is_flag=True,
+        help="indicates that the image stack should be filtered in 3d")
+    @click.pass_context
+    def _cli(ctx, spot_diameter, min_max, max_size, separation, noise_size, smoothing_size,
+             preprocess, show, percentile, is_volume):
 
-@click.command("TrackpyLocalMaxPeakFinder")
-@click.option("--spot-diameter", type=str, help='expected spot size')
-@click.option(
-    "--min-mass", default=4, type=int, help="minimum integrated spot intensity")
-@click.option(
-    "--max-size", default=6, type=int, help="maximum radius of gyration of brightness")
-@click.option(
-    "--separation", default=5, type=float, help="minimum distance between spots")
-@click.option(
-    "--noise-size", default=None, type=int,
-    help="width of gaussian blurring kernel, in pixels")
-@click.option(
-    "--smoothing-size", default=None, type=int,
-    help="odd integer. Size of boxcar (moving average) filter in pixels. Default is the "
-         "Diameter"
-)
-@click.option(
-    "--preprocess", is_flag=True,
-    help="if passed, gaussian and boxcar filtering are applied")
-@click.option(
-    "--show", default=False, is_flag=True, help="display results visually")
-@click.option(
-    "--percentile", default=None, type=float,
-    help="clip bandpass below this value. Thresholding is done on already background-"
-         "subtracted images. Default 1 for integer images and 1/255 for float")
-@click.option(
-    "--is-volume", is_flag=True,
-    help="indicates that the image stack should be filtered in 3d")
-@click.pass_context
-def _cli(ctx, spot_diameter, min_max, max_size, separation, noise_size, smoothing_size,
-         preprocess, show, percentile, is_volume):
-
-    instance = TrackpyLocalMaxPeakFinder(spot_diameter, min_max, max_size,
-                                         separation, noise_size, smoothing_size,
-                                         preprocess, show, percentile, is_volume)
-    ctx.obj["component"]._cli_run(ctx, instance)
-
-
-TrackpyLocalMaxPeakFinder._cli = _cli  # type: ignore
+        instance = TrackpyLocalMaxPeakFinder(spot_diameter, min_max, max_size,
+                                             separation, noise_size, smoothing_size,
+                                             preprocess, show, percentile, is_volume)
+        ctx.obj["component"]._cli_run(ctx, instance)

--- a/starfish/spots/_detector/trackpy_local_max_peak_finder.py
+++ b/starfish/spots/_detector/trackpy_local_max_peak_finder.py
@@ -1,6 +1,7 @@
 import warnings
 from typing import Optional, Tuple, Union
 
+import click
 import numpy as np
 import xarray as xr
 from trackpy import locate
@@ -18,7 +19,7 @@ class TrackpyLocalMaxPeakFinder(SpotFinderAlgorithmBase):
             self, spot_diameter, min_mass, max_size, separation, percentile=0,
             noise_size: Tuple[int, int, int]=(1, 1, 1), smoothing_size=None, threshold=None,
             preprocess: bool=False, measurement_type: str='max', is_volume: bool=False,
-            verbose=False, **kwargs) -> None:
+            verbose=False) -> None:
         """Find spots using a local max peak finding algorithm
 
         This is a wrapper for `trackpy.locate`
@@ -160,32 +161,43 @@ class TrackpyLocalMaxPeakFinder(SpotFinderAlgorithmBase):
 
         return intensity_table
 
-    @classmethod
-    def _add_arguments(cls, group_parser):
-        group_parser.add_argument("--spot-diameter", type=str, help='expected spot size')
-        group_parser.add_argument(
-            "--min-mass", default=4, type=int, help="minimum integrated spot intensity")
-        group_parser.add_argument(
-            "--max-size", default=6, type=int, help="maximum radius of gyration of brightness")
-        group_parser.add_argument(
-            "--separation", default=5, type=float, help="minimum distance between spots")
-        group_parser.add_argument(
-            "--noise-size", default=None, type=int,
-            help="width of gaussian blurring kernel, in pixels")
-        group_parser.add_argument(
-            "--smoothing-size", default=None, type=int,
-            help="odd integer. Size of boxcar (moving average) filter in pixels. Default is the "
-                 "Diameter"
-        )
-        group_parser.add_argument(
-            "--preprocess", action="store_true",
-            help="if passed, gaussian and boxcar filtering are applied")
-        group_parser.add_argument(
-            "--show", default=False, action='store_true', help="display results visually")
-        group_parser.add_argument(
-            "--percentile", default=None, type=float,
-            help="clip bandpass below this value. Thresholding is done on already background-"
-                 "subtracted images. Default 1 for integer images and 1/255 for float")
-        group_parser.add_argument(
-            "--is-volume", action="store_true",
-            help="indicates that the image stack should be filtered in 3d")
+
+@click.command("TrackpyLocalMaxPeakFinder")
+@click.option("--spot-diameter", type=str, help='expected spot size')
+@click.option(
+    "--min-mass", default=4, type=int, help="minimum integrated spot intensity")
+@click.option(
+    "--max-size", default=6, type=int, help="maximum radius of gyration of brightness")
+@click.option(
+    "--separation", default=5, type=float, help="minimum distance between spots")
+@click.option(
+    "--noise-size", default=None, type=int,
+    help="width of gaussian blurring kernel, in pixels")
+@click.option(
+    "--smoothing-size", default=None, type=int,
+    help="odd integer. Size of boxcar (moving average) filter in pixels. Default is the "
+         "Diameter"
+)
+@click.option(
+    "--preprocess", is_flag=True,
+    help="if passed, gaussian and boxcar filtering are applied")
+@click.option(
+    "--show", default=False, is_flag=True, help="display results visually")
+@click.option(
+    "--percentile", default=None, type=float,
+    help="clip bandpass below this value. Thresholding is done on already background-"
+         "subtracted images. Default 1 for integer images and 1/255 for float")
+@click.option(
+    "--is-volume", is_flag=True,
+    help="indicates that the image stack should be filtered in 3d")
+@click.pass_context
+def _cli(ctx, spot_diameter, min_max, max_size, separation, noise_size, smoothing_size,
+         preprocess, show, percentile, is_volume):
+
+    instance = TrackpyLocalMaxPeakFinder(spot_diameter, min_max, max_size,
+                                         separation, noise_size, smoothing_size,
+                                         preprocess, show, percentile, is_volume)
+    ctx.obj["component"]._cli_run(ctx, instance)
+
+
+TrackpyLocalMaxPeakFinder._cli = _cli  # type: ignore

--- a/starfish/spots/_target_assignment/__init__.py
+++ b/starfish/spots/_target_assignment/__init__.py
@@ -26,22 +26,21 @@ class TargetAssignment(PipelineComponent):
         print(f"Writing intensities, including cell ids to {output}")
         assigned.save(os.path.join(output))
 
+    @staticmethod
+    @click.group("target_assignment")
+    @click.option("--label-image", required=True, type=click.Path(exists=True))
+    @click.option("--intensities", required=True, type=click.Path(exists=True))
+    @click.option("-o", "--output", required=True)
+    @click.pass_context
+    def _cli(ctx, label_image, intensities, output):
 
-@click.group("target_assignment")
-@click.option("--label-image", required=True, type=click.Path(exists=True))
-@click.option("--intensities", required=True, type=click.Path(exists=True))
-@click.option("-o", "--output", required=True)
-@click.pass_context
-def _cli(ctx, label_image, intensities, output):
-
-    print('Assigning targets to cells...')
-    ctx.obj = dict(
-        component=TargetAssignment,
-        output=output,
-        intensity_table=IntensityTable.load(intensities),
-        label_image=imread(label_image)
-    )
+        print('Assigning targets to cells...')
+        ctx.obj = dict(
+            component=TargetAssignment,
+            output=output,
+            intensity_table=IntensityTable.load(intensities),
+            label_image=imread(label_image)
+        )
 
 
-TargetAssignment._cli = _cli  # type: ignore
 TargetAssignment._cli_register()

--- a/starfish/spots/_target_assignment/__init__.py
+++ b/starfish/spots/_target_assignment/__init__.py
@@ -1,60 +1,47 @@
-import argparse
 import os
 from typing import Type
 
+import click
 import numpy as np
 from skimage.io import imread
 
 from starfish.intensity_table.intensity_table import IntensityTable
 from starfish.pipeline import AlgorithmBase, PipelineComponent
-from starfish.util.argparse import FsExistsType
 from . import label
 from ._base import TargetAssignmentAlgorithm
 
 
 class TargetAssignment(PipelineComponent):
 
-    target_assignment_group: argparse.ArgumentParser
-
     @classmethod
     def _get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
         return TargetAssignmentAlgorithm
 
     @classmethod
-    def add_to_parser(cls, subparsers) -> None:
-        """Adds the target_assignment component to the CLI argument parser."""
-        target_assignment_group = subparsers.add_parser("target_assignment")
-        target_assignment_group.add_argument(
-            "--label-image", type=FsExistsType(), required=True)
-        target_assignment_group.add_argument("--intensities", type=FsExistsType(), required=True)
-        target_assignment_group.add_argument("-o", "--output", required=True)
-        target_assignment_group.set_defaults(starfish_command=TargetAssignment._cli)
-        target_assignment_group = target_assignment_group.add_subparsers(
-            dest="target_assignment_algorithm_class")
+    def _cli_run(cls, ctx, instance):
+        output = ctx.obj["output"]
+        intensity_table = ctx.obj["intensity_table"]
+        label_image = ctx.obj["label_image"]
+        assigned = instance.run(label_image, intensity_table)
+        print(f"Writing intensities, including cell ids to {output}")
+        assigned.save(os.path.join(output))
 
-        for algorithm_cls in cls._algorithm_to_class_map().values():
-            group_parser = target_assignment_group.add_parser(algorithm_cls._get_algorithm_name())
-            group_parser.set_defaults(target_assignment_algorithm_class=algorithm_cls)
-            algorithm_cls._add_arguments(group_parser)
 
-        cls.target_assignment_group = target_assignment_group
+@click.group("target_assignment")
+@click.option("--label-image", required=True, type=click.Path(exists=True))
+@click.option("--intensities", required=True, type=click.Path(exists=True))
+@click.option("-o", "--output", required=True)
+@click.pass_context
+def _cli(ctx, label_image, intensities, output):
 
-    @classmethod
-    def _cli(cls, args, print_help=False) -> None:
-        """Runs the target_assignment component based on parsed arguments."""
+    print('Assigning targets to cells...')
+    ctx.obj = dict(
+        component=TargetAssignment,
+        output=output,
+        intensity_table=IntensityTable.load(intensities),
+        label_image=imread(label_image)
+    )
 
-        if args.target_assignment_algorithm_class is None or print_help:
-            cls.target_assignment_group.print_help()
-            cls.target_assignment_group.exit(status=2)
 
-        label_image: np.ndarray = imread(args.label_image)
-
-        print('Assigning targets to cells...')
-        intensity_table = IntensityTable.load(args.intensities)
-
-        instance = args.target_assignment_algorithm_class(**vars(args))
-
-        intensities = instance.run(label_image, intensity_table)
-
-        print("Writing intensities, including cell ids to {}".format(args.output))
-        intensities.save(os.path.join(args.output))
+TargetAssignment._cli = _cli  # type: ignore
+TargetAssignment._cli_register()

--- a/starfish/spots/_target_assignment/label.py
+++ b/starfish/spots/_target_assignment/label.py
@@ -70,9 +70,8 @@ class Label(TargetAssignmentAlgorithm):
         """
         return self._assign(label_image, intensity_table, in_place=in_place)
 
-
-@click.command("Label")
-@click.pass_context
-def _cli(ctx):
-    ctx.obj["component"]._cli_run(ctx, Label())
-Label._cli = _cli  # type: ignore
+    @staticmethod
+    @click.command("Label")
+    @click.pass_context
+    def _cli(ctx):
+        ctx.obj["component"]._cli_run(ctx, Label())

--- a/starfish/spots/_target_assignment/label.py
+++ b/starfish/spots/_target_assignment/label.py
@@ -1,3 +1,4 @@
+import click
 import numpy as np
 
 from starfish.intensity_table.intensity_table import IntensityTable
@@ -68,3 +69,10 @@ class Label(TargetAssignmentAlgorithm):
 
         """
         return self._assign(label_image, intensity_table, in_place=in_place)
+
+
+@click.command("Label")
+@click.pass_context
+def _cli(ctx):
+    ctx.obj["component"]._cli_run(ctx, Label())
+Label._cli = _cli  # type: ignore

--- a/starfish/starfish.py
+++ b/starfish/starfish.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
-
-import argparse
 import cProfile
 from pstats import Stats
 
-from sptx_format.cli import Cli as ValidateCli
+import click
+from sptx_format.cli import validate as validate_cli
 
-from starfish.experiment.builder.cli import Cli as BuilderCli
+from starfish.experiment.builder.cli import build as build_cli
 from starfish.image import (
     Filter,
     Registration,
@@ -17,42 +16,6 @@ from starfish.spots import (
     SpotFinder,
     TargetAssignment,
 )
-from .util.argparse import FsExistsType
-
-
-def build_parser():
-    parser = argparse.ArgumentParser()
-
-    parser.add_argument("--profile", action="store_true", help="enable profiling")
-    parser.add_argument(
-        "--noop",
-        help=argparse.SUPPRESS,
-        dest="starfish_command",
-        action="store_const",
-        const=noop
-    )
-
-    subparsers = parser.add_subparsers(dest="starfish_command")
-
-    Registration._add_to_parser(subparsers)
-    Filter._add_to_parser(subparsers)
-    SpotFinder.add_to_parser(subparsers)
-    Segmentation._add_to_parser(subparsers)
-    TargetAssignment.add_to_parser(subparsers)
-    Decoder.add_to_parser(subparsers)
-
-    show_group = subparsers.add_parser("show")
-    show_group.add_argument("in_json", type=FsExistsType())
-    show_group.add_argument("--sz", default=10, type=int, help="Figure size")
-    show_group.set_defaults(starfish_command=show)
-
-    build_group = subparsers.add_parser("build")
-    BuilderCli.add_to_parser(build_group)
-
-    validate_group = subparsers.add_parser("validate")
-    ValidateCli.add_to_parser(validate_group)
-
-    return parser
 
 
 PROFILER_KEY = "profiler"
@@ -61,10 +24,10 @@ PROFILER_LINES = 15
 """This is the number of profiling rows to dump when --profile is enabled."""
 
 
-def starfish():
-    parser = build_parser()
-    args, argv = parser.parse_known_args()
-
+@click.group()
+@click.option("--profile", is_flag=True)
+@click.pass_context
+def starfish(ctx, profile):
     art = """
          _              __ _     _
         | |            / _(_)   | |
@@ -74,32 +37,54 @@ def starfish():
     |___/\__\__,_|_|  |_| |_|___/_| |_|
 
     """
-    print(art)
-    if args.profile:
+    print_art = True
+    sub = ctx.command.get_command(ctx, ctx.invoked_subcommand)
+    if hasattr(sub, "no_art"):
+        print_art = not sub.no_art
+    if print_art:
+        print(art)
+    if profile:
         profiler = cProfile.Profile()
         profiler.enable()
 
-    if args.starfish_command is None:
-        parser.print_help()
-        parser.exit(status=2)
-    args.starfish_command(args, len(argv) != 0)
+        def print_profile():
+            stats = Stats(profiler)
+            stats.sort_stats('tottime').print_stats(PROFILER_LINES)
 
-    if args.profile:
-        stats = Stats(profiler)
-        stats.sort_stats('tottime').print_stats(PROFILER_LINES)
+        ctx.call_on_close(print_profile)
 
 
-def show(args, print_help=False):
+@starfish.command()
+def version():
+    import pkg_resources
+    version = pkg_resources.require("starfish")[0].version
+    print(version)
+version.no_art = True  # type: ignore
+
+
+@starfish.command()
+@click.argument("in_json", type=click.Path(exists=True, dir_okay=False))
+@click.option("--sz", default=10, type=int, help="Figure size")
+def show(in_json, sz):
     import matplotlib.pyplot as plt
     from showit import tile
 
     from .experiment import Experiment
 
     s = Experiment()
-    s.read(args.in_json)
-    tile(s.image.squeeze(), size=args.sz, bar=True)
+    s.read(in_json)
+    tile(s.image.squeeze(), size=sz, bar=True)
     plt.show()
 
 
-def noop(args, print_help=False):
-    pass
+# Pipelines
+starfish.add_command(Registration._cli)  # type: ignore
+starfish.add_command(Filter._cli)  # type: ignore
+starfish.add_command(SpotFinder._cli)  # type: ignore
+starfish.add_command(Segmentation._cli)  # type: ignore
+starfish.add_command(TargetAssignment._cli)  # type: ignore
+starfish.add_command(Decoder._cli)  # type: ignore
+
+# Other
+starfish.add_command(build_cli)  # type: ignore
+starfish.add_command(validate_cli)  # type: ignore

--- a/starfish/test/full_pipelines/cli/test_iss.py
+++ b/starfish/test/full_pipelines/cli/test_iss.py
@@ -94,9 +94,9 @@ class TestWithIssData(CLITest, unittest.TestCase):
             ],
             [
                 "starfish", "segment",
-                "--hybridization-stack", lambda tempdir, *args, **kwargs: os.path.join(
+                "--primary-images", lambda tempdir, *args, **kwargs: os.path.join(
                     tempdir, "filtered", "hybridization.json"),
-                "--nuclei-stack", lambda tempdir, *args, **kwargs: os.path.join(
+                "--nuclei", lambda tempdir, *args, **kwargs: os.path.join(
                     tempdir, "filtered", "nuclei.json"),
                 "-o", lambda tempdir, *args, **kwargs: os.path.join(
                     tempdir, "results", "label_image.png"),

--- a/starfish/test/full_pipelines/cli/test_profiler.py
+++ b/starfish/test/full_pipelines/cli/test_profiler.py
@@ -3,11 +3,11 @@ import subprocess
 
 
 def test_profiler():
-    """Make sure that `starfish --profile --noop works."""
+    """Make sure that `starfish --profile works."""
     cmdline = [
         "starfish",
         "--profile",
-        "--noop",
+        "version",
     ]
     env = os.environ.copy()
     subprocess.check_call(cmdline, env=env)

--- a/starfish/test/image/filter/test_api_contract.py
+++ b/starfish/test/image/filter/test_api_contract.py
@@ -39,8 +39,8 @@ def test_all_methods_adhere_to_contract(filter_class):
 
     default_kwargs = filter_class._DEFAULT_TESTING_PARAMETERS
 
-    # accept boolean is_volume
-    instance = filter_class(is_volume=True, **default_kwargs)
+    # TODO ambrosejcarr: all filters should accept boolean is_volume
+    instance = filter_class(**default_kwargs)
 
     # TODO ambrosejcarr: all methods should process 3d data
     # # stores is_volume, and is_volume is a bool

--- a/starfish/test/image/filter/test_zero_by_channel_magnitude.py
+++ b/starfish/test/image/filter/test_zero_by_channel_magnitude.py
@@ -16,6 +16,6 @@ def create_imagestack_with_magnitude_scale():
 def test_zero_by_channel_magnitude_produces_accurate_results():
     imagestack = create_imagestack_with_magnitude_scale()
 
-    zcm = ZeroByChannelMagnitude(thresh=np.inf, normalize=False, is_volume=False)
+    zcm = ZeroByChannelMagnitude(thresh=np.inf, normalize=False)
     filtered = zcm.run(imagestack, in_place=False, n_processes=1)
     assert np.all(filtered.xarray == 0)


### PR DESCRIPTION
The general call flow here (which likely needs documenting somewhere for devs) is:

 1. `python -m starfish` imports `starfish.starfish` which:
    - imports (if they aren't already) pipeline components (filter, decoder, etc.) which each import their concrete algorithms causing them to be initiated and prepared for registering via the new `PipelineCompenent._cli_register` method
    - defines `starfish.starfish.starfish` which is now a `click.group`
    - registers commands using the `@starfish.command` decorator
    - registers other commands using the `starfish.add_command` method, each of which already has its subcommands from the use of `_cli_register`
2. invocation begins with calling sf.sf.sf; when it completes
3. each subcommand executes from left to right (if a cleanup method is needed, then use `ctx.call_on_close`)

In the concrete example of a pipeline component like `filter` and an algorithm like `clip` invoked using:

```
starfish ... filter ... clip ...
```

 * `starfish` is only responsible for `--profile` (at the moment)
 * `filter` takes `--input` and `--output` via the `_cli()` method at the *bottom* of the module
 * `filter._cli` checks & opens resources as necessary, then sets them as a dictionary in `ctx.obj`
 * `clip._cli` is then called (also defined at the bottom of its module)
 * `clip._cli` is mostly responsible for the instantiation of `Clip`.
 * `clip._cli` then delegates itself to the classmethod `Filter._cli_run` as `instance`
 * `filter._cli_run` gathers the inputs from `ctx.obj`, calls `instance.run`, and saves any results to `output` as necessary.

In this PR:
 * [x] Remove all uses of `argparse` in `starfish/*` (except starfish.util.argparse)
 * [x] i.e. *not* updating `examples/get_*` for the moment
 * [x] Add a `version` command
 * [x] Add a mechanism `command.noart = True` to prevent artwork from being printed
 * [x] Add support for `python -m starfish` invocations to simplify testing
 * [x] Replace the argparse.FsExistsType

Out-of-scope:
 * Updating uses of `print()` etc. for better click integration
 * Integrating click with mypy

Test plan: 
 * `python -svxk cli`
 * General usability of `starfish ...`