### PR TITLE
Treat sphinx warnings as errors in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 env:
   global:
     - STARFISH_STRICT_LOADING=true
+    - SPHINXOPTS=-W
 services:
 - docker
 python:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ all:	fast
 
 ### UNIT #####################################################
 #
-fast:	lint mypy test
+fast:	lint mypy test docs-html
 
 lint:   lint-non-init lint-init
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,11 +2,11 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
-SPHINXPROJ    = Starfish
-SOURCEDIR     = source
-BUILDDIR      = build
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SPHINXPROJ    ?= Starfish
+SOURCEDIR     ?= source
+BUILDDIR      ?= build
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/docs/source/API/core_objects/expression_matrix.rst
+++ b/docs/source/API/core_objects/expression_matrix.rst
@@ -1,3 +1,5 @@
+.. _ExpressionMatrix:
+
 ExpressionMatrix
 ================
 

--- a/docs/source/API/core_objects/index.rst
+++ b/docs/source/API/core_objects/index.rst
@@ -50,6 +50,9 @@ serialization for use in single-cell analysis environments such as Seurat_ and S
    codebook.rst
 
 .. toctree::
+   expression_matrix.rst
+
+.. toctree::
    intensity_table.rst
 
 .. toctree::

--- a/docs/source/API/image/filtering/filtering.rst
+++ b/docs/source/API/image/filtering/filtering.rst
@@ -1,4 +1,4 @@
-.. _filtering
+.. _filtering:
 
 Filtering
 =========

--- a/docs/source/API/image/index.rst
+++ b/docs/source/API/image/index.rst
@@ -1,4 +1,4 @@
-.. _image
+.. _image:
 
 Image Manipulation
 ==================

--- a/docs/source/API/image/registration/registration.rst
+++ b/docs/source/API/image/registration/registration.rst
@@ -1,4 +1,4 @@
-.. _registration
+.. _registration:
 
 Registration
 ============

--- a/docs/source/API/image/segmentation/segmentation.rst
+++ b/docs/source/API/image/segmentation/segmentation.rst
@@ -1,4 +1,4 @@
-.. _segmentation
+.. _segmentation:
 
 Segmentation
 ============

--- a/docs/source/API/plot/plot.rst
+++ b/docs/source/API/plot/plot.rst
@@ -1,4 +1,4 @@
-.. _plot
+.. _plot:
 
 Plotting
 ========

--- a/docs/source/API/spots/decoding/decoding.rst
+++ b/docs/source/API/spots/decoding/decoding.rst
@@ -1,4 +1,4 @@
-.. _decoding
+.. _decoding:
 
 Decoding
 ========

--- a/docs/source/API/spots/detection/detection.rst
+++ b/docs/source/API/spots/detection/detection.rst
@@ -1,4 +1,4 @@
-.. _detection
+.. _detection:
 
 Detecting
 =========
@@ -15,7 +15,7 @@ subclass ``SpotFinderAlgorithmBase``:
 Gaussian Spot Detector
 ----------------------
 
-.. autoclass:: starfish.spots._detector.gaussian.GaussianSpotDetector
+.. autoclass:: starfish.spots._detector.blob.BlobDetector
     :members:
 
 Local Max Peak Finder

--- a/docs/source/API/spots/detection/detection.rst
+++ b/docs/source/API/spots/detection/detection.rst
@@ -12,8 +12,8 @@ subclass ``SpotFinderAlgorithmBase``:
 
 .. contents::
 
-Gaussian Spot Detector
-----------------------
+Blob Detector
+-------------
 
 .. autoclass:: starfish.spots._detector.blob.BlobDetector
     :members:

--- a/docs/source/API/spots/index.rst
+++ b/docs/source/API/spots/index.rst
@@ -1,4 +1,4 @@
-.. _spots
+.. _spots:
 
 Spots
 =====

--- a/docs/source/API/spots/target_assignment/target_assignment.rst
+++ b/docs/source/API/spots/target_assignment/target_assignment.rst
@@ -1,4 +1,4 @@
-.. _assignment
+.. _assignment:
 
 Target Assignment
 =================
@@ -12,8 +12,8 @@ classes that subclass ``TargetAssignmentAlgorithmBase``:
 
 .. contents::
 
-Point In Poly 2D
-----------------
+Label
+-----
 
-.. autoclass:: starfish.spots._target_assignment.point_in_poly.PointInPoly2D
+.. autoclass:: starfish.spots._target_assignment.label.Label
     :members:

--- a/docs/source/API/types/types.rst
+++ b/docs/source/API/types/types.rst
@@ -1,4 +1,4 @@
-.. _types
+.. _types:
 
 Types
 =====

--- a/docs/source/_static/README
+++ b/docs/source/_static/README
@@ -1,0 +1,1 @@
+Place static files here

--- a/docs/source/debugging.rst
+++ b/docs/source/debugging.rst
@@ -22,7 +22,7 @@ data that was updated to work post-update:
     + http://spacetx.starfish.data.public.s3.amazonaws.com/browse/formatted/20180926/iss_breast/experiment.json
 
 If you're using your own data with starfish, you may need to re-run your data ingestion workflow
-based on :ref:`TileFetcher` and :ref:`FetchedTile` to generate up-to-date versions of spaceTx-format.
+based on ``TileFetcher`` and ``FetchedTile`` to generate up-to-date versions of spaceTx-format.
 
 Upgrading to a new version
 --------------------------

--- a/docs/source/debugging.rst
+++ b/docs/source/debugging.rst
@@ -22,7 +22,8 @@ data that was updated to work post-update:
     + http://spacetx.starfish.data.public.s3.amazonaws.com/browse/formatted/20180926/iss_breast/experiment.json
 
 If you're using your own data with starfish, you may need to re-run your data ingestion workflow
