### PR TITLE
[NO-TILESET 2/3] Implement ImageStack write without depending on the source ImageStack

### DIFF
--- a/examples/get_cli_test_data.py
+++ b/examples/get_cli_test_data.py
@@ -21,11 +21,11 @@ if __name__ == "__main__":
     for fov in exp.fovs():
         fov_dir = pathlib.Path(args.output_dir, fov.name)
         fov_dir.mkdir()
-        fov[FieldOfView.PRIMARY_IMAGES].write(str(fov_dir / "hybridization.json"))
+        fov[FieldOfView.PRIMARY_IMAGES].export(str(fov_dir / "hybridization.json"))
         for image_type in fov.image_types:
             if image_type == FieldOfView.PRIMARY_IMAGES:
                 continue
-            fov[image_type].write(str(fov_dir / f"{image_type}.json"))
+            fov[image_type].export(str(fov_dir / f"{image_type}.json"))
 
     # get codebook from url and save locally to tmp dir
     codebook = requests.get(posixpath.join(args.experiment_url, "codebook.json"))

--- a/starfish/image/_filter/__init__.py
+++ b/starfish/image/_filter/__init__.py
@@ -29,7 +29,7 @@ class Filter(PipelineComponent):
         output = ctx.obj["output"]
         stack = ctx.obj["stack"]
         filtered = instance.run(stack)
-        filtered.write(output)
+        filtered.export(output)
 
     @staticmethod
     @click.group("filter")

--- a/starfish/image/_registration/__init__.py
+++ b/starfish/image/_registration/__init__.py
@@ -19,7 +19,7 @@ class Registration(PipelineComponent):
         output = ctx.obj["output"]
         stack = ctx.obj["stack"]
         instance.run(stack)
-        stack.write(output)
+        stack.export(output)
 
     @staticmethod
     @click.group("registration")

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -29,7 +29,7 @@ from scipy.ndimage.filters import gaussian_filter
 from scipy.stats import scoreatpercentile
 from skimage import exposure
 from skimage import img_as_float32, img_as_uint
-from slicedimage import Reader, TileSet, Writer
+from slicedimage import Reader, Tile, TileSet, Writer
 from slicedimage.io import resolve_path_or_url
 from tqdm import tqdm
 
@@ -44,6 +44,7 @@ from starfish.multiprocessing.shmem import SharedMemory
 from starfish.types import (
     Coordinates,
     Indices,
+    Number,
     PHYSICAL_COORDINATE_DIMENSION,
     PhysicalCoordinateTypes,
 )
@@ -941,7 +942,7 @@ class ImageStack:
     def tile_shape(self):
         return self._tile_shape
 
-    def write(self, filepath: str, tile_opener=None) -> None:
+    def export(self, filepath: str, tile_opener=None) -> None:
         """write the image tensor to disk in spaceTx format
 
         Parameters
@@ -951,22 +952,57 @@ class ImageStack:
         tile_opener : TODO ttung: doc me.
 
         """
-        for tile in self._image_partition.tiles():
-            h = tile.indices[Indices.ROUND]
-            c = tile.indices[Indices.CH]
-            zlayer = tile.indices.get(Indices.Z, 0)
-            tile.numpy_array, axes = self.get_slice(
-                indices={Indices.ROUND: h, Indices.CH: c, Indices.Z: zlayer}
-            )
-            assert len(axes) == 0
-
+        tileset = TileSet(
+            dimensions={
+                Indices.ROUND,
+                Indices.CH,
+                Indices.Z,
+                Indices.Y,
+                Indices.X,
+            },
+            shape={
+                Indices.ROUND: self.num_rounds,
+                Indices.CH: self.num_chs,
+                Indices.Z: self.num_zlayers,
+            },
+            default_tile_shape=self._tile_shape,
+            extras=self._tile_metadata.extras,
+        )
         seen_x_coords, seen_y_coords, seen_z_coords = set(), set(), set()
-        for tile in self._image_partition.tiles():
-            seen_x_coords.add(tile.coordinates[Coordinates.X])
-            seen_y_coords.add(tile.coordinates[Coordinates.Y])
-            z_coords = tile.coordinates.get(Coordinates.Z, None)
-            if z_coords is not None:
-                seen_z_coords.add(z_coords)
+        for round_ in range(self.num_rounds):
+            for ch in range(self.num_chs):
+                for zlayer in range(self.num_zlayers):
+                    tilekey = TileKey(round=round_, ch=ch, z=zlayer)
+                    extras: dict = self._tile_metadata[tilekey]
+
+                    tile_indices = {
+                        Indices.ROUND: round_,
+                        Indices.CH: ch,
+                        Indices.Z: zlayer,
+                    }
+
+                    coordinates: MutableMapping[Coordinates, Tuple[Number, Number]] = dict()
+                    x_coordinates = self.coordinates(tile_indices, Coordinates.X)
+                    y_coordinates = self.coordinates(tile_indices, Coordinates.Y)
+                    z_coordinates = self.coordinates(tile_indices, Coordinates.Z)
+
+                    seen_x_coords.add(x_coordinates)
+                    coordinates[Coordinates.X] = x_coordinates
+                    seen_y_coords.add(y_coordinates)
+                    coordinates[Coordinates.Y] = y_coordinates
+                    if z_coordinates[0] != np.nan and z_coordinates[1] != np.nan:
+                        coordinates[Coordinates.Z] = z_coordinates
+                        seen_z_coords.add(z_coordinates)
+
+                    tile = Tile(
+                        coordinates=coordinates,
+                        indices=tile_indices,
+                        extras=extras,
+                    )
+                    tile.numpy_array, _ = self.get_slice(
+                        indices={Indices.ROUND: round_, Indices.CH: ch, Indices.Z: zlayer}
+                    )
+                    tileset.add_tile(tile)
 
         sorted_x_coords = sorted(seen_x_coords)
         sorted_y_coords = sorted(seen_y_coords)
@@ -1005,7 +1041,7 @@ class ImageStack:
         if not filepath.endswith('.json'):
             filepath += '.json'
         Writer.write_to_path(
-            self._image_partition,
+            tileset,
             filepath,
             pretty=True,
             tile_opener=tile_opener)


### PR DESCRIPTION
Rather than writing the data back to the source ImageStack and writing that out to disk, make a new TileSet, and set it up appropriately.

This makes explicit what is needed for writing the ImageStack, and what is used to write the ImageStack.

Depends on #782 

Test plan: `make -j fast run_notebooks`