### PR TITLE
click logging of pipelines

### DIFF
--- a/sptx_format/cli.py
+++ b/sptx_format/cli.py
@@ -1,12 +1,13 @@
 import click
 
 from sptx_format import validate_sptx
+from starfish.util.click import pass_context_and_record
 
 
 @click.command()
 @click.option("--experiment-json", required=True, metavar="JSON_FILE_OR_URL")
 @click.option("--fuzz", is_flag=True)
-@click.pass_context
+@pass_context_and_record
 def validate(ctx, experiment_json, fuzz):
     """invokes validate with the parsed commandline arguments"""
     try:

--- a/starfish/experiment/builder/cli.py
+++ b/starfish/experiment/builder/cli.py
@@ -7,7 +7,6 @@ from starfish.util.click import (
 from . import AUX_IMAGE_NAMES, write_experiment_json
 
 
-
 decorators = [
     click.command(),
     click.argument("output_dir", type=click.Path(exists=True, file_okay=False, writable=True)),

--- a/starfish/experiment/builder/cli.py
+++ b/starfish/experiment/builder/cli.py
@@ -1,40 +1,12 @@
-import json
-
 import click
 
-from starfish.types import Indices
+from starfish.util.click import (
+    dimensions_option,
+    pass_context_and_log,
+)
 from . import AUX_IMAGE_NAMES, write_experiment_json
 
 
-class StarfishIndex(click.ParamType):
-
-    name = "starfish-index"
-
-    def convert(self, spec_json, param, ctx):
-        try:
-            spec = json.loads(spec_json)
-        except json.decoder.JSONDecodeError:
-            self.fail(
-                "Could not parse {} into a valid index specification.".format(spec_json))
-
-        return {
-            Indices.ROUND: spec.get(Indices.ROUND, 1),
-            Indices.CH: spec.get(Indices.CH, 1),
-            Indices.Z: spec.get(Indices.Z, 1),
-        }
-
-def dimensions_option(name, required):
-    return click.option(
-        "--{}-dimensions".format(name),
-        type=StarfishIndex(), required=required,
-        help="Dimensions for the {} images.  Should be a json dict, with {}, {}, "
-             "and {} as the possible keys.  The value should be the shape along that "
-             "dimension.  If a key is not present, the value is assumed to be 0."
-             .format(
-             name,
-             Indices.ROUND.value,
-             Indices.CH.value,
-             Indices.Z.value))
 
 decorators = [
     click.command(),
@@ -45,7 +17,8 @@ decorators = [
 for image_name in AUX_IMAGE_NAMES:
     decorators.append(dimensions_option(image_name, False))
 
-def build(output_dir, fov_count, hybridization_dimensions, **kwargs):
+@pass_context_and_log
+def build(ctx, output_dir, fov_count, hybridization_dimensions, **kwargs):
     write_experiment_json(
         output_dir, fov_count, hybridization_dimensions,
         kwargs

--- a/starfish/experiment/builder/cli.py
+++ b/starfish/experiment/builder/cli.py
@@ -2,7 +2,7 @@ import click
 
 from starfish.util.click import (
     dimensions_option,
-    pass_context_and_log,
+    pass_context_and_record,
 )
 from . import AUX_IMAGE_NAMES, write_experiment_json
 
@@ -16,7 +16,7 @@ decorators = [
 for image_name in AUX_IMAGE_NAMES:
     decorators.append(dimensions_option(image_name, False))
 
-@pass_context_and_log
+@pass_context_and_record
 def build(ctx, output_dir, fov_count, hybridization_dimensions, **kwargs):
     write_experiment_json(
         output_dir, fov_count, hybridization_dimensions,

--- a/starfish/image/_filter/__init__.py
+++ b/starfish/image/_filter/__init__.py
@@ -4,6 +4,7 @@ import click
 
 from starfish.imagestack.imagestack import ImageStack
 from starfish.pipeline import AlgorithmBase, PipelineComponent
+from starfish.util.click import pass_context_and_record
 from . import _base
 from . import bandpass
 from . import clip
@@ -35,7 +36,7 @@ class Filter(PipelineComponent):
     @click.group("filter")
     @click.option("-i", "--input", type=click.Path(exists=True))
     @click.option("-o", "--output", required=True)
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, input, output):
         print("Filtering images...")
         ctx.obj = dict(

--- a/starfish/image/_filter/bandpass.py
+++ b/starfish/image/_filter/bandpass.py
@@ -7,6 +7,7 @@ from trackpy import bandpass
 
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Number
+from starfish.util.click import pass_context_and_record
 from ._base import FilterAlgorithmBase
 from .util import determine_axes_to_group_by, preserve_float_range
 
@@ -125,6 +126,6 @@ class Bandpass(FilterAlgorithmBase):
     @click.option(
         "--truncate", default=4, type=float,
         help="truncate the filter at this many standard deviations")
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, lshort, llong, threshold, truncate):
         ctx.obj["component"]._cli_run(ctx, Bandpass(lshort, llong, threshold, truncate))

--- a/starfish/image/_filter/clip.py
+++ b/starfish/image/_filter/clip.py
@@ -5,6 +5,7 @@ import click
 import numpy as np
 
 from starfish.imagestack.imagestack import ImageStack
+from starfish.util.click import pass_context_and_record
 from ._base import FilterAlgorithmBase
 from .util import determine_axes_to_group_by
 
@@ -95,6 +96,6 @@ class Clip(FilterAlgorithmBase):
         "--p-min", default=0, type=int, help="clip intensities below this percentile")
     @click.option(
         "--p-max", default=100, type=int, help="clip intensities above this percentile")
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, p_min, p_max):
         ctx.obj["component"]._cli_run(ctx, Clip(p_min, p_max))

--- a/starfish/image/_filter/gaussian_high_pass.py
+++ b/starfish/image/_filter/gaussian_high_pass.py
@@ -8,6 +8,7 @@ import xarray as xr
 from starfish.image._filter.gaussian_low_pass import GaussianLowPass
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Number
+from starfish.util.click import pass_context_and_record
 from ._base import FilterAlgorithmBase
 from .util import (
     determine_axes_to_group_by,
@@ -104,6 +105,6 @@ class GaussianHighPass(FilterAlgorithmBase):
     @click.option("--sigma", type=float, help="standard deviation of gaussian kernel")
     @click.option("--is-volume", is_flag=True,
                   help="indicates that the image stack should be filtered in 3d")
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, sigma, is_volume):
         ctx.obj["component"]._cli_run(ctx, GaussianHighPass(sigma, is_volume))

--- a/starfish/image/_filter/gaussian_low_pass.py
+++ b/starfish/image/_filter/gaussian_low_pass.py
@@ -7,6 +7,7 @@ from skimage.filters import gaussian
 
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Number
+from starfish.util.click import pass_context_and_record
 from ._base import FilterAlgorithmBase
 from .util import (
     determine_axes_to_group_by,
@@ -107,6 +108,6 @@ class GaussianLowPass(FilterAlgorithmBase):
     @click.option("--sigma", type=float, help="standard deviation of gaussian kernel")
     @click.option("--is-volume", is_flag=True,
                   help="indicates that the image stack should be filtered in 3d")
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, sigma, is_volume):
         ctx.obj["component"]._cli_run(ctx, GaussianLowPass(sigma, is_volume))

--- a/starfish/image/_filter/laplace.py
+++ b/starfish/image/_filter/laplace.py
@@ -14,6 +14,7 @@ from starfish.image._filter.util import (
 )
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Number
+from starfish.util.click import pass_context_and_record
 
 
 class Laplace(FilterAlgorithmBase):
@@ -130,6 +131,6 @@ class Laplace(FilterAlgorithmBase):
     @click.option(
         "--is-volume", is_flag=True,
         help="indicates that the image stack should be filtered in 3d")
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, sigma, mode, cval, is_volume):
         ctx.obj["component"]._cli_run(ctx, Laplace(sigma, mode, cval, is_volume))

--- a/starfish/image/_filter/max_proj.py
+++ b/starfish/image/_filter/max_proj.py
@@ -4,6 +4,7 @@ import click
 
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Indices
+from starfish.util.click import pass_context_and_record
 from ._base import FilterAlgorithmBase
 
 
@@ -26,6 +27,6 @@ class MaxProj(FilterAlgorithmBase):
                   help="The dimensions the Imagestack should max project over. Options:"
                        "(r, c, z, y, or x) For multiple dimensions add multiple --dims. Ex."
                        "--dims r --dims c")
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, dims):
         ctx.obj["component"]._cli_run(ctx, MaxProj(dims))

--- a/starfish/image/_filter/mean_high_pass.py
+++ b/starfish/image/_filter/mean_high_pass.py
@@ -7,6 +7,7 @@ from scipy.ndimage.filters import uniform_filter
 
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Number
+from starfish.util.click import pass_context_and_record
 from ._base import FilterAlgorithmBase
 from .util import (
     determine_axes_to_group_by, preserve_float_range, validate_and_broadcast_kernel_size
@@ -109,6 +110,6 @@ class MeanHighPass(FilterAlgorithmBase):
     @click.option(
         "--is-volume", is_flag=True,
         help="indicates that the image stack should be filtered in 3d")
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, size, is_volume):
         ctx.obj["component"]._cli_run(ctx, MeanHighPass(size, is_volume))

--- a/starfish/image/_filter/richardson_lucy_deconvolution.py
+++ b/starfish/image/_filter/richardson_lucy_deconvolution.py
@@ -7,6 +7,7 @@ from scipy.signal import convolve, fftconvolve
 
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Indices, Number
+from starfish.util.click import pass_context_and_record
 from ._base import FilterAlgorithmBase
 from .util import gaussian_kernel, preserve_float_range
 
@@ -174,6 +175,6 @@ class DeconvolvePSF(FilterAlgorithmBase):
     @click.option(
         '--no-clip', is_flag=True,
         help='(default True) if True, clip values below 0 and above 1')
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, num_iter, sigma, no_clip):
         ctx.obj["component"]._cli_run(ctx, DeconvolvePSF(num_iter, sigma, no_clip))

