### PR TITLE
Refactor common ImageStack test idioms into utility functions

### DIFF
--- a/starfish/test/image/imagestack_test_utils.py
+++ b/starfish/test/image/imagestack_test_utils.py
@@ -1,0 +1,57 @@
+"""Simple utility function we commonly use across ImageStack tests."""
+from typing import Mapping, Sequence, Tuple, Union
+
+import numpy as np
+
+from starfish.imagestack.imagestack import ImageStack
+from starfish.types import Coordinates, Indices, Number
+
+
+def verify_stack_data(
+        stack: ImageStack,
+        selectors: Mapping[Indices, Union[int, slice]],
+        expected_data: np.ndarray,
+) -> Tuple[np.ndarray, Sequence[Indices]]:
+    """Given an imagestack and a set of selectors, verify that the data referred to by the selectors
+    matches the expected data.
+    """
+    tile_data, axes = stack.get_slice(selectors)
+    assert np.array_equal(tile_data, expected_data)
+
+    return tile_data, axes
+
+
+def verify_stack_fill(
+        stack: ImageStack,
+        selectors: Mapping[Indices, Union[int, slice]],
+        expected_fill_value: Number,
+) -> Tuple[np.ndarray, Sequence[Indices]]:
+    """Given an imagestack and a set of selectors, verify that the data referred to by the selectors
+    matches an expected fill value.
+    """
+    tile_data, axes = stack.get_slice(selectors)
+    expected_data = np.full(tile_data.shape, expected_fill_value, np.float32)
+    assert np.array_equal(tile_data, expected_data)
+
+    return tile_data, axes
+
+
+def verify_physical_coordinates(
+        stack: ImageStack,
+        selectors: Mapping[Indices, int],
+        expected_x_coordinates: Tuple[float, float],
+        expected_y_coordinates: Tuple[float, float],
+        expected_z_coordinates: Tuple[float, float]
+) -> None:
+    """Given an imagestack and a set of selectors, verify that the physical coordinates for the data
+    referred to by the selectors match the expected physical coordinates.
+    """
+    assert np.all(np.isclose(
+        stack.tile_coordinates(selectors, Coordinates.X),
+        expected_x_coordinates))
+    assert np.all(np.isclose(
+        stack.tile_coordinates(selectors, Coordinates.Y),
+        expected_y_coordinates))
+    assert np.all(np.isclose(
+        stack.tile_coordinates(selectors, Coordinates.Z),
+        expected_z_coordinates))

--- a/starfish/test/image/test_imagestack_coordinates.py
+++ b/starfish/test/image/test_imagestack_coordinates.py
@@ -6,6 +6,7 @@ from slicedimage import ImageFormat
 from starfish.experiment.builder import FetchedTile, tile_fetcher_factory
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Coordinates, Indices, Number
+from .imagestack_test_utils import verify_physical_coordinates
 
 NUM_ROUND = 8
 NUM_CH = 1
@@ -65,29 +66,14 @@ def test_coordinates():
         )
     )
 
-    for _round in range(NUM_ROUND):
-        for ch in range(NUM_CH):
-            for z in range(NUM_Z):
-                indices = {
-                    Indices.ROUND: _round,
-                    Indices.CH: ch,
-                    Indices.Z: z
-                }
-
-                xmin, xmax = stack.tile_coordinates(indices, Coordinates.X)
-                ymin, ymax = stack.tile_coordinates(indices, Coordinates.Y)
-                zmin, zmax = stack.tile_coordinates(indices, Coordinates.Z)
-
-                expected_xmin, expected_xmax = round_to_x(_round)
-                expected_ymin, expected_ymax = round_to_y(_round)
-                expected_zmin, expected_zmax = round_to_z(_round)
-
-                assert np.isclose(xmin, expected_xmin)
-                assert np.isclose(xmax, expected_xmax)
-                assert np.isclose(ymin, expected_ymin)
-                assert np.isclose(ymax, expected_ymax)
-                assert np.isclose(zmin, expected_zmin)
-                assert np.isclose(zmax, expected_zmax)
+    for selectors in stack._iter_indices({Indices.ROUND, Indices.CH, Indices.Z}):
+        verify_physical_coordinates(
+            stack,
+            selectors,
+            round_to_x(selectors[Indices.ROUND]),
+            round_to_y(selectors[Indices.ROUND]),
+            round_to_z(selectors[Indices.ROUND]),
+        )
 
 
 class OffsettedScalarTiles(FetchedTile):
@@ -130,26 +116,15 @@ def test_scalar_coordinates():
         )
     )
 
-    for _round in range(NUM_ROUND):
-        for ch in range(NUM_CH):
-            for z in range(NUM_Z):
-                indices = {
-                    Indices.ROUND: _round,
-                    Indices.CH: ch,
-                    Indices.Z: z
-                }
+    for selectors in stack._iter_indices({Indices.ROUND, Indices.CH, Indices.Z}):
+        expected_x = round_to_x(selectors[Indices.ROUND])[0]
+        expected_y = round_to_y(selectors[Indices.ROUND])[0]
+        expected_z = round_to_z(selectors[Indices.ROUND])[0]
 
-                xmin, xmax = stack.tile_coordinates(indices, Coordinates.X)
-                ymin, ymax = stack.tile_coordinates(indices, Coordinates.Y)
-                zmin, zmax = stack.tile_coordinates(indices, Coordinates.Z)
-
-                expected_x = round_to_x(_round)[0]
-                expected_y = round_to_y(_round)[0]
-                expected_z = round_to_z(_round)[0]
-
-                assert np.isclose(xmin, expected_x)
-                assert np.isclose(xmax, expected_x)
-                assert np.isclose(ymin, expected_y)
-                assert np.isclose(ymax, expected_y)
-                assert np.isclose(zmin, expected_z)
-                assert np.isclose(zmax, expected_z)
+        verify_physical_coordinates(
+            stack,
+            selectors,
+            (expected_x, expected_x),
+            (expected_y, expected_y),
+            (expected_z, expected_z),
+        )


### PR DESCRIPTION
These are two common idioms across ImageStack tests (or soon-to-be-coming ImageStack tests):

1. verifying a tile (or set of tiles)'s data.
2. verifying a tile's coordinates are common operations across imagestack tests.

Extract these two idioms so we don't keep repeating ourselves.

Test plan: `pytest -v -n8 starfish/test/image/ && make -j lint mypy`

Depends on #827 