### PR TITLE
[easy] order fovs by name by default

### DIFF
--- a/starfish/experiment/experiment.py
+++ b/starfish/experiment/experiment.py
@@ -269,8 +269,8 @@ class Experiment:
     ) -> FieldOfView:
         """
         Given a callable filter_fn, apply it to all the FOVs in this experiment.  Return the first
-        FOV such that filter_fn(FOV) returns True.  Because there is no guaranteed order for the
-        FOVs, use this cautiously.
+        FOV such that filter_fn(FOV) returns True. The order of the filtered FOVs will be determined
+        by the key_fn callable. By default, this matches the order of fov.name.
 
         If no FOV matches, raise LookupError.
         """
@@ -286,7 +286,8 @@ class Experiment:
     ) -> Sequence[FieldOfView]:
         """
         Given a callable filter_fn, apply it to all the FOVs in this experiment.  Return a list of
-        FOVs such that filter_fn(FOV) returns True.
+        FOVs such that filter_fn(FOV) returns True. The returned list is sorted based on the key_fn
+        callable, which by default matches the order of fov.name.
         """
         results: MutableSequence[FieldOfView] = list()
         for fov in self._fovs:
@@ -297,10 +298,13 @@ class Experiment:
         results = sorted(results, key=key_fn)
         return results
 
-    def fovs_by_name(self, *names):
+    def fovs_by_name(self, *names,
+                     key_fn: Callable[[FieldOfView], str]=lambda fov: fov.name,
+    ) -> Sequence[FieldOfView]:
         """
         Given a callable filter_fn, apply it to all the FOVs in this experiment.  Return a list of
-        FOVs such that filter_fn(FOV) returns True.
+        FOVs such that filter_fn(FOV) returns True.  The returned list is sorted based on the key_fn
+        callable, which by default matches the order of fov.name.
         """
         return self.fovs(filter_fn=lambda fov: fov.name in names)
 

--- a/starfish/experiment/experiment.py
+++ b/starfish/experiment/experiment.py
@@ -294,7 +294,7 @@ class Experiment:
                 continue
 
             results.append(fov)
-        results.sort(key=key_fn)
+        results = sorted(results, key=key_fn)
         return results
 
     def fovs_by_name(self, *names):

--- a/starfish/experiment/experiment.py
+++ b/starfish/experiment/experiment.py
@@ -265,6 +265,7 @@ class Experiment:
     def fov(
             self,
             filter_fn: Callable[[FieldOfView], bool]=lambda _: True,
+            key_fn: Callable[[FieldOfView], str]=lambda fov: fov.name,
     ) -> FieldOfView:
         """
         Given a callable filter_fn, apply it to all the FOVs in this experiment.  Return the first
@@ -273,7 +274,7 @@ class Experiment:
 
         If no FOV matches, raise LookupError.
         """
-        for fov in self._fovs:
+        for fov in sorted(self._fovs, key=key_fn):
             if filter_fn(fov):
                 return fov
         raise LookupError("Cannot find any FOV that the filter allows.")
@@ -281,6 +282,7 @@ class Experiment:
     def fovs(
             self,
             filter_fn: Callable[[FieldOfView], bool]=lambda _: True,
+            key_fn: Callable[[FieldOfView], str]=lambda fov: fov.name,
     ) -> Sequence[FieldOfView]:
         """
         Given a callable filter_fn, apply it to all the FOVs in this experiment.  Return a list of
@@ -292,6 +294,7 @@ class Experiment:
                 continue
 
             results.append(fov)
+        results.sort(key=key_fn)
         return results
 
     def fovs_by_name(self, *names):

--- a/starfish/experiment/experiment.py
+++ b/starfish/experiment/experiment.py
@@ -298,8 +298,10 @@ class Experiment:
         results = sorted(results, key=key_fn)
         return results
 
-    def fovs_by_name(self, *names,
-                     key_fn: Callable[[FieldOfView], str]=lambda fov: fov.name,
+    def fovs_by_name(
+        self,
+        *names,
+        key_fn: Callable[[FieldOfView], str]=lambda fov: fov.name,
     ) -> Sequence[FieldOfView]:
         """
         Given a callable filter_fn, apply it to all the FOVs in this experiment.  Return a list of

--- a/starfish/experiment/test_experiment.py
+++ b/starfish/experiment/test_experiment.py
@@ -1,0 +1,18 @@
+from starfish.experiment.experiment import Experiment, FieldOfView
+from starfish.imagestack.imagestack import ImageStack
+from starfish.util.synthesize import SyntheticData
+
+
+def test_fov_order():
+    data = SyntheticData()
+    codebook = data.codebook()
+    stack1 = ImageStack.synthetic_stack(num_round=5, num_ch=5, num_z=15,
+                                        tile_height=200, tile_width=200)
+    stack2 = ImageStack.synthetic_stack(num_round=5, num_ch=5, num_z=15,
+                                        tile_height=200, tile_width=200)
+    fovs = [FieldOfView("stack2", {"primary": stack2}),
+            FieldOfView("stack1", {"primary": stack1})]
+    extras = {"synthetic": True}
+    experiment = Experiment(fovs, codebook, extras)
+    assert "stack1" == experiment.fov().name
+    assert ["stack1", "stack2"] == [x.name for x in experiment.fovs()]

--- a/starfish/experiment/test_experiment.py
+++ b/starfish/experiment/test_experiment.py
@@ -6,10 +6,8 @@ from starfish.util.synthesize import SyntheticData
 def test_fov_order():
     data = SyntheticData()
     codebook = data.codebook()
-    stack1 = ImageStack.synthetic_stack(num_round=5, num_ch=5, num_z=15,
-                                        tile_height=200, tile_width=200)
-    stack2 = ImageStack.synthetic_stack(num_round=5, num_ch=5, num_z=15,
-                                        tile_height=200, tile_width=200)
+    stack1 = ImageStack.synthetic_stack()
+    stack2 = ImageStack.synthetic_stack()
     fovs = [FieldOfView("stack2", {"primary": stack2}),
             FieldOfView("stack1", {"primary": stack1})]
     extras = {"synthetic": True}


### PR DESCRIPTION
Order all fovs by name by default. (Other idea from starfish sync was to order by physical coordinates)

cc: @berl 