--- a/starfish/image/_filter/scale_by_percentile.py
+++ b/starfish/image/_filter/scale_by_percentile.py
@@ -5,6 +5,7 @@ import click
 import numpy as np
 
 from starfish.imagestack.imagestack import ImageStack
+from starfish.util.click import pass_context_and_record
 from ._base import FilterAlgorithmBase
 from .util import determine_axes_to_group_by, preserve_float_range
 
@@ -94,6 +95,6 @@ class ScaleByPercentile(FilterAlgorithmBase):
         "--p", default=100, type=int, help="scale images by this percentile")
     @click.option(  # FIXME: was this intentionally missed?
         "--is-volume", is_flag=True, help="filter 3D volumes")
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, p, is_volume):
         ctx.obj["component"]._cli_run(ctx, ScaleByPercentile(p, is_volume))

--- a/starfish/image/_filter/white_tophat.py
+++ b/starfish/image/_filter/white_tophat.py
@@ -5,6 +5,7 @@ import numpy as np
 from skimage.morphology import ball, disk, white_tophat
 
 from starfish.imagestack.imagestack import ImageStack
+from starfish.util.click import pass_context_and_record
 from ._base import FilterAlgorithmBase
 from .util import determine_axes_to_group_by
 
@@ -83,6 +84,6 @@ class WhiteTophat(FilterAlgorithmBase):
         help="diameter of morphological masking disk in pixels")
     @click.option(  # FIXME: was this intentionally missed?
         "--is-volume", is_flag=True, help="filter 3D volumes")
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, masking_radius, is_volume):
         ctx.obj["component"]._cli_run(ctx, WhiteTophat(masking_radius, is_volume))

