### PR TITLE
Add ability to save ImageStack as a Multi-page TIFF that FIJI can read. 

### DIFF
--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -992,7 +992,11 @@ class ImageStack:
                 Indices.CH.value,
                 Indices.Y.value,
                 Indices.X.value)
-            skimage.io.imsave(filepath, data.values, imagej=True)
+
+            # catch warnings about low-contrast images.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                skimage.io.imsave(filepath, data.values, imagej=True)
 
     def export(self,
                filepath: str,

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -23,6 +23,7 @@ from typing import (
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+import skimage.io
 import xarray as xr
 from matplotlib import get_backend as get_matplotlib_backend
 from scipy.ndimage.filters import gaussian_filter
@@ -971,6 +972,27 @@ class ImageStack:
     @property
     def tile_shape(self):
         return self._tile_shape
+
+    def to_multipage_tiff(self, filepath: str) -> None:
+            """save the ImageStack as a FIJI-compatible multi-page TIFF file
+
+            Parameters
+            ----------
+            filepath : str
+                filepath for a tiff FILE. "TIFF" suffix will be added if the provided path does not
+                end with .TIFF
+
+            """
+            if not filepath.upper().endswith(".TIFF"):
+                filepath += ".TIFF"
+
+            data = self.xarray.transpose(
+                Indices.ROUND.value,
+                Indices.Z.value,
+                Indices.CH.value,
+                Indices.Y.value,
+                Indices.X.value)
+            skimage.io.imsave(filepath, data.values, imagej=True)
 
     def export(self,
                filepath: str,

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -986,6 +986,7 @@ class ImageStack:
             if not filepath.upper().endswith(".TIFF"):
                 filepath += ".TIFF"
 
+            # RZCYX is the order expected by FIJI
             data = self.xarray.transpose(
                 Indices.ROUND.value,
                 Indices.Z.value,
@@ -993,7 +994,8 @@ class ImageStack:
                 Indices.Y.value,
                 Indices.X.value)
 
-            # catch warnings about low-contrast images.
+            # Any float32 image with low dynamic range will provoke a warning that the image is
+            # low contrast because the data must be converted to uint16 for compatibility with FIJI.
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", UserWarning)
                 skimage.io.imsave(filepath, data.values, imagej=True)


### PR DESCRIPTION
* Adds ability to save ImageStack to a multi-page Tiff that can be directly opened and viewed by FIJI. 

Testing Strategy: 
* Load data from any notebook
* Call function implemented by this PR
* Try to open the result with FIJI. 