### PR TITLE
Rework how we parameterize the image format for starfish.experiment.builder

### DIFF
--- a/examples/format_osmfish.py
+++ b/examples/format_osmfish.py
@@ -52,10 +52,6 @@ class osmFISHTile(FetchedTile):
     def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
         return self._coordinates
 
-    @property
-    def format(self) -> ImageFormat:
-        return ImageFormat.NUMPY
-
     def tile_data(self) -> np.ndarray:
         return cached_read_fn(self.file_path)[self.z]  # slice out the correct z-plane
 
@@ -206,6 +202,7 @@ def cli(input_dir, output_dir, metadata_yaml):
     write_experiment_json(
         path=output_dir,
         fov_count=len(primary_tile_fetcher.fov_map),
+        tile_format=ImageFormat.NUMPY,
         primary_image_dimensions=primary_image_dimensions,
         aux_name_to_dimensions={},
         primary_tile_fetcher=primary_tile_fetcher,

--- a/examples/get_imc_data.py
+++ b/examples/get_imc_data.py
@@ -31,10 +31,6 @@ class ImagingMassCytometryTile(FetchedTile):
             Coordinates.Z: (0.0, 0.0001),
         }
 
-    @property
-    def format(self) -> ImageFormat:
-        return ImageFormat.TIFF
-
     def tile_data(self) -> np.ndarray:
         return self._tile_data
 
@@ -161,6 +157,7 @@ def cli(input_dir, output_dir):
     write_experiment_json(
         path=output_dir,
         fov_count=len(primary_tile_fetcher._fov_map),
+        tile_format=ImageFormat.TIFF,
         primary_image_dimensions=primary_image_dimensions,
         aux_name_to_dimensions={},
         primary_tile_fetcher=primary_tile_fetcher,

--- a/examples/get_iss_breast_data.py
+++ b/examples/get_iss_breast_data.py
@@ -28,10 +28,6 @@ class IssCroppedBreastTile(FetchedTile):
             Coordinates.Z: (0.0, 0.0001),
         }
 
-    @property
-    def format(self) -> ImageFormat:
-        return ImageFormat.TIFF
-
     @staticmethod
     def crop(img):
         crp = img[40:1084, 20:1410]
@@ -112,6 +108,7 @@ def format_data(input_dir, output_dir, num_fovs):
     write_experiment_json(
         path=output_dir,
         fov_count=num_fovs,
+        tile_format=ImageFormat.TIFF,
         primary_image_dimensions=primary_image_dimensions,
         aux_name_to_dimensions=aux_name_to_dimensions,
         primary_tile_fetcher=ISSCroppedBreastPrimaryTileFetcher(input_dir),

--- a/examples/get_iss_data.py
+++ b/examples/get_iss_data.py
@@ -36,10 +36,6 @@ class ISSTile(FetchedTile):
             Coordinates.Z: (0.0, 0.0001),
         }
 
-    @property
-    def format(self) -> ImageFormat:
-        return ImageFormat.TIFF
-
     def tile_data(self) -> np.ndarray:
         return imread(self.file_path)
 