--- a/starfish/image/_filter/zero_by_channel_magnitude.py
+++ b/starfish/image/_filter/zero_by_channel_magnitude.py
@@ -7,6 +7,7 @@ from tqdm import tqdm
 
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Indices
+from starfish.util.click import pass_context_and_record
 from ._base import FilterAlgorithmBase
 
 
@@ -94,6 +95,6 @@ class ZeroByChannelMagnitude(FilterAlgorithmBase):
     @click.option(
         '--normalize', is_flag=True,
         help='Scales all rounds to have unit L2 norm across channels')
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, thresh, normalize):
         ctx.obj["component"]._cli_run(ctx, ZeroByChannelMagnitude(thresh, normalize))

--- a/starfish/image/_registration/__init__.py
+++ b/starfish/image/_registration/__init__.py
@@ -4,6 +4,7 @@ import click
 
 from starfish.imagestack.imagestack import ImageStack
 from starfish.pipeline import AlgorithmBase, PipelineComponent
+from starfish.util.click import pass_context_and_record
 from . import fourier_shift
 from ._base import RegistrationAlgorithmBase
 
@@ -25,7 +26,7 @@ class Registration(PipelineComponent):
     @click.group("registration")
     @click.option("-i", "--input", type=click.Path(exists=True))
     @click.option("-o", "--output", required=True)
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, input, output):
         print("Registering...")
         ctx.obj = dict(

--- a/starfish/image/_registration/fourier_shift.py
+++ b/starfish/image/_registration/fourier_shift.py
@@ -9,6 +9,7 @@ from skimage.feature import register_translation
 from starfish.image._filter.util import preserve_float_range
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Indices
+from starfish.util.click import pass_context_and_record
 from ._base import RegistrationAlgorithmBase
 
 
@@ -96,7 +97,7 @@ class FourierShiftRegistration(RegistrationAlgorithmBase):
     @click.option("--upsampling", default=1, type=int, help="Amount of up-sampling")
     @click.option("--reference-stack", required=True, type=click.Path(exists=True),
                   help="The image stack to align the input image stack to.")
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, upsampling, reference_stack):
         ctx.obj["component"]._cli_run(ctx, FourierShiftRegistration(upsampling, reference_stack))
 

