### PR TITLE
Created specifications for output formats

### DIFF
--- a/docs/source/sptx-format/index.rst
+++ b/docs/source/sptx-format/index.rst
@@ -1,7 +1,12 @@
-.. _sptx_format:
+SpaceTx Format
+==============
 
-.. mdinclude:: ../../../sptx_format/README.md
+.. toctree::
+   :maxdepth: 1
+   :caption: Contents:
 
-.. _schema:
+.. toctree::
+   input_formats/index.rst
 
-.. mdinclude:: ../../../sptx_format/schema/README.md
+.. toctree::
+   output_formats/index.rst

--- a/docs/source/sptx-format/input_formats/SpaceTxFormat/index.rst
+++ b/docs/source/sptx-format/input_formats/SpaceTxFormat/index.rst
@@ -1,0 +1,3 @@
+.. _sptx_format:
+
+.. mdinclude:: ../../../../../sptx_format/README.md

--- a/docs/source/sptx-format/input_formats/Validation/index.rst
+++ b/docs/source/sptx-format/input_formats/Validation/index.rst
@@ -1,0 +1,3 @@
+.. _schema:
+
+.. mdinclude:: ../../../../../sptx_format/schema/README.md

--- a/docs/source/sptx-format/input_formats/index.rst
+++ b/docs/source/sptx-format/input_formats/index.rst
@@ -1,0 +1,12 @@
+Input Data Formats
+==================
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Contents:
+
+.. toctree::
+    SpaceTxFormat/index.rst
+
+.. toctree::
+    Validation/index.rst

--- a/docs/source/sptx-format/output_formats/ExpressionMatrix/index.rst
+++ b/docs/source/sptx-format/output_formats/ExpressionMatrix/index.rst
@@ -1,0 +1,46 @@
+.. _ExpressionMatrixSpecification:
+
+ExpressionMatrix
+================
+The :py:class:`ExpressionMatrix` is a 2-dimensional :code:`cells (x)` by :code:`genes (y)` array
+whose values contain the expression of a gene in a particular cell. The :py:class:`ExpressionMatrix`
+is additionally annotated with the :code:`x, y, z` pixel coordinates of the centroid of the cell in
+a pixel space, and :code:`xc, yc, zc` in physical coordinate space. Additional metadata may be added
+at the user's convenience to either the cells or genes.
+
+Data
+----
+Gene expression are stored as numeric values, typically as integers in Image-based transcriptomics
+experiments, since they represent counted fluorescent spots, each corresponding to a single detected
+RNA molecule.
+
+Metadata
+--------
+
+:code:`cells; cell_id (int):` cell identifier
+
+:code:`cells; x, y, z (int):` coordinates of cell centroid in pixel space
+
+:code:`cells; xc, yc, zc (int):` coordinates of cell centroid in global coordinate space (um)
+
+:code:`genes; gene_id (int):` GENCODE gene ID
+
+:code:`genes; gene_name (int):` Human-readable gene symbol (e.g. HGNC gene symbol for human data)
+
+Implementation
+--------------
+Starfish Implements the :py:class:`ExpressionMatrix` as an :code:`xarray.DataArray` object to take
+advantage of `xarray's`_ high performance, flexible metadata storage capabilities, and serialization
+options
+
+.. _`xarray's`: http://xarray.pydata.org/en/stable/
+
+Serialization
+-------------
+The :py:class:`ExpressionMatrix` can leverage any of the :code:`xarray` serialization features,
+including csv, zarr, and netcdf. We choose netcdf as it currently has the strongest support and
+interoperability between R and python. Users can load and manipulate :py:class:`ExpressionMatrix`
+using R by loading them with the `ncdf4`_ package. In the future, NetCDF serialization may be
+deprecated if R gains Zarr support.
+
+.. _ncdf4: https://cran.r-project.org/web/packages/ncdf4/index.html

