### PR TITLE
fix schema IDs

### DIFF
--- a/sptx_format/schema/field_of_view/tiles/coordinates.json
+++ b/sptx_format/schema/field_of_view/tiles/coordinates.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/sptx-format/schema/field_of_view/tiles/coordinates.json",
+  "$id": "https://github.com/spacetx/starfish/sptx-format/schema/field_of_view/tiles/coordinates.json",
   "type": "object",
   "description": "Physical coordinates of the tile.",
   "required": [

--- a/sptx_format/schema/field_of_view/tiles/indices.json
+++ b/sptx_format/schema/field_of_view/tiles/indices.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/sptx-format/schema/field_of_view/tiles/indices.json",
+  "$id": "https://github.com/spacetx/starfish/sptx-format/schema/field_of_view/tiles/indices.json",
   "type": "object",
   "description": "Describes the categorical indices (channel, round, and z-section) of this tile.",
   "required": "c",


### PR DESCRIPTION
Currently this contains a minor unification, but the given URLs don't resolve. One possibility is to just add "tree/master", but that shouldn't be the general state of the files. On release we could conceivably update the files to point to the upcoming release roughly like https://github.com/spacetx/starfish/tree/0.0.27/validate_sptx/schema/experiment.json as a partial implementation of gh-700.