--- a/starfish/image/_segmentation/__init__.py
+++ b/starfish/image/_segmentation/__init__.py
@@ -5,6 +5,7 @@ from skimage.io import imsave
 
 from starfish.imagestack.imagestack import ImageStack
 from starfish.pipeline import AlgorithmBase, PipelineComponent
+from starfish.util.click import pass_context_and_record
 from . import watershed
 from ._base import SegmentationAlgorithmBase
 
@@ -31,7 +32,7 @@ class Segmentation(PipelineComponent):
     @click.option("--primary-images", required=True, type=click.Path(exists=True))
     @click.option("--nuclei", required=True, type=click.Path(exists=True))
     @click.option("-o", "--output", required=True)
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, primary_images, nuclei, output):
         print('Segmenting ...')
         ctx.obj = dict(

--- a/starfish/image/_segmentation/watershed.py
+++ b/starfish/image/_segmentation/watershed.py
@@ -11,6 +11,7 @@ from skimage.morphology import watershed
 from starfish.image._filter.util import bin_open, bin_thresh
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Indices, Number
+from starfish.util.click import pass_context_and_record
 from ._base import SegmentationAlgorithmBase
 
 
@@ -105,7 +106,7 @@ class Watershed(SegmentationAlgorithmBase):
         "--input-threshold", default=.22, type=float, help="Input threshold")
     @click.option(
         "--min-distance", default=57, type=int, help="Minimum distance between cells")
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, nuclei_threshold, input_threshold, min_distance):
         ctx.obj["component"]._cli_run(
             ctx, Watershed(nuclei_threshold, input_threshold, min_distance))

