### PR TITLE
[Easy] Add default threshold parameter for Bandpass filter

### DIFF
--- a/starfish/image/_filter/bandpass.py
+++ b/starfish/image/_filter/bandpass.py
@@ -14,7 +14,7 @@ from .util import determine_axes_to_group_by, preserve_float_range
 class Bandpass(FilterAlgorithmBase):
 
     def __init__(
-            self, lshort: Number, llong: int, threshold: Number, truncate: Number=4,
+            self, lshort: Number, llong: int, threshold: Number=0, truncate: Number=4,
             is_volume: bool=False) -> None:
         """
 
@@ -34,6 +34,10 @@ class Bandpass(FilterAlgorithmBase):
         """
         self.lshort = lshort
         self.llong = llong
+
+        if threshold is None:
+            raise ValueError("Threshold cannot be None, please pass a float or integer")
+
         self.threshold = threshold
         self.truncate = truncate
         self.is_volume = is_volume

--- a/starfish/image/_filter/bandpass.py
+++ b/starfish/image/_filter/bandpass.py
@@ -25,10 +25,10 @@ class Bandpass(FilterAlgorithmBase):
         llong : int
             filter frequencies above this odd integer value
         threshold : float
-            zero any pixels below this intensity value
+            zero any spots below this intensity value after background subtraction (default 0)
         truncate : float
             truncate the gaussian kernel, used by the gaussian filter, at this many standard
-            deviations
+            deviations (default 4)
         is_volume : bool
             If True, 3d (z, y, x) volumes will be filtered. By default, filter 2-d (y, x) planes
         """
@@ -58,7 +58,7 @@ class Bandpass(FilterAlgorithmBase):
         llong : int
             filter frequencies above this odd integer value
         threshold : float
-            zero any pixels below this intensity value
+            zero any spots below this intensity value after background subtraction (default 0)
         truncate : float
             truncate the gaussian kernel, used by the gaussian filter, at this many standard
             deviations
@@ -76,8 +76,8 @@ class Bandpass(FilterAlgorithmBase):
         return preserve_float_range(bandpassed)
 
     def run(
-            self, stack: ImageStack, in_place: bool=False, verbose: bool=False,
-            n_processes: Optional[int]=None
+            self, stack: ImageStack, in_place: bool = False, verbose: bool = False,
+            n_processes: Optional[int] = None
     ) -> ImageStack:
         """Perform filtering of an image stack
 
@@ -121,7 +121,7 @@ class Bandpass(FilterAlgorithmBase):
     @click.option(
         "--llong", type=int, help="filter signals above this frequency")
     @click.option(
-        "--threshold", type=int, help="clip pixels below this intensity value")
+        "--threshold", default=0, type=float, help="zero pixels below this intensity value")
     @click.option(
         "--truncate", default=4, type=float,
         help="truncate the filter at this many standard deviations")


### PR DESCRIPTION
The Bandpass filter wraps trackpy's bandpass filter. This underlying filter accepts a None value for the threshold parameter. This None value then internally gets set to 1/255. This makes sense for uint8 images, but not for our float32 images which contain small values in [0,1]. This caused some pain for @berl who is used to using trackpy in this manner. 

To counteract this issue, I set the default for the threshold to 0 (which is effectively a noop) and raise an exception if the user passes in a None value.