### PR TITLE
Fix treatment of set_slice's axes parameter.

### DIFF
--- a/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
+++ b/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
@@ -222,7 +222,7 @@
     "for indices in primary_image._iter_indices():\n",
     "    data = scaled_image.get_slice(indices)[0]\n",
     "    scaled = data / scale_factors[indices[Indices.ROUND.value], indices[Indices.CH.value]]\n",
-    "    scaled_image.set_slice(indices, scaled)"
+    "    scaled_image.set_slice(indices, scaled, [Indices.Z])"
    ]
   },
   {

--- a/notebooks/py/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
+++ b/notebooks/py/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
@@ -135,7 +135,7 @@ scaled_image = deepcopy(low_passed)
 for indices in primary_image._iter_indices():
     data = scaled_image.get_slice(indices)[0]
     scaled = data / scale_factors[indices[Indices.ROUND.value], indices[Indices.CH.value]]
-    scaled_image.set_slice(indices, scaled)
+    scaled_image.set_slice(indices, scaled, [Indices.Z])
 # EPY: END code
 
 # EPY: START markdown

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -83,7 +83,7 @@ class ImageStack:
     -------
     get_slice(indices)
         retrieve a slice of the image tensor
-    set_slice(indices, data, axes=None)
+    set_slice(indices, data, axes=[])
         set a slice of the image tensor
     apply(func, group_by={Indices.ROUND, Indices.CH, Indices.Z},
         in_place=False, verbose=False, n_processes=None)
@@ -401,51 +401,97 @@ class ImageStack:
             self,
             indices: Mapping[Indices, Union[int, slice]],
             data: np.ndarray,
-            axes: Sequence[Indices]=None):
+            axes: Optional[Sequence[Indices]]=None):
         """
         Given a dictionary mapping the index name to either a value or a slice range and a source
         numpy array, set the slice of the array of this ImageStack to the values in the source
-        numpy array. If the optional parameter axes is provided, that represents the axes of the
-        numpy array beyond the x-y tile.
+        numpy array.
+
+        Consumers of this API should not be aware of the internal order of the axes in ImageStack.
+        As a result, they should be explicitly providing the order of the axes of the numpy array.
+        This method will reorder the data to the internal order of the axes in ImageStack before
+        writing it.
+
+        Parameters
+        ----------
+        indices : Mapping[Indices, Union[int, slice]]
+            The slice of the data we are writing with this operation.  Each index should map to a
+            value or a range.  If the index is not present, we are writing to the entire range along
+            that index.
+        data : np.ndarray
+            The source data for the operation
+        axes : Optional[Sequence[Indices]]
+            The order of the axes for the source data, excluding (Y, X).  If not provided, it is
+            assumed that the data is a 2D tile.
 
         Examples
         --------
-        ImageStack axes: H, C, and Z with shape 3, 4, 5, respectively.
-        ImageStack Implicit axes: X, Y with shape 10, 20, respectively.
-        Called to set a slice with indices {Z: 5}.
-        Data: a 4-dimensional numpy array with shape (3, 4, 10, 20)
-        Result: Replace the data for Z=5.
+        Setting a slice indicated by scalars.
+            >>> import numpy as np
+            >>> from starfish import ImageStack
+            >>> from starfish.types import Indices
+            >>> stack = ImageStack.synthetic_stack(3, 4, 5, 20, 10)
+            >>> stack.shape
+            OrderedDict([(<Indices.ROUND: 'r'>, 3),
+             (<Indices.CH: 'c'>, 4),
+             (<Indices.Z: 'z'>, 5),
+             ('y', 20),
+             ('x', 10)])
+            >>> new_data = np.zeros((3, 4, 10, 20), dtype=np.float32)
+            >>> stack.set_slice(new_data, axes=[Indices.ROUND, Indices.CH]
 
-        ImageStack axes: H, C, and Z. (shape 3, 4, 5)
-        ImageStack Implicit axes: X, Y. (shape 10, 20)
-        Called to set a slice with indices {Z: 5, C: slice(2, 4)}.
-        Data: a 4-dimensional numpy array with shape (3, 2, 10, 20)
-        Result: Replace the data for Z=5, C=2-3.
+        Setting a slice indicated by scalars.  The data presented has a different axis order than
+        the previous example.
+            >>> import numpy as np
+            >>> from starfish import ImageStack
+            >>> from starfish.types import Indices
+            >>> stack = ImageStack.synthetic_stack(3, 4, 5, 20, 10)
+            >>> stack.shape
+            OrderedDict([(<Indices.ROUND: 'r'>, 3),
+             (<Indices.CH: 'c'>, 4),
+             (<Indices.Z: 'z'>, 5),
+             ('y', 20),
+             ('x', 10)])
+            >>> new_data = np.zeros((4, 3, 10, 20), dtype=np.float32)
+            >>> stack.set_slice(new_data, axes=[Indices.CH, Indices.ROUND]
+
+        Setting a slice indicated by a range.
+            >>> from starfish import ImageStack
+            >>> from starfish.types import Indices
+            >>> stack = ImageStack.synthetic_stack(3, 4, 5, 20, 10)
+            >>> stack.shape
+            OrderedDict([(<Indices.ROUND: 'r'>, 3),
+             (<Indices.CH: 'c'>, 4),
+             (<Indices.Z: 'z'>, 5),
+             ('y', 20),
+             ('x', 10)])
+            >>> new_data = np.zeros((3, 2, 10, 20), dtype=np.float32)
+            >>> stack.set_slice({Indices.Z: 5, Indices.CH: slice(2, 4)}, new_data)
         """
 
         self._validate_data_dtype_and_range(data)
 
         slice_list, expected_axes = self._build_slice_list(indices)
 