--- a/starfish/spots/_decoder/__init__.py
+++ b/starfish/spots/_decoder/__init__.py
@@ -5,6 +5,7 @@ import click
 from starfish.codebook.codebook import Codebook
 from starfish.intensity_table.intensity_table import IntensityTable
 from starfish.pipeline import AlgorithmBase, PipelineComponent
+from starfish.util.click import pass_context_and_record
 from . import _base
 from . import per_round_max_channel_decoder
 
@@ -28,7 +29,7 @@ class Decoder(PipelineComponent):
     @click.option("-i", "--input", required=True, type=click.Path(exists=True))
     @click.option("-o", "--output", required=True)
     @click.option("--codebook", required=True, type=click.Path(exists=True))
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, input, output, codebook):
         ctx.obj = dict(
             component=Decoder,

--- a/starfish/spots/_decoder/per_round_max_channel_decoder.py
+++ b/starfish/spots/_decoder/per_round_max_channel_decoder.py
@@ -2,6 +2,7 @@ import click
 
 from starfish.codebook.codebook import Codebook
 from starfish.intensity_table.intensity_table import IntensityTable
+from starfish.util.click import pass_context_and_record
 from ._base import DecoderAlgorithmBase
 
 
@@ -30,6 +31,6 @@ class PerRoundMaxChannelDecoder(DecoderAlgorithmBase):
 
     @staticmethod
     @click.command("PerRoundMaxChannelDecoder")
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx):
         ctx.obj["component"]._cli_run(ctx, PerRoundMaxChannelDecoder())

--- a/starfish/spots/_detector/__init__.py
+++ b/starfish/spots/_detector/__init__.py
@@ -7,6 +7,7 @@ from starfish.codebook.codebook import Codebook
 from starfish.imagestack.imagestack import ImageStack
 from starfish.pipeline import AlgorithmBase, PipelineComponent
 from starfish.types import Indices
+from starfish.util.click import pass_context_and_record
 from . import _base
 from . import blob
 from . import pixel_spot_detector
