### PR TITLE
Pass the entire tensor to child processes as well as the slice indices

### DIFF
--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -6,8 +6,17 @@ from copy import deepcopy
 from functools import partial
 from itertools import product
 from typing import (
-    Any, Callable, Iterable, Iterator, List, Mapping, MutableSequence,
-    Optional, Sequence, Set, Tuple, Union
+    Any,
+    Callable,
+    Iterator,
+    List,
+    Mapping,
+    MutableSequence,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
 )
 
 import matplotlib.pyplot as plt
@@ -29,12 +38,14 @@ from starfish.experiment.builder.defaultproviders import OnesTile, tile_fetcher_
 from starfish.imagestack import indexing_utils
 from starfish.imagestack import physical_coordinate_calculator
 from starfish.intensity_table.intensity_table import IntensityTable
+from starfish.multiprocessing.shmem import SharedMemory
 from starfish.types import (
     Coordinates,
     Indices,
     PHYSICAL_COORDINATE_DIMENSION,
     PhysicalCoordinateTypes,
 )
+from starfish.util import StripArguments
 from starfish.util.try_import import try_import
 from ._mp_dataarray import MPDataArray
 
@@ -672,25 +683,6 @@ class ImageStack:
             a = zip(indices, items)
             yield {ind: val for (ind, val) in a}
 
-    def _iter_tiles(
-            self, indices: Iterable[Mapping[Indices, Union[int, slice]]]
-    ) -> Iterable[np.ndarray]:
-        """Given an iterable of indices, return a generator of numpy arrays from self
-
-        Parameters
-        ----------
-        indices, Iterable[Mapping[str, int]]
-            Iterable of indices that map a dimension (str) to a value (int)
-
-        Yields
-        ------
-        np.ndarray
-            Numpy array that corresponds to provided indices
-        """
-        for inds in indices:
-            array, axes = self.get_slice(inds)
-            yield array
-
     def apply(
             self,
             func: Callable,
@@ -784,17 +776,42 @@ class ImageStack:
             group_by = {Indices.X, Indices.Y}
 
         indices = list(self._iter_indices(group_by))
+        slice_list = [self._build_slice_list(index)[0]
+                      for index in indices]
 
+        indices_and_slice_list = zip(indices, slice_list)
         if verbose:
-            tiles = tqdm(self._iter_tiles(indices))
-        else:
-            tiles = self._iter_tiles(indices)
+            indices_and_slice_list = tqdm(indices_and_slice_list)
 
-        applyfunc: Callable = partial(func, **kwargs)
+        applyfunc: Callable = partial(
+            self._multiprocessing_workflow,
+            StripArguments(partial(func, **kwargs), positional_arguments_removed=(1, 2)),
+        )
 
-        with multiprocessing.Pool(n_processes) as pool:
-            results = pool.imap(applyfunc, tiles)
+        with multiprocessing.Pool(
+                n_processes,
+                initializer=SharedMemory.initializer,
+                initargs=((self._data._backing_mp_array,
+                           self._data._data.shape,
+                           self._data._data.dtype),)) as pool:
+            results = pool.imap(applyfunc, indices_and_slice_list)
             return list(zip(results, indices))
+
+    @staticmethod
+    def _multiprocessing_workflow(
+            worker_callable: Callable[[np.ndarray,
+                                       Mapping[Indices, int],
+                                       Tuple[Union[int, slice], ...]], Any],
+            indices_and_slice_list: Tuple[Mapping[Indices, int],
+                                          Tuple[Union[int, slice], ...]],
+    ):
+        backing_mp_array, shape, dtype = SharedMemory.get_payload()
+        unshaped_numpy_array = np.frombuffer(backing_mp_array.get_obj(), dtype=dtype)
+        numpy_array = unshaped_numpy_array.reshape(shape)
+
+        sliced = numpy_array[indices_and_slice_list[1]]
+
+        return worker_callable(sliced, *indices_and_slice_list)
 
     @property
     def tile_metadata(self) -> pd.DataFrame:

--- a/starfish/util/__init__.py
+++ b/starfish/util/__init__.py
@@ -1,0 +1,1 @@
+from ._functools import StripArguments

--- a/starfish/util/_functools.py
+++ b/starfish/util/_functools.py
@@ -1,0 +1,39 @@
+from typing import Callable, Container, Optional
+
+
+class StripArguments:
+    """
+    Class to strip out arguments to a function call.  This is spiritually the opposite of
+    functools.partial.  This proxy will remove some arguments and call the nested callable.
+
+    This is used in scenarios where factory methods and lambdas cannot be used, such as dispatching
+    work with multiprocessing.  Inputs to multiprocessing must be pickle-able, and factory methods
+    and lambdas always generate a lexical scope (i.e., locals()) that cannot be picked.
+
+    This class is initialized with a callable, positional argument positions to remove, and keyword
+    arguments to remove.
+
+    For instance, if someone expects a callable that accepts as its parameters (str, int, obj), but
+    the callable you have only accepts an int (and does not need the str, obj arguments), then wrap
+    the object with _StripArguments(my_callable, positional_arguments_removed=(0, 2)).
+    """
+    def __init__(
+            self,
+            func: Callable,
+            *,
+            positional_arguments_removed: Optional[Container[int]]=None,
+            keyword_arguments_removed: Container[set]=None,
+    ) -> None:
+        self.func = func
+        self.positional_arguments_removed = positional_arguments_removed or list()
+        self.keyword_arguments_removed = keyword_arguments_removed or set()
+
+    def __call__(self, *args, **kwargs):
+        called_args = [
+            arg
+            for ix, arg in enumerate(args)
+            if ix not in self.positional_arguments_removed
+        ]
+        for keyword_argument_removed in self.keyword_arguments_removed:
+            kwargs.remove(keyword_argument_removed)
+        return self.func(*called_args, **kwargs)


### PR DESCRIPTION
Currently, we are slicing the tensor in the parent process, and passing the slices to each of the child processes.  To share memory more efficiently, we want to pass the entire tensor (and the backing shared memory construct) to the child processes, and instead just pass the slice indices to the child process.  The child process will slice out the part of the tensor it is interested in, and then pass it to the callable (filter, spot calling code, etc.).

`_multiprocessing_workflow` is the entry point for the child processes.  It retrieves the tensor using the constructs provided by https://github.com/spacetx/starfish/pull/738, and slices the data.

Remove `_iter_tiles` as it is no longer needed.

Depends on #736, #737, #738, #739, #740

This is a continuation of #741 