### PR TITLE
[NO-TILESET 1/3] Decouple tile_metadata from the TileSet.

### DIFF
--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -36,8 +36,9 @@ from tqdm import tqdm
 from starfish.errors import DataFormatWarning
 from starfish.experiment.builder import build_image, TileFetcher
 from starfish.experiment.builder.defaultproviders import OnesTile, tile_fetcher_factory
-from starfish.imagestack import indexing_utils
-from starfish.imagestack import physical_coordinate_calculator
+from starfish.imagestack import indexing_utils, physical_coordinate_calculator
+from starfish.imagestack.parser import TileKey
+from starfish.imagestack.parser.tileset import TileSetData
 from starfish.intensity_table.intensity_table import IntensityTable
 from starfish.multiprocessing.shmem import SharedMemory
 from starfish.types import (
@@ -96,6 +97,7 @@ class ImageStack:
 
     def __init__(self, image_partition: TileSet) -> None:
         self._image_partition = image_partition
+        self._tile_metadata = TileSetData(self._image_partition)
         self._tile_shape = image_partition.default_tile_shape
 
         # Examine the tiles to figure out the right kind (int, float, etc.) and size.  We require
@@ -833,14 +835,15 @@ class ImageStack:
         """
 
         data: collections.defaultdict = collections.defaultdict(list)
+        keys = self._tile_metadata.keys()
         index_keys = set(
-            key
-            for tile in self._image_partition.tiles()
-            for key in tile.indices.keys())
+            key.value
+            for key in AXES_DATA.keys()
+        )
         extras_keys = set(
             key
-            for tile in self._image_partition.tiles()
-            for key in tile.extras.keys())
+            for tilekey in keys
+            for key in self._tile_metadata[tilekey].keys())
         duplicate_keys = index_keys.intersection(extras_keys)
         if len(duplicate_keys) > 0:
             duplicate_keys_str = ", ".join([str(key) for key in duplicate_keys])
@@ -848,17 +851,23 @@ class ImageStack:
                 f"keys ({duplicate_keys_str}) was found in both the Tile specification and extras "
                 f"field. Tile specification keys may not be duplicated in the extras field.")
 
-        for tile in self._image_partition.tiles():
-            for k in index_keys:
-                data[k].append(tile.indices.get(k, None))
-            for k in extras_keys:
-                data[k].append(tile.extras.get(k, None))
+        for indices in self._iter_indices({Indices.ROUND, Indices.CH, Indices.Z}):
+            tilekey = TileKey(
+                round=indices[Indices.ROUND],
+                ch=indices[Indices.CH],
+                z=indices[Indices.Z])
+            extras = self._tile_metadata[tilekey]
 
-            if 'barcode_index' not in tile.extras:
-                round_ = tile.indices[Indices.ROUND]
-                ch = tile.indices[Indices.CH]
-                z = tile.indices.get(Indices.Z, 0)
-                barcode_index = (((z * self.num_rounds) + round_) * self.num_chs) + ch
+            for index, index_value in indices.items():
+                data[index.value].append(index_value)
+
+            for k in extras_keys:
+                data[k].append(extras.get(k, None))
+
+            if 'barcode_index' not in extras:
+                barcode_index = ((((indices[Indices.Z]
+                                    * self.num_rounds) + indices[Indices.ROUND])
+                                  * self.num_chs) + indices[Indices.CH])
 
                 data['barcode_index'].append(barcode_index)
 

--- a/starfish/imagestack/parser/__init__.py
+++ b/starfish/imagestack/parser/__init__.py
@@ -1,0 +1,2 @@
+from ._key import TileKey
+from ._tiledata import TileCollectionData

--- a/starfish/imagestack/parser/_key.py
+++ b/starfish/imagestack/parser/_key.py
@@ -1,0 +1,32 @@
+class TileKey:
+    """
+    This class is used to index into the TileData class.
+    """
+    def __init__(self, *, round: int, ch: int, z: int) -> None:
+        self._round = round
+        self._ch = ch
+        self._z = z
+
+    @property
+    def round(self) -> int:
+        return self._round
+
+    @property
+    def ch(self) -> int:
+        return self._ch
+
+    @property
+    def z(self) -> int:
+        return self._z
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, TileKey):
+            return False
+
+        return self._round == other.round and self._ch == other.ch and self._z == other.z
+
+    def __hash__(self) -> int:
+        return int(self._round ^ self._ch ^ self._z)
+
+    def __repr__(self) -> str:
+        return f"(round: {self._round} ch: {self._ch} z: {self._z})"

--- a/starfish/imagestack/parser/_tiledata.py
+++ b/starfish/imagestack/parser/_tiledata.py
@@ -1,0 +1,22 @@
+from typing import Collection
+
+from ._key import TileKey
+
+
+class TileCollectionData:
+    """
+    Base class for a parser to implement that provides the data for a collection of tiles to be
+    assembled into an ImageStack.
+    """
+    def __getitem__(self, tilekey: TileKey) -> dict:
+        """Returns the extras metadata for a given tile, addressed by its TileKey"""
+        raise NotImplementedError()
+
+    def keys(self) -> Collection[TileKey]:
+        """Returns a Collection of the TileKey's for all the tiles."""
+        raise NotImplementedError()
+
+    @property
+    def extras(self) -> dict:
+        """Returns the extras metadata for the TileSet."""
+        raise NotImplementedError()

--- a/starfish/imagestack/parser/tileset/__init__.py
+++ b/starfish/imagestack/parser/tileset/__init__.py
@@ -1,0 +1,1 @@
+from ._parser import TileSetData

--- a/starfish/imagestack/parser/tileset/_parser.py
+++ b/starfish/imagestack/parser/tileset/_parser.py
@@ -1,0 +1,40 @@
+"""
+This module parses and retains the extras metadata attached to TileSet extras.
+"""
+
+from typing import Collection, Mapping, MutableMapping
+
+from slicedimage import TileSet
+
+from starfish.imagestack.parser import TileCollectionData, TileKey
+from starfish.types import Indices
+
+
+class TileSetData(TileCollectionData):
+    """
+    This class parses the data, including extras, from a TileSet and its constituent tiles.
+    """
+    def __init__(self, tileset: TileSet) -> None:
+        tile_extras: MutableMapping[TileKey, dict] = dict()
+        for tile in tileset.tiles():
+            round_ = tile.indices[Indices.ROUND]
+            ch = tile.indices[Indices.CH]
+            z = tile.indices.get(Indices.Z, 0)
+
+            tile_extras[TileKey(round=round_, ch=ch, z=z)] = tile.extras
+
+        self.tile_extras: Mapping[TileKey, dict] = tile_extras
+        self._extras = tileset.extras
+
+    def __getitem__(self, tilekey: TileKey) -> dict:
+        """Returns the extras metadata for a given tile, addressed by its TileKey"""
+        return self.tile_extras[tilekey]
+
+    def keys(self) -> Collection[TileKey]:
+        """Returns a Collection of the TileKey's for all the tiles."""
+        return self.tile_extras.keys()
+
+    @property
+    def extras(self) -> dict:
+        """Returns the extras metadata for the TileSet."""
+        return self._extras


### PR DESCRIPTION
At the construction of the `ImageStack`, we use the `TileData` class to parse and store the extras associated with tiles.

`ImageStack.tile_metadata` gets its data from TileSet instance we store.

Test plan: `pytest -vv -n4  starfish/test/image/test_imagestack_metadata.py   starfish/test/full_pipelines/cli/test_merfish_cli.py  starfish/test/full_pipelines/api/test_merfish.py`

Note:
- This is the first part of #776