@@ -66,7 +67,7 @@ class SpotFinder(PipelineComponent):
             'round and each color channel.'
         )
     )
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, input, output, blobs_stack, reference_image_from_max_projection, codebook):
         print('Detecting Spots ...')
         ctx.obj = dict(

--- a/starfish/spots/_detector/__init__.py
+++ b/starfish/spots/_detector/__init__.py
@@ -7,7 +7,10 @@ from starfish.codebook.codebook import Codebook
 from starfish.imagestack.imagestack import ImageStack
 from starfish.pipeline import AlgorithmBase, PipelineComponent
 from starfish.types import Indices
-from starfish.util.click import pass_context_and_record
+from starfish.util.click import (
+    pass_context_and_record,
+    RequiredParentOption
+)
 from . import _base
 from . import blob
 from . import pixel_spot_detector
@@ -46,8 +49,9 @@ class SpotFinder(PipelineComponent):
 
     @staticmethod
     @click.group("detect_spots")
-    @click.option("-i", "--input", required=True, type=click.Path(exists=True))
-    @click.option("-o", "--output", required=True)
+    @click.option("-i", "--input", required=True, cls=RequiredParentOption,
+                  type=click.Path(exists=True))
+    @click.option("-o", "--output", required=True, cls=RequiredParentOption)
     @click.option(
         '--blobs-stack', default=None, required=False, help=(
             'ImageStack that contains the blobs. Will be max-projected across imaging round '

--- a/starfish/spots/_detector/blob.py
+++ b/starfish/spots/_detector/blob.py
@@ -9,6 +9,7 @@ from skimage.feature import blob_dog, blob_doh, blob_log
 from starfish.imagestack.imagestack import ImageStack
 from starfish.intensity_table.intensity_table import IntensityTable
 from starfish.types import Features, Indices, Number, SpotAttributes
+from starfish.util.click import pass_context_and_record
 from ._base import SpotFinderAlgorithmBase
 from .detect import detect_spots, measure_spot_intensity
 
@@ -180,7 +181,7 @@ class BlobDetector(SpotFinderAlgorithmBase):
         help="str ['blob_dog', 'blob_doh', 'blob_log'] name of the type of "
              "detection method used from skimage.feature"
     )
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, min_sigma, max_sigma, num_sigma, threshold, overlap, show, detector_method):
             instance = BlobDetector(min_sigma, max_sigma, num_sigma, threshold, overlap,
                                     detector_method=detector_method)

--- a/starfish/spots/_detector/local_max_peak_finder.py
+++ b/starfish/spots/_detector/local_max_peak_finder.py
@@ -13,6 +13,7 @@ from tqdm import tqdm
 from starfish.imagestack.imagestack import ImageStack
 from starfish.intensity_table.intensity_table import IntensityTable
 from starfish.types import Features, Indices, Number, SpotAttributes
+from starfish.util.click import pass_context_and_record
 from ._base import SpotFinderAlgorithmBase
 from .detect import detect_spots
 
@@ -334,7 +335,7 @@ class LocalMaxPeakFinder(SpotFinderAlgorithmBase):
         "--is-volume", default=False, action='store_false', help="Find spots in 3D or not")
     @click.option(
         "--verbose", default=True, action='store_true', help="Verbosity flag")
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, min_distance, min_obj_area, max_obj_area, stringency, threshold,
              min_num_spots_detected, measurement_type, is_volume, verbose):
         instance = LocalMaxPeakFinder(min_distance, min_obj_area, max_obj_area,

--- a/starfish/spots/_detector/pixel_spot_detector.py
+++ b/starfish/spots/_detector/pixel_spot_detector.py
@@ -6,6 +6,7 @@ import numpy as np
 from starfish.codebook.codebook import Codebook
 from starfish.imagestack.imagestack import ImageStack
 from starfish.intensity_table.intensity_table import IntensityTable
+from starfish.util.click import pass_context_and_record
 from ._base import SpotFinderAlgorithmBase
 from .combine_adjacent_features import CombineAdjacentFeatures, ConnectedComponentDecodingResult
 
@@ -114,7 +115,7 @@ class PixelSpotDetector(SpotFinderAlgorithmBase):
     @click.option('--crop-x', type=int, default=0)
     @click.option('--crop-y', type=int, default=0)
     @click.option('--crop-z', type=int, default=0)
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, metric, distance_threshold, magnitude_threshold,
              min_area, max_area, norm_order, crop_x, crop_y, crop_z):
         codebook = ctx.obj["codebook"]

--- a/starfish/spots/_detector/trackpy_local_max_peak_finder.py
+++ b/starfish/spots/_detector/trackpy_local_max_peak_finder.py
@@ -9,6 +9,7 @@ from trackpy import locate
 from starfish.imagestack.imagestack import ImageStack
 from starfish.intensity_table.intensity_table import IntensityTable
 from starfish.types import SpotAttributes
+from starfish.util.click import pass_context_and_record
 from ._base import SpotFinderAlgorithmBase
 from .detect import detect_spots
 
@@ -190,7 +191,7 @@ class TrackpyLocalMaxPeakFinder(SpotFinderAlgorithmBase):
     @click.option(
         "--is-volume", is_flag=True,
         help="indicates that the image stack should be filtered in 3d")
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, spot_diameter, min_max, max_size, separation, noise_size, smoothing_size,
              preprocess, show, percentile, is_volume):
 

--- a/starfish/spots/_target_assignment/__init__.py
+++ b/starfish/spots/_target_assignment/__init__.py
@@ -7,6 +7,7 @@ from skimage.io import imread
 
 from starfish.intensity_table.intensity_table import IntensityTable
 from starfish.pipeline import AlgorithmBase, PipelineComponent
