### PR TITLE
[easy] Rename coordinates -> tile_coordinates

### DIFF
--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -924,7 +924,15 @@ class ImageStack:
 
         return result
 
-    def coordinates(
+    @property
+    def coordinates(self):
+        """
+        Returns an xarray where the row labels are the indices (R, C, Z) and the column labels are
+        the min and max for each type of coordinate (X, Y, Z).
+        """
+        return self._coordinates
+
+    def tile_coordinates(
             self,
             indices: Mapping[Indices, int],
             physical_axis: Coordinates) -> Tuple[float, float]:
@@ -937,9 +945,10 @@ class ImageStack:
             Retrieves the xmin, xmax for the tile identified by round=4, ch=3, z=2
         """
 
-        return physical_coordinate_calculator.get_coordinates(coords_array=self._coordinates,
-                                                              indices=indices,
-                                                              physical_axis=physical_axis)
+        return physical_coordinate_calculator.get_coordinates(
+            coords_array=self._coordinates,
+            indices=indices,
+            physical_axis=physical_axis)
 
     @staticmethod
     def _get_dimension_size(tileset: TileSet, dimension: Indices):
@@ -1008,9 +1017,9 @@ class ImageStack:
                     }
 
                     coordinates: MutableMapping[Coordinates, Tuple[Number, Number]] = dict()
-                    x_coordinates = self.coordinates(tile_indices, Coordinates.X)
-                    y_coordinates = self.coordinates(tile_indices, Coordinates.Y)
-                    z_coordinates = self.coordinates(tile_indices, Coordinates.Z)
+                    x_coordinates = self.tile_coordinates(tile_indices, Coordinates.X)
+                    y_coordinates = self.tile_coordinates(tile_indices, Coordinates.Y)
+                    z_coordinates = self.tile_coordinates(tile_indices, Coordinates.Z)
 
                     coordinates[Coordinates.X] = x_coordinates
                     coordinates[Coordinates.Y] = y_coordinates

--- a/starfish/test/image/test_imagestack_coordinates.py
+++ b/starfish/test/image/test_imagestack_coordinates.py
@@ -74,9 +74,9 @@ def test_coordinates():
                     Indices.Z: z
                 }
 
-                xmin, xmax = stack.coordinates(indices, Coordinates.X)
-                ymin, ymax = stack.coordinates(indices, Coordinates.Y)
-                zmin, zmax = stack.coordinates(indices, Coordinates.Z)
+                xmin, xmax = stack.tile_coordinates(indices, Coordinates.X)
+                ymin, ymax = stack.tile_coordinates(indices, Coordinates.Y)
+                zmin, zmax = stack.tile_coordinates(indices, Coordinates.Z)
 
                 expected_xmin, expected_xmax = round_to_x(_round)
                 expected_ymin, expected_ymax = round_to_y(_round)
@@ -139,9 +139,9 @@ def test_scalar_coordinates():
                     Indices.Z: z
                 }
 
-                xmin, xmax = stack.coordinates(indices, Coordinates.X)
-                ymin, ymax = stack.coordinates(indices, Coordinates.Y)
-                zmin, zmax = stack.coordinates(indices, Coordinates.Z)
+                xmin, xmax = stack.tile_coordinates(indices, Coordinates.X)
+                ymin, ymax = stack.tile_coordinates(indices, Coordinates.Y)
+                zmin, zmax = stack.tile_coordinates(indices, Coordinates.Z)
 
                 expected_x = round_to_x(_round)[0]
                 expected_y = round_to_y(_round)[0]


### PR DESCRIPTION
Add a coordinates accessor that gets the entire coordinates array.

Test plan: `make -j fast`

Depends on #824