### PR TITLE
[easy] Fix writing of experiment document.

### DIFF
--- a/starfish/experiment/builder/__init__.py
+++ b/starfish/experiment/builder/__init__.py
@@ -239,9 +239,6 @@ def write_experiment_json(
         experiment_doc['images'][aux_name] = "{}.json".format(aux_name)
 
     experiment_doc["codebook"] = "codebook.json"
-    with open(os.path.join(path, "experiment.json"), "w") as fh:
-        json.dump(experiment_doc, fh, indent=4)
-
     codebook_array = [
         {
             "codeword": [
@@ -255,3 +252,6 @@ def write_experiment_json(
     codebook.to_json(os.path.join(path, codebook_json_filename))
 
     experiment_doc = postprocess_func(experiment_doc)
+
+    with open(os.path.join(path, "experiment.json"), "w") as fh:
+        json.dump(experiment_doc, fh, indent=4)


### PR DESCRIPTION
#730 reordered it such that the postprocess_func is called at the end.  However, that means any side effects of the postprocess_func is not reflected in the written experiment document.

This PR moves the write of the experiment document to *after* the postprocess_func.

Test plan: visual inspection.