### PR TITLE
Use labeled coordinates on r/c/z.

### DIFF
--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -126,6 +126,7 @@ class ImageStack:
 
         data_shape: MutableSequence[int] = []
         data_dimensions: MutableSequence[str] = []
+        data_tick_marks: MutableMapping[str, Sequence[int]] = dict()
         coordinates_shape: MutableSequence[int] = []
         coordinates_dimensions: MutableSequence[str] = []
         coordinates_tick_marks: MutableMapping[str, Sequence[Union[int, str]]] = dict()
@@ -145,6 +146,7 @@ class ImageStack:
 
             data_shape.append(size_for_axis)
             data_dimensions.append(dim_for_axis.value)
+            data_tick_marks[dim_for_axis.value] = list(range(size_for_axis))
             coordinates_shape.append(size_for_axis)
             coordinates_dimensions.append(dim_for_axis.value)
             coordinates_tick_marks[dim_for_axis.value] = list(range(size_for_axis))
@@ -167,6 +169,7 @@ class ImageStack:
             dtype=np.float32,
             initial_value=0,
             dims=data_dimensions,
+            coords=data_tick_marks,
         )
         self._coordinates = xr.DataArray(
             np.empty(

--- a/starfish/imagestack/indexing_utils.py
+++ b/starfish/imagestack/indexing_utils.py
@@ -24,8 +24,8 @@ def convert_to_indexers_dict(indexers) -> Mapping[str, Union[int, slice]]:
     return return_dict
 
 
-def index_keep_dimensions(data: xr.DataArray, indexers: Mapping[str, Union[int, slice]]
-                          ) -> xr.DataArray:
+def index_keep_dimensions(
+        data: xr.DataArray, indexers: Mapping[str, Union[int, slice]]) -> xr.DataArray:
     """Takes an xarray and key to index it. Indexes then adds back in lost dimensions"""
     # store original dims
     original_dims = data.dims

--- a/starfish/test/image/test_imagestack_index.py
+++ b/starfish/test/image/test_imagestack_index.py
@@ -36,7 +36,7 @@ def test_imagestack_indexing():
     # index on single round and range of ch and Z
     indexed = stack.sel({Indices.ROUND: 1, Indices.CH: (None, 3), Indices.Z: (7, None)})
     expected_shape = OrderedDict(
-        [(Indices.ROUND, 1), (Indices.CH, 3), (Indices.Z, 8), (Indices.Y, 200), (Indices.X, 200)])
+        [(Indices.ROUND, 1), (Indices.CH, 4), (Indices.Z, 8), (Indices.Y, 200), (Indices.X, 200)])
     assert indexed.shape == expected_shape
 
     # index on first half of X and single value of Y


### PR DESCRIPTION
Right now, we use the default indexing provided by xarray, which is by pixel index.  To support r/c/z where the labels are not contiguous, we need to manually assign the labels.

One side effect is that label indexing is inclusive of the start _and_ end bounds.  That is the reason the test is updated.

Test plan: `make -j lint mypy && pytest -v -n8 starfish/test/image/`

Depends on #816 