### PR TITLE
Extract the TileSet → ImageStack code into a separate module.

### DIFF
--- a/starfish/experiment/experiment.py
+++ b/starfish/experiment/experiment.py
@@ -91,7 +91,7 @@ class FieldOfView:
 
     def __getitem__(self, item) -> ImageStack:
         if isinstance(self._images[item], TileSet):
-            self._images[item] = ImageStack(self._images[item])
+            self._images[item] = ImageStack.from_tileset(self._images[item])
         return self._images[item]
 
 

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -40,12 +40,11 @@ from slicedimage.io import resolve_path_or_url
 from tqdm import tqdm
 
 from starfish.config import StarfishConfig
-from starfish.errors import DataFormatWarning
 from starfish.experiment.builder import build_image, TileFetcher
 from starfish.experiment.builder.defaultproviders import OnesTile, tile_fetcher_factory
 from starfish.imagestack import indexing_utils, physical_coordinate_calculator
 from starfish.imagestack.parser import TileKey
-from starfish.imagestack.parser.tileset import TileSetData
+from starfish.imagestack.parser.tileset import parse_tileset, TileSetData
 from starfish.intensity_table.intensity_table import IntensityTable
 from starfish.multiprocessing.shmem import SharedMemory
 from starfish.types import (
@@ -111,31 +110,18 @@ class ImageStack:
         save the (potentially modified) image tensor to disk
     """
 
-    def __init__(self, tileset: TileSet) -> None:
-        self._num_rounds = ImageStack._get_dimension_size(tileset, Indices.ROUND)
-        self._num_chs = ImageStack._get_dimension_size(tileset, Indices.CH)
-        self._num_zlayers = ImageStack._get_dimension_size(tileset, Indices.Z)
-        self._tile_metadata = TileSetData(tileset)
-        self._tile_shape = tileset.default_tile_shape
-
-        # Examine the tiles to figure out the right kind (int, float, etc.) and size.  We require
-        # that all the tiles have the same kind of data type, but we do not require that they all
-        # have the same size of data type. The # allocated array is the highest size we encounter.
-        kind = None
-        max_size = 0
-        for tile in tqdm(tileset.tiles(), disable=(not StarfishConfig().verbose)):
-            dtype = tile.numpy_array.dtype
-            if kind is None:
-                kind = dtype.kind
-            else:
-                if kind != dtype.kind:
-                    raise TypeError("All tiles should have the same kind of dtype")
-            if dtype.itemsize > max_size:
-                max_size = dtype.itemsize
-            if self._tile_shape is None:
-                self._tile_shape = tile.tile_shape
-            elif tile.tile_shape is not None and self._tile_shape != tile.tile_shape:
-                raise ValueError("Starfish does not support tiles that are not identical in shape")
+    def __init__(
+            self,
+            tile_shape: Tuple[int, int],
+            tile_data: TileSetData,
+    ) -> None:
+        self._axes_sizes = {
+            Indices.ROUND: len(set(tilekey.round for tilekey in tile_data.keys())),
+            Indices.CH: len(set(tilekey.ch for tilekey in tile_data.keys())),
+            Indices.Z: len(set(tilekey.z for tilekey in tile_data.keys())),
+        }
+        self._tile_shape = tile_shape
+        self._tile_data = tile_data
 
         shape: MutableSequence[int] = []
         dims: MutableSequence[str] = []
@@ -148,7 +134,7 @@ class ImageStack:
 
             for axis_name, axis_data in AXES_DATA.items():
                 if ix == axis_data.order:
-                    size_for_axis = ImageStack._get_dimension_size(tileset, axis_name)
+                    size_for_axis = self._axes_sizes[axis_name]
                     dim_for_axis = axis_name
                     break
 
@@ -190,28 +176,16 @@ class ImageStack:
             coords=coordinates_tick_marks,
         )
 
-        # iterate through the tiles and set the data.
-        for tile in tileset.tiles():
-            h = tile.indices[Indices.ROUND]
-            c = tile.indices[Indices.CH]
-            zlayer = tile.indices.get(Indices.Z, 0)
-            data = tile.numpy_array
+        all_indices = list(self._iter_indices({Indices.ROUND, Indices.CH, Indices.Z}))
+        for indices in tqdm(all_indices):
+            tile = tile_data.get_tile(
+                r=indices[Indices.ROUND], ch=indices[Indices.CH], z=indices[Indices.Z])
 
-            if max_size != data.dtype.itemsize:
-                warnings.warn(
-                    f"Tile "
-                    f"(R: {tile.indices[Indices.ROUND]} C: {tile.indices[Indices.CH]} "
-                    f"Z: {tile.indices[Indices.Z]}) has "
-                    f"dtype {data.dtype}.  One or more tiles is of a larger dtype "
-                    f"{self._data.dtype}.",
-                    DataFormatWarning)
-
-            data = img_as_float32(data)
-            self.set_slice(indices={Indices.ROUND: h, Indices.CH: c, Indices.Z: zlayer}, data=data)
+            data = img_as_float32(tile.numpy_array)
+            self.set_slice(indices=indices, data=data)
             coordinate_selector = {
-                Indices.ROUND.value: h,
-                Indices.CH.value: c,
-                Indices.Z.value: zlayer,
+                index.value: index_value
+                for index, index_value in indices.items()
             }
             coordinates_values = [
                 tile.coordinates[Coordinates.X][0], tile.coordinates[Coordinates.X][1],
@@ -245,6 +219,24 @@ class ImageStack:
         return f"<starfish.ImageStack ({shape})>"
 
     @classmethod
+    def from_tileset(cls, tileset: TileSet) -> "ImageStack":
+        """
+        Parse a :py:class:`slicedimage.TileSet` into an ImageStack.
+
+        Parameters
+        ----------
+        tileset : TileSet
+            The tileset to parse.
+
+        Returns
+        -------
+        ImageStack :
+            An ImageStack representing encapsulating the data from the TileSet.
+        """
+        parsed = parse_tileset(tileset)
+        return cls(*parsed)
+
+    @classmethod
     def from_url(cls, url: str, baseurl: Optional[str]):
         """
         Constructs an ImageStack object from a URL and a base URL.
@@ -264,10 +256,9 @@ class ImageStack:
             this parameter is ignored.
         """
         config = StarfishConfig()
-        image_partition = Reader.parse_doc(url, baseurl,
-                                           backend_config=config.slicedimage)
+        tileset = Reader.parse_doc(url, baseurl, backend_config=config.slicedimage)
 
-        return cls(image_partition)
+        return cls.from_tileset(tileset)
 
     @classmethod
     def from_path_or_url(cls, url_or_path: str) -> "ImageStack":
@@ -856,7 +847,7 @@ class ImageStack:
         """
 
         data: collections.defaultdict = collections.defaultdict(list)
-        keys = self._tile_metadata.keys()
+        keys = self._tile_data.keys()
         index_keys = set(
             key.value
             for key in AXES_DATA.keys()
@@ -864,7 +855,7 @@ class ImageStack:
         extras_keys = set(
             key
             for tilekey in keys
-            for key in self._tile_metadata[tilekey].keys())
+            for key in self._tile_data[tilekey].keys())
         duplicate_keys = index_keys.intersection(extras_keys)
         if len(duplicate_keys) > 0:
             duplicate_keys_str = ", ".join([str(key) for key in duplicate_keys])
@@ -877,7 +868,7 @@ class ImageStack:
                 round=indices[Indices.ROUND],
                 ch=indices[Indices.CH],
                 z=indices[Indices.Z])