@@ -100,12 +96,13 @@ def format_data(input_dir, output_dir, d):
     write_experiment_json(
         output_dir,
         1,
-        {
+        ImageFormat.TIFF,
+        primary_image_dimensions={
             Indices.ROUND: 4,
             Indices.CH: 4,
             Indices.Z: 1,
         },
-        {
+        aux_name_to_dimensions={
             'nuclei': {
                 Indices.ROUND: 1,
                 Indices.CH: 1,

--- a/examples/get_merfish_u20s_data.py
+++ b/examples/get_merfish_u20s_data.py
@@ -59,10 +59,6 @@ class MERFISHTile(FetchedTile):
             Coordinates.Z: (0.0, 0.0001),
         }
 
-    @property
-    def format(self) -> ImageFormat:
-        return ImageFormat.TIFF
-
     def tile_data(self) -> IO:
         return cached_read_fn(self.file_path)[self.map[(self.r, self.ch)], :, :]
 
@@ -84,10 +80,6 @@ class MERFISHAuxTile(FetchedTile):
             Coordinates.Y: (0.0, 0.0001),
             Coordinates.Z: (0.0, 0.0001),
         }
-
-    @property
-    def format(self) -> ImageFormat:
-        return ImageFormat.TIFF
 
     def tile_data(self) -> np.ndarray:
         return cached_read_fn(self.file_path)[self.dapi_index, :, :]
@@ -130,8 +122,9 @@ def format_data(input_dir, output_dir):
 
     write_experiment_json(output_dir,
                           num_fovs,
-                          hyb_dimensions,
-                          aux_name_to_dimensions,
+                          tile_format=ImageFormat.TIFF,
+                          primary_image_dimensions=hyb_dimensions,
+                          aux_name_to_dimensions=aux_name_to_dimensions,
                           primary_tile_fetcher=MERFISHTileFetcher(input_dir, is_dapi=False),
                           aux_tile_fetcher={
                               'nuclei': MERFISHTileFetcher(input_dir, is_dapi=True),

--- a/starfish/experiment/builder/__init__.py
+++ b/starfish/experiment/builder/__init__.py
@@ -137,6 +137,8 @@ def build_image(
 def write_experiment_json(
         path: str,
         fov_count: int,
+        tile_format: ImageFormat,
+        *,
         primary_image_dimensions: Mapping[Union[str, Indices], int],
         aux_name_to_dimensions: Mapping[str, Mapping[Union[str, Indices], int]],
         primary_tile_fetcher: Optional[TileFetcher]=None,
@@ -214,7 +216,7 @@ def write_experiment_json(
         pretty=True,
         partition_path_generator=_fov_path_generator,
         tile_opener=_tile_opener,
-        tile_format=ImageFormat.TIFF,
+        tile_format=tile_format,
     )
     experiment_doc['images']['primary'] = "primary_image.json"
 
@@ -234,7 +236,7 @@ def write_experiment_json(
             pretty=True,
             partition_path_generator=_fov_path_generator,
             tile_opener=_tile_opener,
-            tile_format=ImageFormat.TIFF,
+            tile_format=tile_format,
         )
         experiment_doc['images'][aux_name] = "{}.json".format(aux_name)
 

--- a/starfish/experiment/builder/cli.py
+++ b/starfish/experiment/builder/cli.py
@@ -1,6 +1,7 @@
 import json
 
 import click
+from slicedimage import ImageFormat
 
 from starfish.types import Indices
 from . import AUX_IMAGE_NAMES, write_experiment_json
@@ -47,8 +48,9 @@ for image_name in AUX_IMAGE_NAMES:
 
 def build(output_dir, fov_count, hybridization_dimensions, **kwargs):
     write_experiment_json(
-        output_dir, fov_count, hybridization_dimensions,
-        kwargs
+        output_dir, fov_count, ImageFormat.TIFF,
+        primary_image_dimensions=hybridization_dimensions,
+        aux_name_to_dimensions=kwargs,
     )
 
 for decorator in reversed(decorators):

--- a/starfish/experiment/builder/providers.py
+++ b/starfish/experiment/builder/providers.py
@@ -5,9 +5,6 @@ This module describes the contracts to provide data to the experiment builder.
 from typing import Mapping, Tuple, Union
 
 import numpy as np
-from slicedimage import (
-    ImageFormat,
-)
 
 from starfish.types import Coordinates, Number
 
@@ -51,17 +48,6 @@ class FetchedTile:
             Maps from a key to its value.
         """
         return {}
-
-    @property
-    def format(self) -> ImageFormat:
-        """Return the Tile's format
-
-        Returns
-        -------
-        ImageFormat :
-            a slicedimage format type, e.g. ImageFormat.TIFF
-        """
-        raise NotImplementedError()
 
     def tile_data(self) -> np.ndarray:
         """Return the image data representing the tile.


### PR DESCRIPTION
While slicedimage supports images where the individual tiles are different formats, there isn't an API that actually allows _writing_ images of that nature.  We can just provide the tile format at the top level `write_experiment_json` call and write the data accordingly.

Test plan: `python examples/get_iss_breast_data.py /Users/ttung/Downloads/starfish_data/mignardi_breast_1/raw/ ../starfish-formatted-data/breast/ 1` and visual inspection.