### PR TITLE
Bump python-requests to 2.20.0

### DIFF
--- a/REQUIREMENTS-DEV.txt
+++ b/REQUIREMENTS-DEV.txt
@@ -73,7 +73,7 @@ PyWavelets==1.0.0
 PyYAML==3.13
 recommonmark==0.4.0
 regional==1.1.2
-requests==2.19.1
+requests==2.20.0
 scikit-image==0.14.0
 scikit-learn==0.19.2
 scipy==1.1.0

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -30,7 +30,7 @@ pytz==2018.5
 PyWavelets==1.0.0
 PyYAML==3.13
 regional==1.1.2
-requests==2.19.1
+requests==2.20.0
 scikit-image==0.14.0
 scikit-learn==0.19.2
 scipy==1.1.0


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2018-18074 affects < 2.20.0