### PR TITLE
Add optional install for Napari

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ jobs:
       script: make check_notebooks install-src fast
       after_success:
         - bash <(curl -s https://codecov.io/bash)
+    - name: Install Napari
+      script: pip install .[napari]
     - name: Docker
       if: type = push and branch =~ /^(master|merge)/
       script: make docker

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,9 @@ setuptools.setup(
     license="MIT",
     packages=setuptools.find_packages(),
     install_requires=install_requires,
+    extras_require={
+        'napari': ['napari-gui==0.0.5.1', 'matplotlib==2.1.2']
+    },
     entry_points={
         'console_scripts': [
             "starfish=starfish.starfish:starfish",


### PR DESCRIPTION
Adds specific installation instructions because this is the only way for us to effectively "freeze" the installation of `napari` while allowing it to be an optional dependency. In addition, `napari`, through it's `vispy` dependency, requires an old version of `matplotlib`. 

Use `pip install -e .[napari]` to install (note the lack of space after the period). 

cc @kevinyamauchi 