### PR TITLE
Bump version for `notebook` requirement

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -49,7 +49,7 @@ nbconvert==5.4.0
 nbencdec==0.0.7
 nbformat==4.4.0
 networkx==2.1
-notebook==5.7.0
+notebook==5.7.2
 numpy==1.15.1
 packaging==17.1
 pandas==0.23.4


### PR DESCRIPTION
This is due to https://nvd.nist.gov/vuln/detail/CVE-2018-19352 and https://nvd.nist.gov/vuln/detail/CVE-2018-19351