### PR TITLE
Remove unnecessary initialization in MPDataArray

### DIFF
--- a/starfish/imagestack/_mp_dataarray.py
+++ b/starfish/imagestack/_mp_dataarray.py
@@ -32,7 +32,7 @@ class MPDataArray:
             cls, shape: Sequence[int], dtype, initial_value: Number=None, *args, **kwargs
     ) -> "MPDataArray":
         np_array, backing_mp_array = np_array_backed_by_mp_array(shape, dtype)
-        if initial_value is not None:
+        if initial_value is not None and initial_value != 0:
             np_array.fill(initial_value)
         xarray = xr.DataArray(np_array, *args, **kwargs)
         xarray.copy = functools.partial(replacement_copy, xarray.copy)


### PR DESCRIPTION
multiprocessing.Array actually [initializes the data array to 0](https://github.com/python/cpython/blob/c9566b8c454120e3d0ddb5ab970f262a6cd80077/Lib/multiprocessing/sharedctypes.py#L59), though it's not documented.  This reduces the initialization costs of ImageStack significantly.

This partially remediates https://github.com/spacetx/starfish/issues/833, though it's a very tiny part.