### PR TITLE
Dockerfile: Cannot uninstall 'certifi'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN echo "source activate starfish" >> ~/.bashrc
 ENV PATH /home/starfish/.conda/envs/starfish/bin:$PATH
 
 # Build and configure for running
-RUN pip install -e .
+RUN pip install --ignore-installed -e .
 
 env MPLBACKEND Agg
 ENTRYPOINT ["starfish"]


### PR DESCRIPTION
This PR fixes `Cannot uninstall 'certifi'`

```
Successfully built mpmath networkx slicedimage sympy
mkl-random 1.0.1 requires cython, which is not installed.
Installing collected packages: certifi, click, cloudpickle, dask, pytz, pyparsing, python-dateutil, numpy, matplotlib, mpmath, networkx, packaging, Pillow, pluggy, py, pycodestyle, pytest, PyWavelets, scikit-learn, slicedimage, sympy, tqdm, xarray, starfish
  Found existing installation: certifi 2018.10.15
Cannot uninstall 'certifi'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.
You are using pip version 10.0.1, however version 18.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
The command '/bin/sh -c pip install -e .' returned a non-zero code: 1
```

cc: @joshmoore 