--- a/docs/source/sptx-format/output_formats/IntensityTable/index.rst
+++ b/docs/source/sptx-format/output_formats/IntensityTable/index.rst
@@ -1,0 +1,85 @@
+IntensityTable
+==============
+
+The :py:class:`IntensityTable` summarizes information about RNA features that are detected in
+image-based transcriptomics experiments. The most common features are spots, pixels, or connected
+pixels that result from the fluorescence of a probe that has been experimentally attached to an RNA
+molecule.
+
+To gather information on the RNA present in a tissue slice, image-based transcriptomics experiments
+require the imaging of the same RNA molecules over multiple rounds and across multiple fluorescence
+channels. In multiplex assays, the identity of these spots is only determined after measuring the
+spot's intensity across all rounds and channels. In sequential assays, each round and channel
+identifies all detected RNA molecules for a specific target.
+
+The :py:class:`IntensityTable` stores a summary of the intensity of each feature across each round
+and channel, forming a 3-dimensional array with dimensions (feature, round, channel). It also stores
+metadata that declare how the features were measured and are defined, and metadata for each
+individual feature. Finally, it supports addition of arbitrary metadata for each feature, round,
+channel, or on the detection of those features.
+
+Data
+----
+
+IntensityTables are stored as three dimensional arrays of shape :code:`(f, r, c)`, where :code:`f`
+is the number of detected features in the experiment, :code:`r` is the number of rounds, and
+:code:`c` is the number of channels. Entries in the array are floats in the range of :code:`[0, 1]`,
+where :code:`1` represents the maximum intensity and :code:`0`, the minimum intensity.
+
+Table Metadata
+--------------
+The IntensityTable stores some standard metadata that record how features are summarized.
+
+:code:`intensity_measurement_type (string):`
+
+In the case where features are composed of spots or connected pixels, the intensity of each pixel
+in the feature must be integrated into a single measurement. The :code:`intensity_measurement_type`
+field stores the calculation made to carry out this integration. This entry is filled by the spot
+detector. The default value is :code:`max` but other common methods might include :code:`mean` or
+:code:`median`.
+
+:code:`area_measurment_type (string):`
+
+This size of each feature can be summarize in different ways that often depend on how they're
+detected. For example, it is natural to summarize spots as circles, while pixel-based
+approaches can produce irregular features that are difficult to summarize parametrically. This
+entry is filled by the spot detector and describes how areas are calculated.
+
+
+Feature Metadata
+----------------
+:py:class:`IntensityTable` Features are annotated with several types of metadata. These include the
+:code:`x, y, z` position of each feature in pixel and coordinate space and the area of the feature.
+Additionally, there are entries that can be filled by a decoder which determines the target that a
+spot corresponds to, or a Segmentation mask, which determines which cell an object corresponds to.
+Users may add additional metadata columns with names that do not overlap this list as they see fit.
+The following metadata are always present on IntensityTables. In some cases, these values may be
+set to NaN or null if the IntensityTable has not been decoded or merged with a segmentation result.
+
+:code:`x, y, z (int):` coordinates of the centroid of the feature in pixel space
+
+:code:`xc, yc, zc (float):` coordinates of the centroid of the feature in global coordinates (um)
+
+:code:`area (float):` area of the spot in pixels  # TODO: should this be in um^2?
+
+:code:`cell (int):` the id for the cell that this feature belongs to
+
+:code:`gene (str):` gene name of target RNA, (gene symbol or GENCODE gene ID)
+
+Implementation
+--------------
+Starfish Implements the :py:class:`ExpressionMatrix` as an :code:`xarray.DataArray` object to take
+advantage of `xarray's`_ high performance, flexible metadata storage capabilities, and Serialization
+options
+
+.. _`xarray's`: http://xarray.pydata.org/en/stable/
+
+Serialization
+-------------
+The :py:class:`IntensityTable` can leverage any of the :code:`xarray` serialization features,
+including csv, zarr, and netcdf. We choose netcdf as it currently has the strongest support and
+interoperability between R and python. Users can load and manipulate :py:class:`IntensityTables`
+using R by loading them with the `ncdf4`_ package. In the future, NetCDF serialization may be
+deprecated if R gains Zarr support.
+
+.. _ncdf4: https://cran.r-project.org/web/packages/ncdf4/index.html

--- a/docs/source/sptx-format/output_formats/SegmentationMask/index.rst
+++ b/docs/source/sptx-format/output_formats/SegmentationMask/index.rst
@@ -1,0 +1,20 @@
+.. _SegmentationMask:
+
+SegmentationMask
+================
+The :py:class:`SegmentationMask` is an integer array the same size as the :code:`x-y` plane of the
+input :py:class:`ImageStack`. The values of the :py:class:`SegmentationMask` indicate which cell
+each pixel corresponds to. At the moment, only hard assignment is supported.
+
+Implementation
+--------------
+The :py:class:`SegmentationMask` is currently implemented as a :code:`numpy.ndarray` object. We are
+revisiting the optimal object for this information, and are aware of the pending need to use
+segmented instances of cells to label points in 3d, and also to support non-cell instances. The
+current implementation is expected to change.
+
+Serialization
+-------------
+numpy arrays can be saved in a variety of formats of which the most common is npy_
+
+.. _npy: https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.save.html

--- a/docs/source/sptx-format/output_formats/index.rst
+++ b/docs/source/sptx-format/output_formats/index.rst
@@ -1,0 +1,15 @@
+Output Formats
+==============
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Contents:
+
+.. toctree::
+    IntensityTable/index.rst
+
+.. toctree::
+    ExpressionMatrix/index.rst
+
+.. toctree::
+    SegmentationMask/index.rst


### PR DESCRIPTION
Bug Fix: 
- Corrected API references for `IntensityTable` and `Codebook` 

New Docs: 
- Add Specification for `IntensityTable`
- Add Specification for `ExpressionMatrix`
- Add Placeholder Specification for `SegmentationMask` while we research what object we want to use for this. 