### PR TITLE
Fix E605 warnings.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,4 @@
 [flake8]
 max-line-length=100
-ignore: E252, E301, E302, E305, W503, W605, E731, F811
 application-import-names = starfish, examples, sptx_format
 import-order-style = smarkets

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,10 @@ fast:	lint mypy test
 lint:   lint-non-init lint-init
 
 lint-non-init:
-	flake8 --ignore 'E252, E301, E302, E305, E401, W503, W605, E731, F811' --exclude='*__init__.py' $(MODULES)
+	flake8 --ignore 'E252, E301, E302, E305, E401, W503, E731, F811' --exclude='*__init__.py' $(MODULES)
 
 lint-init:
-	flake8 --ignore 'E252, E301, E302, E305, E401, F401, W503, W605, E731, F811' --filename='*__init__.py' $(MODULES)
+	flake8 --ignore 'E252, E301, E302, E305, E401, F401, W503, E731, F811' --filename='*__init__.py' $(MODULES)
 
 test:
 	pytest -v -n 8 --cov starfish --cov sptx_format

--- a/examples/format_osmfish.py
+++ b/examples/format_osmfish.py
@@ -105,7 +105,7 @@ class osmFISHTileFetcher(TileFetcher):
             # the metadata references a larger corpus of data than we use for this example so as we
             # iterate over the metadata, some rounds will not be found. In those cases, we just
             # continue through the loop without adding to parsed_metadata
-            round_match = re.match("Hybridization(\d{1,2})", round_)
+            round_match = re.match(r"Hybridization(\d{1,2})", round_)
             if round_match is None:
                 continue
 

--- a/starfish/starfish.py
+++ b/starfish/starfish.py
@@ -28,7 +28,7 @@ PROFILER_LINES = 15
 @click.option("--profile", is_flag=True)
 @click.pass_context
 def starfish(ctx, profile):
-    art = """
+    art = r"""
          _              __ _     _
         | |            / _(_)   | |
      ___| |_ __ _ _ __| |_ _ ___| |__
@@ -36,7 +36,7 @@ def starfish(ctx, profile):
     \__ \ || (_| | |  | | | \__ \ | | |
     |___/\__\__,_|_|  |_| |_|___/_| |_|
 
-    """  # noqa
+    """
     print_art = True
     sub = ctx.command.get_command(ctx, ctx.invoked_subcommand)
     if hasattr(sub, "no_art"):


### PR DESCRIPTION
1. Put back E605 as a valid warning.
2. Use r-style strings to not quote backslashes.

Test plan: `make -j lint`, waiting on travis now...