### PR TITLE
[EASY] Pass ImageFormat to ImageStack.export

### DIFF
--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -1045,8 +1045,8 @@ class ImageStack:
             tileset,
             filepath,
             pretty=True,
-            tile_format=tile_format,
-            tile_opener=tile_opener)
+            tile_opener=tile_opener,
+            tile_format=tile_format)
 
     def max_proj(self, *dims: Indices) -> "ImageStack":
         """return a max projection over one or more axis of the image tensor

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -29,7 +29,13 @@ from scipy.ndimage.filters import gaussian_filter
 from scipy.stats import scoreatpercentile
 from skimage import exposure
 from skimage import img_as_float32, img_as_uint
-from slicedimage import Reader, Tile, TileSet, Writer
+from slicedimage import (
+    ImageFormat,
+    Reader,
+    Tile,
+    TileSet,
+    Writer,
+)
 from slicedimage.io import resolve_path_or_url
 from tqdm import tqdm
 
@@ -952,7 +958,10 @@ class ImageStack:
     def tile_shape(self):
         return self._tile_shape
 
-    def export(self, filepath: str, tile_opener=None) -> None:
+    def export(self,
+               filepath: str,
+               tile_opener=None,
+               tile_format: ImageFormat=ImageFormat.NUMPY) -> None:
         """write the image tensor to disk in spaceTx format
 
         Parameters
@@ -960,6 +969,8 @@ class ImageStack:
         filepath : str
             Path + prefix for the images and primary_images.json written by this function
         tile_opener : TODO ttung: doc me.
+        tile_format : ImageFormat
+            Format in which each 2D plane should be written.
 
         """
         tileset = TileSet(
@@ -1034,6 +1045,7 @@ class ImageStack:
             tileset,
             filepath,
             pretty=True,
+            tile_format=tile_format,
             tile_opener=tile_opener)
 
     def max_proj(self, *dims: Indices) -> "ImageStack":

--- a/starfish/test/image/test_imagestack.py
+++ b/starfish/test/image/test_imagestack.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import xarray as xr
+from slicedimage import ImageFormat
 
 from starfish.imagestack.imagestack import ImageStack
 from starfish.intensity_table.intensity_table import IntensityTable
@@ -239,3 +240,18 @@ def test_imagestack_to_intensity_table_no_noise(synthetic_spot_pass_through_stac
     pixel_intensities = codebook.metric_decode(
         pixel_intensities, max_distance=0, min_intensity=1000, norm_order=2)
     assert isinstance(pixel_intensities, IntensityTable)
+
+
+@pytest.mark.parametrize("format,ending,count", (
+    (ImageFormat.TIFF, "tiff", 192),
+    (ImageFormat.NUMPY, "npy", 192),
+))
+def test_imagestack_export(tmpdir, format, ending, count, recwarn):
+    """
+    Save a synthetic stack to files and check the results
+    """
+    stack = ImageStack.synthetic_stack()
+    stack_json = tmpdir / "output.json"
+    stack.export(str(stack_json), tile_format=format)
+    assert ImageStack.from_path_or_url(str(stack_json))
+    assert count == len([x for x in tmpdir.listdir() if str(x).endswith(ending)])

--- a/starfish/test/image/test_imagestack.py
+++ b/starfish/test/image/test_imagestack.py
@@ -242,16 +242,19 @@ def test_imagestack_to_intensity_table_no_noise(synthetic_spot_pass_through_stac
     assert isinstance(pixel_intensities, IntensityTable)
 
 
-@pytest.mark.parametrize("format,ending,count", (
-    (ImageFormat.TIFF, "tiff", 192),
-    (ImageFormat.NUMPY, "npy", 192),
+@pytest.mark.parametrize("format,count", (
+    (ImageFormat.TIFF, 192),
+    (ImageFormat.NUMPY, 192),
 ))
-def test_imagestack_export(tmpdir, format, ending, count, recwarn):
+def test_imagestack_export(tmpdir, format, count, recwarn):
     """
     Save a synthetic stack to files and check the results
     """
     stack = ImageStack.synthetic_stack()
     stack_json = tmpdir / "output.json"
     stack.export(str(stack_json), tile_format=format)
+    files = list([x for x in tmpdir.listdir() if str(x).endswith(format.file_ext)])
     assert ImageStack.from_path_or_url(str(stack_json))
-    assert count == len([x for x in tmpdir.listdir() if str(x).endswith(ending)])
+    assert count == len(files)
+    with open(files[0], "rb") as fh:
+        format.reader_func(fh)


### PR DESCRIPTION
Allows passing `ImageFormat` to the export method. This does *not* reproduce the error seen by @ambrosejcarr that NUMPY files were being written with ".tiff" names. Both tests here currently produce files with the expected file-ending.

prerequisite for: tiff writing (gh-603)