### PR TITLE
Add Barista-seq to starfish.data

### DIFF
--- a/starfish/data/__init__.py
+++ b/starfish/data/__init__.py
@@ -33,3 +33,23 @@ def ISS(use_test_data: bool=False):
 def osmFISH(use_test_data: bool=False):
     return Experiment.from_json(
         'https://d2nhj9g34unfro.cloudfront.net/20181005/osmFISH/experiment.json')
+
+
+def BaristaSeq(use_test_data: bool=False) -> Experiment:
+    """Loads a BaristaSeq dataset generated from mouse visual cortex. The extracted field of view
+    comes from an internal layer of V1 (range: 2-5)
+
+    Parameters
+    ----------
+    use_test_data : bool
+        This parameter is not used for this data type, as there is no data of testing size.
+
+    Returns
+    -------
+    Experiment
+        Experiment containing raw image data
+    """
+    return Experiment.from_json(
+        "https://s3.amazonaws.com/spacetx.starfish.data.public/browse/formatted/20181028/"
+        "BaristaSeq/cropped_formatted/experiment.json"
+    )


### PR DESCRIPTION
- Add Barista-seq to starfish.data

Testing strategy, from a notebook: 
```python3
%gui qt5
from starfish import data, types
exp = data.BaristaSeq()
image = exp['fov_000']['primary']
image.show_stack_napari({types.Indices.CH: 0})
```
