### PR TITLE
Dynamically evaluate the tile shape and dtype as we decode.

### DIFF
--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -44,8 +44,8 @@ from starfish.config import StarfishConfig
 from starfish.experiment.builder import build_image, TileFetcher
 from starfish.experiment.builder.defaultproviders import OnesTile, tile_fetcher_factory
 from starfish.imagestack import indexing_utils, physical_coordinate_calculator
-from starfish.imagestack.parser import TileKey
-from starfish.imagestack.parser.tileset import parse_tileset, TileSetData
+from starfish.imagestack.parser import TileCollectionData, TileKey
+from starfish.imagestack.parser.tileset import parse_tileset
 from starfish.intensity_table.intensity_table import IntensityTable
 from starfish.multiprocessing.shmem import SharedMemory
 from starfish.types import (
@@ -113,7 +113,7 @@ class ImageStack:
     def __init__(
             self,
             tile_shape: Tuple[int, int],
-            tile_data: TileSetData,
+            tile_data: TileCollectionData,
     ) -> None:
         self._axes_sizes = {
             Indices.ROUND: len(set(tilekey.round for tilekey in tile_data.keys())),

--- a/starfish/imagestack/parser/__init__.py
+++ b/starfish/imagestack/parser/__init__.py
@@ -1,2 +1,2 @@
 from ._key import TileKey
-from ._tiledata import TileCollectionData
+from ._tiledata import TileCollectionData, TileData

--- a/starfish/imagestack/parser/_tiledata.py
+++ b/starfish/imagestack/parser/_tiledata.py
@@ -1,6 +1,30 @@
-from typing import Collection
+from typing import Collection, Mapping, Tuple
 
+import numpy as np
+
+from starfish.types import Coordinates, Indices, Number
 from ._key import TileKey
+
+
+class TileData:
+    """
+    Base class for a parser to implement that provides the data for a single tile.
+    """
+    @property
+    def tile_shape(self) -> Tuple[int, int]:
+        raise NotImplementedError()
+
+    @property
+    def numpy_array(self) -> np.ndarray:
+        raise NotImplementedError()
+
+    @property
+    def coordinates(self) -> Mapping[Coordinates, Tuple[Number, Number]]:
+        raise NotImplementedError()
+
+    @property
+    def indices(self) -> Mapping[Indices, int]:
+        raise NotImplementedError()
 
 
 class TileCollectionData:
@@ -19,4 +43,10 @@ class TileCollectionData:
     @property
     def extras(self) -> dict:
         """Returns the extras metadata for the TileSet."""
+        raise NotImplementedError()
+
+    def get_tile_by_key(self, tilekey: TileKey) -> TileData:
+        raise NotImplementedError()
+
+    def get_tile(self, r: int, ch: int, z: int) -> TileData:
         raise NotImplementedError()

--- a/starfish/imagestack/parser/tileset/_parser.py
+++ b/starfish/imagestack/parser/tileset/_parser.py
@@ -2,14 +2,127 @@
 This module parses and retains the extras metadata attached to TileSet extras.
 """
 import warnings
-from typing import Collection, MutableMapping, Tuple
+from typing import Collection, Mapping, MutableMapping, Optional, Tuple
 
+import numpy as np
 from slicedimage import Tile, TileSet
 
 from starfish.errors import DataFormatWarning
 from starfish.imagestack.dataorder import AXES_DATA
-from starfish.imagestack.parser import TileCollectionData, TileKey
-from starfish.types import Indices
+from starfish.imagestack.parser import TileCollectionData, TileData, TileKey
+from starfish.types import Coordinates, Indices, Number
+
+
+class _TileSetConsistencyDetector:
+    """
+    This class tracks all the tile shapes and the dtypes seen thus far during the decode of a
+    :py:class:`slicedimage.TileSet`.  If the shapes are not all identical, it will trigger a
+    ValueError.  If the kind of dtypes are not all identical, it will trigger a TypeError.
+    Additionally, if the dtypes are all of the same kind, but not all of the same size, it will
+    trigger a :py:class:`starfish.errors.DataFormatWarning`.
+    """
+    def __init__(self) -> None:
+        self.tile_shape: Optional[Tuple[int, ...]] = None
+        self.kind = None
+        self.dtype_size = None
+
+    def report_tile_shape(self, r: int, ch: int, z: int, tile_shape: Tuple[int, ...]) -> None:
+        """As each tile is parsed, the tile shape should be reported via this method.  If an
+        inconsistency is detected, a ValueError exception will be raised.
+
+        Parameters
+        ----------
+        r, ch, z : int
+            The indices of the tile, which is used to generate the exception text.
+        tile_shape : Tuple[int, ...]
+            The shape of the tile.
+        """
+        if self.tile_shape is not None and self.tile_shape != tile_shape:
+            raise ValueError(
+                f"Tile (R: {r} C: {ch} Z: {z}) has shape {tile_shape}, which is different from one "
+                f"or more of the other tiles.  Starfish does not support tiles that are not "
+                f"identical in shape."
+            )
+        self.tile_shape = tile_shape
+
+    def report_dtype(self, r: int, ch: int, z: int, dtype) -> None:
+        """As each tile is parsed, the tile data type should be reported via this method.  If an
+        inconsistency in the data type kind is is detected, a TypeError exception will be raised.
+        If the data type are of the same kind but not the same size, it will trigger a
+        :py:class:`starfish.errors.DataFormatWarning`
+
+        Parameters
+        ----------
+        r, ch, z : int
+            The indices of the tile, which is used to generate the exception text.
+        dtype :
+            The data type of the tile.
+        """
+        if self.kind is not None and self.kind != dtype.kind:
+            raise TypeError("All tiles should have the same kind of dtype")
+        if self.dtype_size is not None and self.dtype_size != dtype.itemsize:
+            warnings.warn(
+                f"Tile (R: {r} C: {ch} Z: {z}) has dtype {dtype}, which is different from one or "
+                f"more of the other tiles.",
+                DataFormatWarning)
+
+        self.kind = dtype.kind
+        self.dtype_size = dtype.itemsize
+
+
+class SlicedImageTile(TileData):
+    """
+    This wraps a :py:class:`slicedimage.Tile`.  The difference between this and
+    :py:class:`slicedimage.Tile` is that this class does cache the image data upon load.  It is
+    therefore incumbent on the consumers of these objects to discard them as soon as it is
+    reasonable to do so to free up memory.
+    """
+    def __init__(
+            self,
+            wrapped_tile: Tile,
+            expectations: _TileSetConsistencyDetector,
+            r: int,
+            ch: int,
+            z: int,
+    ) -> None:
+        self._wrapped_tile = wrapped_tile
+        self._expectations = expectations
+        self._r = r
+        self._ch = ch
+        self._z = z
+        self._numpy_array: np.ndarray = None
+
+    def _load(self):
+        if self._numpy_array is not None:
+            return
+        self._numpy_array = self._wrapped_tile.numpy_array
+        self._expectations.report_dtype(self._r, self._ch, self._z, self._numpy_array.dtype)
+
+    @property
+    def tile_shape(self) -> Tuple[int, int]:
+        self._load()
+        tile_shape = self._numpy_array.shape
+        self._expectations.report_tile_shape(self._r, self._ch, self._z, tile_shape)
+        return tile_shape
+
+    @property
+    def numpy_array(self) -> np.ndarray:
+        self._load()
+        return self._numpy_array
+
+    @property
+    def coordinates(self) -> Mapping[Coordinates, Tuple[Number, Number]]:
+        return {
+            Coordinates(coordinate_name): coordinate_value
+            for coordinate_name, coordinate_value in self._wrapped_tile.coordinates.items()
+        }
+
+    @property
+    def indices(self) -> Mapping[Indices, int]:
+        return {
+            Indices(indices_str): indices_val
+            for indices_str, indices_val in self._wrapped_tile.indices.items()
+        }
 
 
 class TileSetData(TileCollectionData):
@@ -25,6 +138,7 @@ class TileSetData(TileCollectionData):
                 z=tile.indices.get(Indices.Z, 0))
             self.tiles[key] = tile
         self._extras = tileset.extras
+        self._expectations = _TileSetConsistencyDetector()
 
     def __getitem__(self, tilekey: TileKey) -> dict:
         """Returns the extras metadata for a given tile, addressed by its TileKey"""
@@ -39,13 +153,24 @@ class TileSetData(TileCollectionData):
         """Returns the extras metadata for the TileSet."""
         return self._extras
 
-    def get_tile(self, r: int, ch: int, z: int) -> Tile:
-        return self.tiles[TileKey(round=r, ch=ch, z=z)]
+    def get_tile_by_key(self, tilekey: TileKey) -> TileData:
+        return SlicedImageTile(
+            self.tiles[tilekey],
+            self._expectations,
+            tilekey.round, tilekey.ch, tilekey.z,
+        )
+
+    def get_tile(self, r: int, ch: int, z: int) -> TileData:
+        return SlicedImageTile(
+            self.tiles[TileKey(round=r, ch=ch, z=z)],
+            self._expectations,
+            r, ch, z,
+        )
 
 
 def parse_tileset(
         tileset: TileSet
-) -> Tuple[Tuple[int, int], TileSetData]:
+) -> Tuple[Tuple[int, int], TileCollectionData]:
     """
     Parse a :py:class:`slicedimage.TileSet` for formatting into an
     :py:class:`starfish.imagestack.ImageStack`.
@@ -66,40 +191,13 @@ def parse_tileset(
     """
     tile_data = TileSetData(tileset)
 
-    # NOTE: (ttung) this is highly inefficient as it forces us to decode the tiles multiple times.
-    # However, to simplify code review, I'm going to punt this until the next PR.
-
     tile_shape = tileset.default_tile_shape
 
-    # Examine the tiles to figure out the right kind (int, float, etc.) and size.  We require
-    # that all the tiles have the same kind of data type, but we do not require that they all
-    # have the same size of data type. The # allocated array is the highest size we encounter.
-    kind = None
-    max_size = 0
-    max_dtype = None
-    for tile in tileset.tiles():
-        dtype = tile.numpy_array.dtype
-        if kind is None:
-            kind = dtype.kind
-        else:
-            if kind != dtype.kind:
-                raise TypeError("All tiles should have the same kind of dtype")
-        if dtype.itemsize > max_size:
-            max_size = dtype.itemsize
-            max_dtype = dtype
-        if tile_shape is None:
-            tile_shape = tile.tile_shape
-        elif tile.tile_shape is not None and tile_shape != tile.tile_shape:
-            raise ValueError("Starfish does not support tiles that are not identical in shape")
-    for tile in tileset.tiles():
-        if max_size != tile.numpy_array.dtype.itemsize:
-            warnings.warn(
-                f"Tile "
-                f"(R: {tile.indices[Indices.ROUND]} C: {tile.indices[Indices.CH]} "
-                f"Z: {tile.indices[Indices.Z]}) has "
-                f"dtype {tile.numpy_array.dtype}.  One or more tiles is of a larger dtype "
-                f"{max_dtype}.",
-                DataFormatWarning)
+    # if we don't have the tile shape, then we peek at the first tile and get its shape.
+    if tile_shape is None:
+        tile_key = next(iter(tile_data.keys()))
+        tile = tile_data.get_tile_by_key(tile_key)
+        tile_shape = tile.tile_shape
 
     return (
         tile_shape,


### PR DESCRIPTION
There is an inefficiency in the code that has us decoding the image _twice_, once to find the common dtype of the data and once to constitute the 5D tensor.

#802 exacerbates the inefficiency even more, by calling numpy_array multiple times, each time triggering a decode.

This PR changes the code so that we just decode the image once and storing it in a proxy object that looks a lot like a slicedimage Tile object.  Unlike a slicedimage Tile object, however, it retains the image for the lifetime of the object.  We tightly constrain the lifetime of these objects in the ImageStack constructor to avoid bloating memory requirements.

This PR also introduces an `_Expectations` class, which tracks the tile shapes and dtypes of the tiles seen during a decode of a TileSet.  If the shapes are not all identical, it will trigger a ValueError.  If the kind of dtypes are not all identical, it will trigger a TypeError.  Additionally, if the dtypes are all of the same kind, but not all of the same size, it will trigger a :py:class:`starfish.errors.DataFormatWarning`.

Depends on #802

This is part of RFC #776

Test plan: `make -j run_notebooks`