+from starfish.util.click import pass_context_and_record
 from . import label
 from ._base import TargetAssignmentAlgorithm
 
@@ -31,7 +32,7 @@ class TargetAssignment(PipelineComponent):
     @click.option("--label-image", required=True, type=click.Path(exists=True))
     @click.option("--intensities", required=True, type=click.Path(exists=True))
     @click.option("-o", "--output", required=True)
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx, label_image, intensities, output):
 
         print('Assigning targets to cells...')

--- a/starfish/spots/_target_assignment/label.py
+++ b/starfish/spots/_target_assignment/label.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from starfish.intensity_table.intensity_table import IntensityTable
 from starfish.types import Features, Indices
+from starfish.util.click import pass_context_and_record
 from ._base import TargetAssignmentAlgorithm
 
 
@@ -72,6 +73,6 @@ class Label(TargetAssignmentAlgorithm):
 
     @staticmethod
     @click.command("Label")
-    @click.pass_context
+    @pass_context_and_record
     def _cli(ctx):
         ctx.obj["component"]._cli_run(ctx, Label())

--- a/starfish/test/full_pipelines/cli/test_help.py
+++ b/starfish/test/full_pipelines/cli/test_help.py
@@ -1,0 +1,22 @@
+import unittest
+
+from starfish.util import exec
+
+
+class TestHelp(unittest.TestCase):
+
+    STAGES = (
+        [
+            "starfish", "detect_spots", "--help",
+            lambda tempdir: tempdir
+        ],
+        [
+            "starfish", "detect_spots", "BlobDetector", "--help",
+            lambda tempdir: tempdir
+        ],
+    )
+
+    def test_run_build(self):
+        exec.stages(
+            TestHelp.STAGES,
+            keep_data=False)

--- a/starfish/util/click.py
+++ b/starfish/util/click.py
@@ -1,7 +1,7 @@
 import json
+from functools import update_wrapper
 
 import click
-from functools import update_wrapper
 from click.globals import get_current_context
 
 from starfish.types import Indices
@@ -42,7 +42,7 @@ def dimensions_option(name, required):
 def pass_context_and_log(f):
     def new_func(*args, **kwargs):
         ctx = get_current_context()
-        print(ctx.info_name,":")
+        print(ctx.info_name, ":")
         for k, v in sorted(ctx.params.items()):
             print(f"\t{k}={v}")
         return f(ctx, *args, **kwargs)

--- a/starfish/util/click.py
+++ b/starfish/util/click.py
@@ -42,8 +42,9 @@ def dimensions_option(name, required):
 def pass_context_and_record(f):
     def new_func(*args, **kwargs):
         ctx = get_current_context()
-        print(ctx.info_name, ":")
-        for k, v in sorted(ctx.params.items()):
-            print(f"\t{k}={v}")
+        record = ctx.obj.get("record", None)
+        if record is not None:
+            data = {ctx.info_name: {"params": ctx.params}}
+            record.append(data)
         return f(ctx, *args, **kwargs)
     return update_wrapper(new_func, f)

--- a/starfish/util/click.py
+++ b/starfish/util/click.py
@@ -48,3 +48,28 @@ def pass_context_and_record(f):
             record.append(data)
         return f(ctx, *args, **kwargs)
     return update_wrapper(new_func, f)
+
+
+class RequiredParentOption(click.Option):
+    """
+    For any required option in a parent group, use this type
+    so that --help works for the parent command as well as the
+    sub-command.
+    """
+
+    def handle_parse_result(self, ctx, opts, args):
+        # check to see if there is a --help on the command line
+        if any(arg in ctx.help_option_names for arg in args):
+            # if asking for help see if we are a subcommand name
+            for arg in args:
+                if arg in ctx.command.commands:
+                    # this matches a sub command name, and --help is
+                    # present, let's assume the user wants help for the
+                    # subcommand
+                    cmd = ctx.command.commands[arg]
+                    with click.Context(cmd) as sub_ctx:
+                        click.echo(cmd.get_help(sub_ctx))
+                        sub_ctx.exit()
+
+        return super(RequiredParentOption, self).handle_parse_result(
+            ctx, opts, args)

