### PR TITLE
Remove the requirement to import all the algorithm implementations.

### DIFF
--- a/docs/source/contributing/contributing.md
+++ b/docs/source/contributing/contributing.md
@@ -26,8 +26,6 @@ For example, `--foo-bar` would convert to `foo_bar` and init must accept such an
 
 5. `NewFilter.__init__()` must have a `**kwargs` parameter to accept arbitrary CLI args.
 
-6. Finally, add a line that imports your new filter in `starfish/pipeline/filter/__init__.py`. This will make your new algorithm available for registration
-
 That's it! your `NewFilter` algoritm will automatically register and be available under `starfish filter` in the CLI.
 If at any point something gets confusing, it should be possible to look at existing pipeline components of the same category for guidance on implementation.
 

--- a/starfish/image/_filter/__init__.py
+++ b/starfish/image/_filter/__init__.py
@@ -3,19 +3,9 @@ from typing import Type
 import click
 
 from starfish.imagestack.imagestack import ImageStack
-from starfish.pipeline import AlgorithmBase, PipelineComponent
+from starfish.pipeline import AlgorithmBase, import_all_submodules, PipelineComponent
 from . import _base
-from . import bandpass
-from . import clip
-from . import gaussian_high_pass
-from . import gaussian_low_pass
-from . import laplace
-from . import max_proj
-from . import mean_high_pass
-from . import richardson_lucy_deconvolution
-from . import scale_by_percentile
-from . import white_tophat
-from . import zero_by_channel_magnitude
+import_all_submodules(__file__, __package__)
 
 
 class Filter(PipelineComponent):

--- a/starfish/image/_registration/__init__.py
+++ b/starfish/image/_registration/__init__.py
@@ -3,16 +3,16 @@ from typing import Type
 import click
 
 from starfish.imagestack.imagestack import ImageStack
-from starfish.pipeline import AlgorithmBase, PipelineComponent
-from . import fourier_shift
-from ._base import RegistrationAlgorithmBase
+from starfish.pipeline import AlgorithmBase, import_all_submodules, PipelineComponent
+from . import _base
+import_all_submodules(__file__, __package__)
 
 
 class Registration(PipelineComponent):
 
     @classmethod
     def _get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
-        return RegistrationAlgorithmBase
+        return _base.RegistrationAlgorithmBase
 
     @classmethod
     def _cli_run(cls, ctx, instance):

--- a/starfish/image/_segmentation/__init__.py
+++ b/starfish/image/_segmentation/__init__.py
@@ -1,19 +1,19 @@
-from typing import Any, Dict, List, Type
+from typing import Type
 
 import click
 from skimage.io import imsave
 
 from starfish.imagestack.imagestack import ImageStack
-from starfish.pipeline import AlgorithmBase, PipelineComponent
-from . import watershed
-from ._base import SegmentationAlgorithmBase
+from starfish.pipeline import AlgorithmBase, import_all_submodules, PipelineComponent
+from . import _base
+import_all_submodules(__file__, __package__)
 
 
 class Segmentation(PipelineComponent):
 
     @classmethod
     def _get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
-        return SegmentationAlgorithmBase
+        return _base.SegmentationAlgorithmBase
 
     @classmethod
     def _cli_run(cls, ctx, instance):

--- a/starfish/pipeline/__init__.py
+++ b/starfish/pipeline/__init__.py
@@ -1,2 +1,2 @@
 from .algorithmbase import AlgorithmBase
-from .pipelinecomponent import PipelineComponent
+from .pipelinecomponent import import_all_submodules, PipelineComponent

--- a/starfish/pipeline/pipelinecomponent.py
+++ b/starfish/pipeline/pipelinecomponent.py
@@ -1,5 +1,7 @@
 import collections
-from typing import Mapping, Optional, Type
+import importlib
+from pathlib import Path
+from typing import Mapping, Optional, Set, Type
 
 from .algorithmbase import AlgorithmBase
 
@@ -55,3 +57,30 @@ class PipelineComponent(metaclass=PipelineComponentType):
     def _cli_register(cls):
         for algorithm_cls in cls._algorithm_to_class_map().values():
             cls._cli.add_command(algorithm_cls._cli)
+
+
+def import_all_submodules(path_str: str, package: str, excluded: Optional[Set[str]]=None) -> None:
+    """
+    Given a path of a __init__.py file, find all the .py files in that directory and import them
+    relatively to a package.
+
+    Parameters:
+    -----------
+    path_str : str
+        The path of a __init__.py file.
+    package : str
+        The package name that the modules should be imported relative to.
+    excluded : Optional[Set[str]]
+        A set of files not to include.  If this is not provided, it defaults to set("__init__.py").
+    """
+    if excluded is None:
+        excluded = set("__init__.py")
+
+    path: Path = Path(path_str).parent
+    for entry in path.iterdir():
+        if not entry.suffix.lower().endswith(".py"):
+            continue
+        if entry.name.lower() in excluded:
+            continue
+
+        importlib.import_module(f".{entry.stem}", package)

--- a/starfish/spots/_decoder/__init__.py
+++ b/starfish/spots/_decoder/__init__.py
@@ -4,9 +4,10 @@ import click
 
 from starfish.codebook.codebook import Codebook
 from starfish.intensity_table.intensity_table import IntensityTable
-from starfish.pipeline import AlgorithmBase, PipelineComponent
+from starfish.pipeline import AlgorithmBase, import_all_submodules, PipelineComponent
 from . import _base
-from . import per_round_max_channel_decoder
+
+import_all_submodules(__file__, __package__)
 
 
 class Decoder(PipelineComponent):

--- a/starfish/spots/_detector/__init__.py
+++ b/starfish/spots/_detector/__init__.py
@@ -4,13 +4,11 @@ import click
 
 from starfish.codebook.codebook import Codebook
 from starfish.imagestack.imagestack import ImageStack
-from starfish.pipeline import AlgorithmBase, PipelineComponent
+from starfish.pipeline import AlgorithmBase, import_all_submodules, PipelineComponent
 from starfish.types import Indices
 from . import _base
-from . import blob
-from . import local_max_peak_finder
-from . import pixel_spot_detector
-from . import trackpy_local_max_peak_finder
+
+import_all_submodules(__file__, __package__)
 
 
 class SpotFinder(PipelineComponent):

--- a/starfish/spots/_target_assignment/__init__.py
+++ b/starfish/spots/_target_assignment/__init__.py
@@ -2,7 +2,6 @@ import os
 from typing import Type
 
 import click
-import numpy as np
 from skimage.io import imread
 
 from starfish.intensity_table.intensity_table import IntensityTable


### PR DESCRIPTION
Created a method that automatically imports all the modules in a directory (with exclusions, so we don't import ourselves).

Test plan: Test plan: `pytest -v -n8 starfish/test/image/`

Depends on #830 