-            extras = self._tile_metadata[tilekey]
+            extras = self._tile_data[tilekey]
 
             for index, index_value in indices.items():
                 data[index.value].append(index_value)
@@ -955,24 +946,17 @@ class ImageStack:
             indices=indices,
             physical_axis=physical_axis)
 
-    @staticmethod
-    def _get_dimension_size(tileset: TileSet, dimension: Indices):
-        axis_data = AXES_DATA[dimension]
-        if dimension in tileset.dimensions or axis_data.required:
-            return tileset.get_dimension_shape(dimension)
-        return 1
-
     @property
     def num_rounds(self):
-        return self._num_rounds
+        return self._axes_sizes[Indices.ROUND]
 
     @property
     def num_chs(self):
-        return self._num_chs
+        return self._axes_sizes[Indices.CH]
 
     @property
     def num_zlayers(self):
-        return self._num_zlayers
+        return self._axes_sizes[Indices.Z]
 
     @property
     def tile_shape(self):
@@ -1007,13 +991,13 @@ class ImageStack:
                 Indices.Z: self.num_zlayers,
             },
             default_tile_shape=self._tile_shape,
-            extras=self._tile_metadata.extras,
+            extras=self._tile_data.extras,
         )
         for round_ in range(self.num_rounds):
             for ch in range(self.num_chs):
                 for zlayer in range(self.num_zlayers):
                     tilekey = TileKey(round=round_, ch=ch, z=zlayer)
-                    extras: dict = self._tile_metadata[tilekey]
+                    extras: dict = self._tile_data[tilekey]
 
                     tile_indices = {
                         Indices.ROUND: round_,
@@ -1127,7 +1111,7 @@ class ImageStack:
         )
         tileset = list(collection.all_tilesets())[0][1]
 
