### PR TITLE
Add local max peak finder to the CLI.

### DIFF
--- a/starfish/spots/_detector/__init__.py
+++ b/starfish/spots/_detector/__init__.py
@@ -1,4 +1,3 @@
-import os
 from typing import Type
 
 import click
@@ -9,6 +8,7 @@ from starfish.pipeline import AlgorithmBase, PipelineComponent
 from starfish.types import Indices
 from . import _base
 from . import blob
+from . import local_max_peak_finder
 from . import pixel_spot_detector
 from . import trackpy_local_max_peak_finder
 

--- a/starfish/spots/_detector/local_max_peak_finder.py
+++ b/starfish/spots/_detector/local_max_peak_finder.py
@@ -331,9 +331,9 @@ class LocalMaxPeakFinder(SpotFinderAlgorithmBase):
         "--measurement-type", default='max', type=str,
         help="How to aggregate pixel intensities in a spot")
     @click.option(
-        "--is-volume", default=False, action='store_false', help="Find spots in 3D or not")
+        "--is-volume", default=False, help="Find spots in 3D or not")
     @click.option(
-        "--verbose", default=True, action='store_true', help="Verbosity flag")
+        "--verbose", default=True, help="Verbosity flag")
     @click.pass_context
     def _cli(ctx, min_distance, min_obj_area, max_obj_area, stringency, threshold,
              min_num_spots_detected, measurement_type, is_volume, verbose):


### PR DESCRIPTION
It was not imported, and so it wasn't registered with the CLI.

Fix some of the click.option calls as action is not a valid parameter for click.

Test plan: `pytest -v -n8 starfish/test/image/` and
```
[tt (.venv)]:~/microscopy/starfish:tonytung-local-max-peak-finder> starfish detect_spots --help

         _              __ _     _
        | |            / _(_)   | |
     ___| |_ __ _ _ __| |_ _ ___| |__
    / __| __/ _` | '__|  _| / __| '_  `
    \__ \ || (_| | |  | | | \__ \ | | |
    |___/\__\__,_|_|  |_| |_|___/_| |_|


Usage: starfish detect_spots [OPTIONS] COMMAND [ARGS]...

Options:
  -i, --input PATH                [required]
  -o, --output TEXT               [required]
  --blobs-stack TEXT              ImageStack that contains the blobs. Will be
                                  max-projected across imaging round and
                                  channel to produce the blobs_image
  --reference-image-from-max-projection
                                  Construct a reference image by max
                                  projecting imaging rounds and channels.
                                  Spots are found in this image and then
                                  measured across all images in the input
                                  stack.
  --codebook TEXT                 A spaceTx spec-compliant json file that
                                  describes a three dimensional tensor whose
                                  values are the expected intensity of a spot
                                  for each code in each imaging round and each
                                  color channel.
  --help                          Show this message and exit.

Commands:
  BlobDetector
  LocalMaxPeakFinder
  PixelSpotDetector
  TrackpyLocalMaxPeakFinder
```