### PR TITLE
Decouple the index values from the # of possible index values.

### DIFF
--- a/starfish/image/_filter/zero_by_channel_magnitude.py
+++ b/starfish/image/_filter/zero_by_channel_magnitude.py
@@ -78,7 +78,7 @@ class ZeroByChannelMagnitude(FilterAlgorithmBase):
             magnitude_mask = ch_magnitude >= self.thresh
 
             # apply mask and optionally, normalize by channel magnitude
-            for c in range(stack.num_chs):
+            for c in stack.index_labels(Indices.CH):
                 ind = {Indices.ROUND.value: r, Indices.CH.value: c}
                 stack._data[ind] = stack._data[ind] * magnitude_mask
 

--- a/starfish/image/_registration/fourier_shift.py
+++ b/starfish/image/_registration/fourier_shift.py
@@ -69,14 +69,14 @@ class FourierShiftRegistration(RegistrationAlgorithmBase):
                                                                    Indices.CH,
                                                                    Indices.Z)
 
-        for r in range(image.num_rounds):
+        for r in image.index_labels(Indices.ROUND):
             # compute shift between maximum projection (across channels) and dots, for each round
             # TODO: make the max projection array ignorant of axes ordering.
             shift, error = compute_shift(mp_numpy[r, :, :], reference_image_numpy, self.upsampling)
             print(f"For round: {r}, Shift: {shift}, Error: {error}")
 
-            for c in range(image.num_chs):
-                for z in range(image.num_zlayers):
+            for c in image.index_labels(Indices.CH):
+                for z in image.index_labels(Indices.Z):
                     # apply shift to all zlayers, channels, and imaging rounds
                     indices = {Indices.ROUND: r, Indices.CH: c, Indices.Z: z}
                     data, axes = image.get_slice(indices=indices)