-        return ImageStack(tileset)
+        return cls.from_tileset(tileset)
 
     @classmethod
     def synthetic_spots(

--- a/starfish/imagestack/parser/tileset/__init__.py
+++ b/starfish/imagestack/parser/tileset/__init__.py
@@ -1,1 +1,1 @@
-from ._parser import TileSetData
+from ._parser import parse_tileset, TileSetData

--- a/starfish/imagestack/parser/tileset/_parser.py
+++ b/starfish/imagestack/parser/tileset/_parser.py
@@ -1,40 +1,114 @@
 """
 This module parses and retains the extras metadata attached to TileSet extras.
 """
+import warnings
+from typing import Collection, MutableMapping, Tuple
 
-from typing import Collection, Mapping, MutableMapping
+from slicedimage import Tile, TileSet
 
-from slicedimage import TileSet
-
+from starfish.errors import DataFormatWarning
+from starfish.imagestack.dataorder import AXES_DATA
 from starfish.imagestack.parser import TileCollectionData, TileKey
 from starfish.types import Indices
 
 
 class TileSetData(TileCollectionData):
     """
-    This class parses the data, including extras, from a TileSet and its constituent tiles.
+    This class presents a simpler API for accessing a TileSet and its constituent tiles.
     """
     def __init__(self, tileset: TileSet) -> None:
-        tile_extras: MutableMapping[TileKey, dict] = dict()
+        self.tiles: MutableMapping[TileKey, Tile] = dict()
         for tile in tileset.tiles():
-            round_ = tile.indices[Indices.ROUND]
-            ch = tile.indices[Indices.CH]
-            z = tile.indices.get(Indices.Z, 0)
-
-            tile_extras[TileKey(round=round_, ch=ch, z=z)] = tile.extras
-
-        self.tile_extras: Mapping[TileKey, dict] = tile_extras
+            key = TileKey(
+                round=tile.indices[Indices.ROUND],
+                ch=tile.indices[Indices.CH],
+                z=tile.indices.get(Indices.Z, 0))
+            self.tiles[key] = tile
         self._extras = tileset.extras
 
     def __getitem__(self, tilekey: TileKey) -> dict:
         """Returns the extras metadata for a given tile, addressed by its TileKey"""
-        return self.tile_extras[tilekey]
+        return self.tiles[tilekey].extras
 
     def keys(self) -> Collection[TileKey]:
         """Returns a Collection of the TileKey's for all the tiles."""
-        return self.tile_extras.keys()
+        return self.tiles.keys()
 
     @property
     def extras(self) -> dict:
         """Returns the extras metadata for the TileSet."""
         return self._extras
+
+    def get_tile(self, r: int, ch: int, z: int) -> Tile:
+        return self.tiles[TileKey(round=r, ch=ch, z=z)]
+
+
+def parse_tileset(
+        tileset: TileSet
+) -> Tuple[Tuple[int, int], TileSetData]:
+    """
+    Parse a :py:class:`slicedimage.TileSet` for formatting into an
+    :py:class:`starfish.imagestack.ImageStack`.
+
+    Parameters:
+    -----------
+    tileset : TileSet
+        The tileset to parse.
+
+    Returns:
+    --------
+    Tuple[Tuple[int, int], TileSetData] :
+        A tuple consisting of the following:
+            1. The (y, x) size of each tile.
+            2. A :py:class:`starfish.imagestack.tileset.TileSetData` that can be queried to obtain
+               the image data and extras metadata of each tile, as well as the extras metadata of
+               the entire :py:class:`slicedimage.TileSet`.
+    """
+    tile_data = TileSetData(tileset)
+
+    # NOTE: (ttung) this is highly inefficient as it forces us to decode the tiles multiple times.
+    # However, to simplify code review, I'm going to punt this until the next PR.
+
+    tile_shape = tileset.default_tile_shape
+
+    # Examine the tiles to figure out the right kind (int, float, etc.) and size.  We require
+    # that all the tiles have the same kind of data type, but we do not require that they all
+    # have the same size of data type. The # allocated array is the highest size we encounter.
+    kind = None
+    max_size = 0
+    max_dtype = None
+    for tile in tileset.tiles():
+        dtype = tile.numpy_array.dtype
+        if kind is None:
+            kind = dtype.kind
+        else:
+            if kind != dtype.kind:
+                raise TypeError("All tiles should have the same kind of dtype")
+        if dtype.itemsize > max_size:
+            max_size = dtype.itemsize
+            max_dtype = dtype
+        if tile_shape is None:
+            tile_shape = tile.tile_shape
+        elif tile.tile_shape is not None and tile_shape != tile.tile_shape:
+            raise ValueError("Starfish does not support tiles that are not identical in shape")
+    for tile in tileset.tiles():
+        if max_size != tile.numpy_array.dtype.itemsize:
+            warnings.warn(
+                f"Tile "
+                f"(R: {tile.indices[Indices.ROUND]} C: {tile.indices[Indices.CH]} "
+                f"Z: {tile.indices[Indices.Z]}) has "
+                f"dtype {tile.numpy_array.dtype}.  One or more tiles is of a larger dtype "
+                f"{max_dtype}.",
+                DataFormatWarning)
+
+    return (
+        tile_shape,
+        tile_data,
+    )
+
+
+def _get_dimension_size(tileset: TileSet, dimension: Indices):
+    axis_data = AXES_DATA[dimension]
+    if dimension in tileset.dimensions or axis_data.required:
+        return tileset.get_dimension_shape(dimension)
+    return 1


### PR DESCRIPTION
1. `_get_dimension_size` gets moved to the new module as it is no longer needed in ImageStack.
2. Rename `tile_metadata` to `tile_data` as it represents both the image data and the metadata now.

Depends on #791

This is part of RFC #776

Test plan: make -j run_notebooks