### PR TITLE
sptx-format: remove uses of validate_sptx/validate-sptx

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
 max-line-length=100
 ignore: E301, E302, E305, E731, F811
-application-import-names = starfish, examples, validate_sptx
+application-import-names = starfish, examples, sptx_format
 import-order-style = smarkets

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include REQUIREMENTS.txt
-recursive-include validate_sptx/schema/ *.json
-recursive-include validate_sptx/examples/ *.json
+recursive-include sptx_format/schema/ *.json
+recursive-include sptx_format/examples/ *.json

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ lint-init:
 	flake8 --ignore 'E301, E302, E305, E401, F401, E731, F811' --filename='*__init__.py' $(MODULES)
 
 test:
-	pytest -v -n 8 --cov starfish --cov validate_sptx
+	pytest -v -n 8 --cov starfish --cov sptx_format
 
 mypy:
 	mypy --ignore-missing-imports $(MODULES)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setuptools.setup(
     entry_points={
         'console_scripts': [
             "starfish=starfish.starfish:starfish",
-            "validate-sptx=sptx_format.validate_sptx:validate_sptx",
         ]
     },
     classifiers=CLASSIFIERS,

--- a/sptx_format/cli.py
+++ b/sptx_format/cli.py
@@ -1,4 +1,5 @@
 import click
+
 from sptx_format import validate_sptx
 
 

--- a/starfish/experiment/experiment.py
+++ b/starfish/experiment/experiment.py
@@ -16,8 +16,8 @@ from semantic_version import Version
 from slicedimage import Collection, TileSet
 from slicedimage.io import Reader, resolve_path_or_url, resolve_url
 from slicedimage.urlpath import pathjoin
-from sptx_format import validate_sptx
 
+from sptx_format import validate_sptx
 from starfish.codebook.codebook import Codebook
 from starfish.imagestack.imagestack import ImageStack
 from starfish.util.config import Config

--- a/starfish/starfish.py
+++ b/starfish/starfish.py
@@ -3,8 +3,8 @@ import cProfile
 from pstats import Stats
 
 import click
-from sptx_format.cli import validate as validate_cli
 
+from sptx_format.cli import validate as validate_cli
 from starfish.experiment.builder.cli import build as build_cli
 from starfish.image import (
     Filter,

--- a/starfish/util/exec.py
+++ b/starfish/util/exec.py
@@ -106,13 +106,4 @@ def prepare_stage(stage: Sequence[Union[str, Callable]],
         ]
         coverage_cmdline.extend(cmdline[1:])
         cmdline = coverage_cmdline
-    elif cmdline[0] == "validate-sptx" and coverage_enabled:
-        coverage_cmdline = [
-            "coverage", "run",
-            "-p",
-            "--source", "validate_sptx",
-            "-m", "validate_sptx",
-        ]
-        coverage_cmdline.extend(cmdline[1:])
-        cmdline = coverage_cmdline
     return cmdline


### PR DESCRIPTION
0.0.28 is missing the schema json files for sptx-format leading
to the error:

```
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/sptx_format/util.py", line 51, in load_json
    with open(json_file, 'rb') as f:
FileNotFoundError: [Errno 2] No such file or directory:
    '/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/sptx_format/schema/experiment.json'
make: *** [run__notebooks/py/assay_comparison.py] Error 1
```

see: gh-717