--- a/starfish/imagestack/parser/_key.py
+++ b/starfish/imagestack/parser/_key.py
@@ -1,3 +1,8 @@
+import typing
+
+from starfish.types import Indices
+
+
 class TileKey:
     """
     This class is used to index into the TileData class.
@@ -18,6 +23,19 @@ class TileKey:
     @property
     def z(self) -> int:
         return self._z
+
+    INDICES_TO_PROPERTY_MAP = {
+        Indices.ROUND: round,
+        Indices.CH: ch,
+        Indices.Z: z,
+    }
+
+    def __getitem__(self, item) -> int:
+        """Given a index, return the corresponding value for that index for this tilekey.  For
+        instance, tilekey[Indices.ROUND] returns the round for this tilekey."""
+        index = typing.cast(Indices, item)
+        prop: property = TileKey.INDICES_TO_PROPERTY_MAP[index]  # type: ignore
+        return prop.__get__(self, TileKey)
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, TileKey):

--- a/starfish/test/image/test_imagestack.py
+++ b/starfish/test/image/test_imagestack.py
@@ -161,7 +161,7 @@ def test_set_slice_range():
     y, x = stack.tile_shape
 
     expected = np.full(
-        (stack.shape[Indices.ROUND], stack.shape[Indices.CH], zrange.stop - zrange.start, y, x),
+        (stack.shape[Indices.ROUND], stack.shape[Indices.CH], zrange.stop - zrange.start + 1, y, x),
         fill_value=0.5,
         dtype=np.float32
     )
@@ -239,7 +239,7 @@ def test_synthetic_spot_creation_produces_an_imagestack_with_correct_spot_locati
     # only 8 values should be set, since there are only 8 locations across the tensor
     assert np.sum(image.xarray != 0) == 8
 
-    intensities = image.xarray.isel(
+    intensities = image.xarray.sel(
         x=xr.DataArray(x, dims=['intensity']),
         y=xr.DataArray(y, dims=['intensity']),
         z=xr.DataArray(z, dims=['intensity']),

--- a/starfish/test/image/test_imagestack_labeled_indices.py
+++ b/starfish/test/image/test_imagestack_labeled_indices.py
@@ -1,0 +1,206 @@
+"""
+These tests center around creating an ImageStack with labeled indices and verifying that operations
+on such an ImageStack work.
+"""
+from typing import Mapping, Tuple, Union
+
+import numpy as np
+from slicedimage import ImageFormat
+
+from starfish.experiment.builder import build_image, FetchedTile, tile_fetcher_factory
+from starfish.imagestack.imagestack import ImageStack
+from starfish.types import Coordinates, Indices, Number
+from .imagestack_test_utils import verify_physical_coordinates, verify_stack_fill
+
+ROUND_LABELS = (1, 4, 6)
+CH_LABELS = (2, 4, 6, 8)
+Z_LABELS = (3, 4)
+HEIGHT = 2
+WIDTH = 4
+
+NUM_ROUND = len(ROUND_LABELS)
+NUM_CH = len(CH_LABELS)
+NUM_Z = len(Z_LABELS)
+
+
+def fill_value(round_: int, ch: int, z: int) -> float:
+    """Return the expected fill value for a given tile."""
+    round_idx = ROUND_LABELS.index(round_)
+    ch_idx = CH_LABELS.index(ch)
+    z_idx = Z_LABELS.index(z)
+    return float((((round_idx * NUM_CH) + ch_idx) * NUM_Z) + z_idx) / (NUM_ROUND * NUM_CH * NUM_Z)
+
+
+def x_coordinates(round_: int, ch: int) -> Tuple[float, float]:
+    """Return the expected physical x coordinate value for a given round/ch tuple.  Note that in
+    real life, physical coordinates are not expected to vary for different ch values.  However, for
+    completeness of the tests, we are pretending they will."""
+    return min(round_, ch) * 0.01, max(round_, ch) * 0.01
+
+
+def y_coordinates(round_: int, ch: int) -> Tuple[float, float]:
+    """Return the expected physical y coordinate value for a given round/ch tuple.  Note that in
+    real life, physical coordinates are not expected to vary for different ch values.  However, for
+    completeness of the tests, we are pretending they will."""
+    return min(round_, ch) * 0.001, max(round_, ch) * 0.001
+
+
+def z_coordinates(z: int) -> Tuple[float, float]:
+    """Return the expected physical z coordinate value for a given zlayer index."""
+    return z * 0.0001, (z + 1) * 0.0001
+
+
+class UniqueTiles(FetchedTile):
+    """Tiles where the pixel values are unique per round/ch/z."""
+    def __init__(self, fov: int, _round: int, ch: int, z: int) -> None:
+        super().__init__()
+        self._round = _round
+        self._ch = ch
+        self._z = z
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        return HEIGHT, WIDTH
+
+    @property
+    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+        return {
+            Coordinates.X: x_coordinates(self._round, self._ch),
+            Coordinates.Y: y_coordinates(self._round, self._ch),
+            Coordinates.Z: z_coordinates(self._z),
+        }
+
+    @property
+    def format(self) -> ImageFormat:
+        return ImageFormat.TIFF
+
+    def tile_data(self) -> np.ndarray:
+        return np.full(
+            shape=(HEIGHT, WIDTH),
+            fill_value=fill_value(self._round, self._ch, self._z),
+            dtype=np.float32)
+
+
+def setup_imagestack() -> ImageStack:
+    """Build an imagestack with labeled indices (i.e., indices that do not start at 0 or are not
+    sequential non-negative integers).
+    """
+    collection = build_image(
+        range(1),
+        ROUND_LABELS,
+        CH_LABELS,
+        Z_LABELS,
+        tile_fetcher_factory(UniqueTiles, True),
+    )
+    tileset = list(collection.all_tilesets())[0][1]
+
+    return ImageStack.from_tileset(tileset)
+
+
+def test_labeled_indices_read():
+    """Build an imagestack with labeled indices (i.e., indices that do not start at 0 or are not
+    sequential non-negative integers).  Verify that get_slice behaves correctly.
+    """
+    stack = setup_imagestack()
+
+    for round_ in stack.index_labels(Indices.ROUND):
+        for ch in stack.index_labels(Indices.CH):
+            for zlayer in stack.index_labels(Indices.Z):
+                verify_stack_fill(
+                    stack,
+                    {Indices.ROUND: round_, Indices.CH: ch, Indices.Z: zlayer},
+                    fill_value(round_, ch, zlayer),
+                )
+
+
+def test_labeled_indices_set_slice():
+    """Build an imagestack with labeled indices (i.e., indices that do not start at 0 or are not
+    sequential non-negative integers).  Verify that set_slice behaves correctly.
+    """
+    for round_ in ROUND_LABELS:
+        for ch in CH_LABELS:
+            for zlayer in Z_LABELS:
+                stack = setup_imagestack()
+                zeros = np.zeros((HEIGHT, WIDTH), dtype=np.float32)
+
+                stack.set_slice(
+                    {Indices.ROUND: round_, Indices.CH: ch, Indices.Z: zlayer}, zeros)
+
+                for indices in stack._iter_indices({Indices.ROUND, Indices.CH, Indices.Z}):
+                    if (indices[Indices.ROUND] == round_
+                            and indices[Indices.CH] == ch
+                            and indices[Indices.Z] == zlayer):
+                        expected_fill_value = 0
+                    else:
+                        expected_fill_value = fill_value(
+                            indices[Indices.ROUND], indices[Indices.CH], indices[Indices.Z])
+
+                    verify_stack_fill(stack, indices, expected_fill_value)
+
+
+def test_labeled_indices_sel_single_across_all_indices():
+    """Select a single tile across each index from an ImageStack with labeled indices.  Verify that
+    the data is correct and that the physical coordinates are correctly set."""
+    stack = setup_imagestack()
+
+    for indices in stack._iter_indices({Indices.ROUND, Indices.CH, Indices.Z}):
+        subselected = stack.sel(indices)
+
+        # verify that the subselected stack has the correct index labels.
+        for index_type in (Indices.ROUND, Indices.CH, Indices.Z):
+            assert subselected.index_labels(index_type) == [indices[index_type]]
+
+        # verify that the subselected stack has the correct data.
+        expected_fill_value = fill_value(
+            indices[Indices.ROUND], indices[Indices.CH], indices[Indices.Z])
+        verify_stack_fill(stack, indices, expected_fill_value)
+
+        # verify that the subselected stack has the correct size for the physical coordinates table.
+        sizes = subselected.coordinates.sizes
+        for dim in (Indices.ROUND.value, Indices.CH.value, Indices.Z.value):
+            assert sizes[dim] == 1
+
+        # assert that the physical coordinate values are what we expect.
+        verify_physical_coordinates(
+            stack,
+            indices,
+            x_coordinates(indices[Indices.ROUND], indices[Indices.CH]),
+            y_coordinates(indices[Indices.ROUND], indices[Indices.CH]),
+            z_coordinates(indices[Indices.Z]),
+        )
+
+
+def test_labeled_indices_sel_slice():
+    """Select a single tile across each index from an ImageStack with labeled indices.  Verify that
+    the data is correct and that the physical coordinates are correctly set."""
+    stack = setup_imagestack()
+    selector = {Indices.ROUND: slice(None, 4), Indices.CH: slice(4, 6), Indices.Z: 4}
+    subselected = stack.sel(selector)
+
+    # verify that the subselected stack has the correct index labels.
+    for index_type, expected_results in (
+            (Indices.ROUND, [1, 4]),
+            (Indices.CH, [4, 6]),
+            (Indices.Z, [4],)):
+        assert subselected.index_labels(index_type) == expected_results
+
+    # verify that the subselected stack has the correct size for the physical coordinates table.
+    sizes = subselected.coordinates.sizes
+    assert sizes[Indices.ROUND] == 2
+    assert sizes[Indices.CH] == 2
+    assert sizes[Indices.Z] == 1
+
+    for selectors in subselected._iter_indices({Indices.ROUND, Indices.CH, Indices.Z}):
+        # verify that the subselected stack has the correct data.
+        expected_fill_value = fill_value(
+            selectors[Indices.ROUND], selectors[Indices.CH], selectors[Indices.Z])
+        verify_stack_fill(subselected, selectors, expected_fill_value)
+
+        # verify that each tile in the subselected stack has the correct physical coordinates.
+        verify_physical_coordinates(
+            stack,
+            selectors,
+            x_coordinates(selectors[Indices.ROUND], selectors[Indices.CH]),
+            y_coordinates(selectors[Indices.ROUND], selectors[Indices.CH]),
+            z_coordinates(selectors[Indices.Z]),
+        )

--- a/starfish/test/test_utils.py
+++ b/starfish/test/test_utils.py
@@ -34,9 +34,9 @@ def imagestack_with_coords_factory(stack_shape: OrderedDict, coords: OrderedDict
                     coords[PhysicalCoordinateTypes.Z_MIN],
                     coords[PhysicalCoordinateTypes.Z_MAX]]
 
-    for _round in range(stack.num_rounds):
-        for ch in range(stack.num_chs):
-            for z in range(stack.num_zlayers):
+    for _round in stack.index_labels(Indices.ROUND):
+        for ch in stack.index_labels(Indices.CH):
+            for z in stack.index_labels(Indices.Z):
                 coordinate_selector = {
                     Indices.ROUND.value: _round,
                     Indices.CH.value: ch,


### PR DESCRIPTION
Currently, we assume all the index values are 0..n-1, if the index has dimension size=n.  This assumption will no longer hold with round-at-a-time processing, where we crop before load.  In that case, we want to preserve the existing round numbers so that we can merge the results.

A new method is added to `ImageStack`, called `index_values`, which returns an iterable over the valid index values.

This PR is missing a test for selecting a subset of an ImageStack, and verifying that the data, the labels on the axes, and the coordinates of the tiles are correct.

Test plan: `make -j test lint mypy`.

Depends on #817, #818, #823, #877 