--- a/starfish/util/click.py
+++ b/starfish/util/click.py
@@ -19,9 +19,9 @@ class StarfishIndex(click.ParamType):
                 "Could not parse {} into a valid index specification.".format(spec_json))
 
         return {
-            Indices.ROUND: spec.get(Indices.ROUND, 1),
-            Indices.CH: spec.get(Indices.CH, 1),
-            Indices.Z: spec.get(Indices.Z, 1),
+            str(Indices.ROUND): spec.get(Indices.ROUND, 1),
+            str(Indices.CH): spec.get(Indices.CH, 1),
+            str(Indices.Z): spec.get(Indices.Z, 1),
         }
 
 

--- a/starfish/util/click.py
+++ b/starfish/util/click.py
@@ -39,7 +39,7 @@ def dimensions_option(name, required):
              Indices.Z.value))
 
 
-def pass_context_and_log(f):
+def pass_context_and_record(f):
     def new_func(*args, **kwargs):
         ctx = get_current_context()
         print(ctx.info_name, ":")

--- a/starfish/util/click.py
+++ b/starfish/util/click.py
@@ -1,0 +1,49 @@
+import json
+
+import click
+from functools import update_wrapper
+from click.globals import get_current_context
+
+from starfish.types import Indices
+
+
+class StarfishIndex(click.ParamType):
+
+    name = "starfish-index"
+
+    def convert(self, spec_json, param, ctx):
+        try:
+            spec = json.loads(spec_json)
+        except json.decoder.JSONDecodeError:
+            self.fail(
+                "Could not parse {} into a valid index specification.".format(spec_json))
+
+        return {
+            Indices.ROUND: spec.get(Indices.ROUND, 1),
+            Indices.CH: spec.get(Indices.CH, 1),
+            Indices.Z: spec.get(Indices.Z, 1),
+        }
+
+
+def dimensions_option(name, required):
+    return click.option(
+        "--{}-dimensions".format(name),
+        type=StarfishIndex(), required=required,
+        help="Dimensions for the {} images.  Should be a json dict, with {}, {}, "
+             "and {} as the possible keys.  The value should be the shape along that "
+             "dimension.  If a key is not present, the value is assumed to be 0."
+             .format(
+             name,
+             Indices.ROUND.value,
+             Indices.CH.value,
+             Indices.Z.value))
+
+
+def pass_context_and_log(f):
+    def new_func(*args, **kwargs):
+        ctx = get_current_context()
+        print(ctx.info_name,":")
+        for k, v in sorted(ctx.params.items()):
+            print(f"\t{k}={v}")
+        return f(ctx, *args, **kwargs)
+    return update_wrapper(new_func, f)


### PR DESCRIPTION
Generate a record of all top-level build steps (in click land this is currently equivalent to those methods which are wrapped with `pass_context`).

Also:
 * Add --quiet flag to block art (config: `cli.quiet`)
 * Add --record flag for a file path or `-` (config: `cli.record`)
 * Record all cli steps in the ctx.obj["record"] array
 * Print the records to the given path on exit

Current usage with output:

```
$ python -m starfish build --record=- --fov-count=1 --hybridization-dimensions='{"z":1}' out2
[{"build": {"params": {"fov_count": 1, "hybridization_dimensions": {"r": 1, "c": 1, "z": 1}, "output_dir": "out2", "nuclei_dimensions": null, "dots_dimensions": null}}}]
```

A solid next refactoring step might be to build a general `Recorder` object that accessible by other methods for further recording. (This may or may not be best handled by re-using `logging`)
 
cc: @berl @dganguli @shanaxel42 