### PR TITLE
Add napari-gui requirement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,12 +109,12 @@ help-integration:
 ### INSTALL ##################################################
 #
 install-src:
-	pip install --force-reinstall --upgrade -r REQUIREMENTS.txt
+	pip install --force-reinstall --upgrade -r REQUIREMENTS.txt napari-gui
 	pip install -e .
 	pip freeze
 
 install-pypi:
-	pip install -r REQUIREMENTS.txt starfish
+	pip install -r REQUIREMENTS.txt starfish napari-gui
 
 help-install:
 	$(call print_help, install-src, pip install the current directory)

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ SHELL := /bin/bash
 MPLBACKEND?=Agg
 export MPLBACKEND
 
+QT_QPA_PLATFORM=offscreen
+export QT_QPA_PLATFORM
+
 MODULES=starfish examples sptx_format
 
 define print_help


### PR DESCRIPTION
osmFISH is failing the travis master cron build on `run_notebooks` since napari isn't installed. This installs `napari-gui` as part of the two `install-*` make targets (until there's a "kitchen sink" requirements file).

Test plan:

 * ~https://travis-ci.org/spacetx/starfish/builds/454422095~
 * ~https://travis-ci.org/spacetx/starfish/builds/454433101~
 * ~https://travis-ci.org/spacetx/starfish/builds/454442888~

See:

 * https://github.com/spacetx/starfish/pull/756
 * https://travis-ci.org/spacetx/starfish/builds/452688080