### PR TITLE
[easy] rename shape/dimensions for the data array

### DIFF
--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -124,8 +124,8 @@ class ImageStack:
         self._tile_shape = tile_shape
         self._tile_data = tile_data
 
-        shape: MutableSequence[int] = []
-        dims: MutableSequence[str] = []
+        data_shape: MutableSequence[int] = []
+        data_dimensions: MutableSequence[str] = []
         coordinates_shape: MutableSequence[int] = []
         coordinates_dimensions: MutableSequence[str] = []
         coordinates_tick_marks: MutableMapping[str, Sequence[Union[int, str]]] = dict()
@@ -143,14 +143,14 @@ class ImageStack:
                 raise ValueError(
                     f"Could not find entry for the {ix}th axis in AXES_DATA")
 
-            shape.append(size_for_axis)
-            dims.append(dim_for_axis.value)
+            data_shape.append(size_for_axis)
+            data_dimensions.append(dim_for_axis.value)
             coordinates_shape.append(size_for_axis)
             coordinates_dimensions.append(dim_for_axis.value)
             coordinates_tick_marks[dim_for_axis.value] = list(range(size_for_axis))
 
-        shape.extend(self._tile_shape)
-        dims.extend([Indices.Y.value, Indices.X.value])
+        data_shape.extend(self._tile_shape)
+        data_dimensions.extend([Indices.Y.value, Indices.X.value])
         coordinates_shape.append(6)
         coordinates_dimensions.append(PHYSICAL_COORDINATE_DIMENSION)
         coordinates_tick_marks[PHYSICAL_COORDINATE_DIMENSION] = [
@@ -163,10 +163,10 @@ class ImageStack:
         ]
         # now that we know the tile data type (kind and size), we can allocate the data array.
         self._data = MPDataArray.from_shape_and_dtype(
-            shape=shape,
+            shape=data_shape,
             dtype=np.float32,
             initial_value=0,
-            dims=dims,
+            dims=data_dimensions,
         )
         self._coordinates = xr.DataArray(
             np.empty(


### PR DESCRIPTION
Rename the variables to `data_shape` and `data_dimensions` to match what is being done for the coordinates array.