### PR TITLE
Updated ImageStack docstrings

### DIFF
--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -94,7 +94,7 @@ class ImageStack:
         show an interactive, pageable view of the image tensor, or a slice of the image tensor
     show_stack_napari(indices)
         view the selected indices of the image tensor with Napari. Note that Napari is
-        still a prototype, but does offer more performant viewing of multi-dimensional images
+        still a prototype, but does offer more performant viewing of multi-dimensional images.
         pip install napari-gui (requires 0.0.4)
     sel(indexers)
         return an ImageStack (coordinates preserved) that is the subset of tiles described

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -92,7 +92,14 @@ class ImageStack:
     show_stack(indices, color_map='gray', figure_size=(10, 10), rescale=False, p_min=None,
             p_max=None)
         show an interactive, pageable view of the image tensor, or a slice of the image tensor
-    write(filepath, tile_opener=None)
+    show_stack_napari(indices)
+        view the selected indices of the image tensor with Napari. Note that Napari is
+        still a prototype, but does offer more performant viewing of multi-dimensional images
+        pip install napari-gui (requires 0.0.4)
+    sel(indexers)
+        return an ImageStack (coordinates preserved) that is the subset of tiles described
+        by the indexers.
+    export(filepath, tile_opener=None)
         save the (potentially modified) image tensor to disk
     """
 

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -97,8 +97,8 @@ class ImageStack:
         still a prototype, but does offer more performant viewing of multi-dimensional images.
         pip install napari-gui (requires 0.0.4)
     sel(indexers)
-        return an ImageStack (coordinates preserved) that is the subset of tiles described
-        by the indexers.
+        return an ImageStack (coordinates preserved) that is the subset described
+        by the indexers. The indexers can slice all 5 dimensions of the image tensor.
     export(filepath, tile_opener=None)
         save the (potentially modified) image tensor to disk
     """


### PR DESCRIPTION
I updated the docstring for the ImageStack class to reflect some of the recently added/changed methods. Specifically:

- `sel()`
- `write()` -> `export()`
- `show_stack_napari()`

I'm not sure how this interacts with the readthedocs documentation, but I use the class docstrings frequently. Please let me know if anything is incomplete or incorrect.