### PR TITLE
[easy] Move data order concerns to its own module.

### DIFF
--- a/starfish/imagestack/dataorder.py
+++ b/starfish/imagestack/dataorder.py
@@ -1,0 +1,13 @@
+import collections
+from typing import Mapping
+
+from starfish.types import Indices
+
+_DimensionMetadata = collections.namedtuple("_DimensionMetadata", ['order', 'required'])
+
+AXES_DATA: Mapping[Indices, _DimensionMetadata] = {
+    Indices.ROUND: _DimensionMetadata(0, True),
+    Indices.CH: _DimensionMetadata(1, True),
+    Indices.Z: _DimensionMetadata(2, False),
+}
+N_AXES = max(data.order for data in AXES_DATA.values()) + 1


### PR DESCRIPTION
This is necessary so we can have modules that ImageStack depends on that depend on this data.