-based on ``TileFetcher`` and ``FetchedTile`` to generate up-to-date versions of spaceTx-format.
+based on :py:class:`starfish.experiment.builder.providers.TileFetcher` and
+:py:class:`starfish.experiment.builder.providers.FetchedTile` to generate up-to-date versions of spaceTx-format.
 
 Upgrading to a new version
 --------------------------

--- a/docs/source/installation/installation.rst
+++ b/docs/source/installation/installation.rst
@@ -1,4 +1,4 @@
-.. _installation
+.. _installation:
 
 Installation
 ============

--- a/docs/source/license/license.rst
+++ b/docs/source/license/license.rst
@@ -1,4 +1,4 @@
-.. _license
+.. _license:
 
 License
 =======

--- a/docs/source/sptx-format/data_conversion/data_conversion.rst
+++ b/docs/source/sptx-format/data_conversion/data_conversion.rst
@@ -1,4 +1,4 @@
-.. _data_conversion
+.. _data_conversion:
 
 Data Conversion
 ===============

--- a/docs/source/sptx-format/index.rst
+++ b/docs/source/sptx-format/index.rst
@@ -1,4 +1,4 @@
-.. _sptx_format
+.. _sptx_format:
 
 
 SpaceTx Format

--- a/docs/source/sptx-format/specification.rst
+++ b/docs/source/sptx-format/specification.rst
@@ -1,4 +1,4 @@
-.. _specification
+.. _specification:
 
 .. mdinclude:: ../../../sptx_format/README.md
 

--- a/docs/source/sptx-format/validation.rst
+++ b/docs/source/sptx-format/validation.rst
@@ -1,4 +1,4 @@
-.. _validation
+.. _validation:
 
 Validating SpaceTx Format Files
 ===============================

--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -1,4 +1,4 @@
-.. _usage
+.. _usage:
 
 Starfish Usage
 ==============
@@ -13,6 +13,9 @@ transcriptomics data. The first vignette provides an example of using starfish t
 
 .. toctree::
    iss/iss_vignette.rst
+
+.. toctree::
+   iss/iss_cli_vignette.rst
 
 .. toctree::
    fov-builder/fov-builder.rst

--- a/docs/source/usage/iss/iss_cli.sh
+++ b/docs/source/usage/iss/iss_cli.sh
@@ -54,7 +54,7 @@ starfish target_assignment \
     --coordinates-geojson /tmp/starfish/results/regions.geojson \
     --intensities /tmp/starfish/results/spots.nc \
     --output /tmp/starfish/results/targeted-spots.nc \
-    PointInPoly2D
+    Label
 
 starfish decode \
     -i /tmp/starfish/results/targeted-spots.nc \

--- a/starfish/experiment/experiment.py
+++ b/starfish/experiment/experiment.py
@@ -177,11 +177,11 @@ class Experiment:
         STARISH_CONFIG :
             This parameter is read from the environment to permit setting configuration
             values either directly or via a file. Keys read include:
-             - cache.allow_caching
+            - cache.allow_caching
         STARFISH_STRICT_LOADING :
-             This parameter is read from the environment. If set, then all JSON loaded by this
-             method will be passed to the appropriate validator. The `strict` parameter to this
-             method has priority over the environment variable.
+            This parameter is read from the environment. If set, then all JSON loaded by this
+            method will be passed to the appropriate validator. The `strict` parameter to this
+            method has priority over the environment variable.
 
         Returns
         -------

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -84,19 +84,19 @@ class ImageStack:
         retrieve a slice of the image tensor
     set_slice(indices, data, axes=None)
         set a slice of the image tensor
-    apply(func, group_by={Indices.ROUND, Indices.CH, Indices.Z}, in_place=False, verbose=False,
-            n_processes=None)
+    apply(func, group_by={Indices.ROUND, Indices.CH, Indices.Z},
+        in_place=False, verbose=False, n_processes=None)
         split the image tensor along one or more axes and apply a function across each of the
         components to yield an image tensor
     transform(func, group_by={Indices.ROUND, Indices.CH, Indices.Z}, verbose=False,
-            n_processes=None)
+        n_processes=None)
         split the image tensor along one or more axes and apply a function across each of the
         components. Results are returned as a List with length equal to the number of times
         the image tensor is split.
     max_proj(*dims)
         return a max projection over one or more axis of the image tensor
     show_stack(indices, color_map='gray', figure_size=(10, 10), rescale=False, p_min=None,
-            p_max=None)
+        p_max=None)
         show an interactive, pageable view of the image tensor, or a slice of the image tensor
     show_stack_napari(indices)
         view the selected indices of the image tensor with Napari. Note that Napari is
@@ -466,8 +466,7 @@ class ImageStack:
         -----
         To use in a Jupyter notebook, use the %gui qt5 magic.
         Axes currently cannot be labeled. Until such a time that they can, this function will
-            order them by Round, Channel, and Z.
-
+        order them by Round, Channel, and Z.
 
         """
         try:
@@ -939,8 +938,8 @@ class ImageStack:
         """Given a set of indices that uniquely identify a tile and a physical axis, return the min
         and the max coordinates for that tile along that axis.
 
-        Examples:
-        ---------
+        Examples
+        --------
         stack.coordinates({Indices.ROUND: 4, Indices.CH: 3, Indices.Z: 2}, Coordinates.X)
             Retrieves the xmin, xmax for the tile identified by round=4, ch=3, z=2
         """


### PR DESCRIPTION
Fixes applied:

 * Corrected formatting of anchors
 * Added a few missing pages to index
 * Un-ref'd a few undocumented classes
 * Allow overriding Makefile variables

Test plan:
 * If travis is green, then in the future doc warnings should be avoided.
 * Docs should also look reasonable.