-        if axes is not None:
-            if len(axes) != len(data.shape) - 2:
+        if axes is None:
+            axes = list()
+        if len(axes) != len(data.shape) - 2:
+            raise ValueError(
+                "data shape ({}) should be the axes ({}) and (x,y).".format(data.shape, axes))
+        move_src = list()
+        move_dst = list()
+        for src_idx, axis in enumerate(axes):
+            try:
+                dst_idx = expected_axes.index(axis)
+            except ValueError:
                 raise ValueError(
-                    "data shape ({}) should be the axes ({}) and (x,y).".format(data.shape, axes))
-            move_src = list()
-            move_dst = list()
-            for src_idx, axis in enumerate(axes):
-                try:
-                    dst_idx = expected_axes.index(axis)
-                except ValueError:
-                    raise ValueError(
-                        "Unexpected axis {}.  Expecting only {}.".format(axis, expected_axes))
-                if src_idx != dst_idx:
-                    move_src.append(src_idx)
-                    move_dst.append(dst_idx)
+                    "Unexpected axis {}.  Expecting only {}.".format(axis, expected_axes))
+            if src_idx != dst_idx:
+                move_src.append(src_idx)
+                move_dst.append(dst_idx)
 
-            if len(move_src) != 0:
-                data = data.view()
-                np.moveaxis(data, move_src, move_dst)
+        if len(move_src) != 0:
+            data = np.moveaxis(data, move_src, move_dst)
 
         if self._data[slice_list].shape != data.shape:
             raise ValueError("source shape {} mismatches destination shape {}".format(

--- a/starfish/test/image/test_imagestack.py
+++ b/starfish/test/image/test_imagestack.py
@@ -101,7 +101,7 @@ def test_set_slice_simple_index():
     )
     index = {Indices.ROUND: round_}
 
-    stack.set_slice(index, expected)
+    stack.set_slice(index, expected, [Indices.CH, Indices.Z])
 
     assert np.array_equal(stack.get_slice(index)[0], expected)
 
@@ -122,8 +122,33 @@ def test_set_slice_middle_index():
     )
     index = {Indices.CH: ch}
 
-    stack.set_slice(index, expected)
+    stack.set_slice(index, expected, [Indices.ROUND, Indices.Z])
 
+    assert np.array_equal(stack.get_slice(index)[0], expected)
+
+
+def test_set_slice_reorder():
+    """
+    Sets a slice across one of the indices.  The source data is not in the same order as the
+    imagestack order, but set_slice should reorder the axes and write it correctly.
+    """
+    stack = ImageStack.synthetic_stack()
+    round_ = 1
+    y, x = stack.tile_shape
+    index = {Indices.ROUND: round_}
+
+    written = np.full(
+        (stack.shape[Indices.Z], stack.shape[Indices.CH], y, x),
+        fill_value=0.5,
+        dtype=np.float32
+    )
+    stack.set_slice(index, written, [Indices.Z, Indices.CH])
+
+    expected = np.full(
+        (stack.shape[Indices.CH], stack.shape[Indices.Z], y, x),
+        fill_value=0.5,
+        dtype=np.float32
+    )
     assert np.array_equal(stack.get_slice(index)[0], expected)
 
 
@@ -142,7 +167,7 @@ def test_set_slice_range():
     )
     index = {Indices.Z: zrange}
 
-    stack.set_slice(index, expected)
+    stack.set_slice(index, expected, [Indices.ROUND, Indices.CH, Indices.Z])
 
     assert np.array_equal(stack.get_slice(index)[0], expected)
 


### PR DESCRIPTION
The axes parameter for set_slice _should_ always be known, in order to achieve true independence in the ordering of axes for ImageStack data.  A rational default of [] is provided, as most call sites set a 2D tile.

Attempted to clarify what the parameter does and wrote a test that exercises the reordering code path (and found a bug!).

Test plan: `make -j run_notebooks`