### PR TITLE
starfish.display.stack

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -38,7 +38,7 @@ jupyter-core==4.4.0
 kiwisolver==1.0.1
 m2r==0.2.1
 MarkupSafe==1.0
-matplotlib==2.2.2
+matplotlib==2.1.2
 mccabe==0.6.1
 mistune==0.8.4
 more-itertools==4.3.0

--- a/REQUIREMENTS.txt.in
+++ b/REQUIREMENTS.txt.in
@@ -1,5 +1,6 @@
 click
 jsonschema
+matplotlib==2.1.2
 numpy != 1.13.0
 pandas >= 0.23.4
 pycodestyle==2.4.0
@@ -23,7 +24,6 @@ flake8-import-order
 ipywidgets
 jsonpath_rw
 m2r
-matplotlib<=2.2.2
 pytest-cov>=2.5.1
 pytest-xdist
 mypy

--- a/notebooks/DARTFISH_Pipeline_-_Human_Occipital_Cortex_-_1_FOV.ipynb
+++ b/notebooks/DARTFISH_Pipeline_-_Human_Occipital_Cortex_-_1_FOV.ipynb
@@ -23,6 +23,7 @@
     "import seaborn as sns\n",
     "import os\n",
     "\n",
+    "import starfish.display\n",
     "from starfish import data, FieldOfView\n",
     "from starfish.types import Features, Axes\n",
     "\n",
@@ -71,7 +72,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stack.show_stack({Axes.CH:0}, rescale=True);"
+    "starfish.display.stack(stack)"
    ]
   },
   {

--- a/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
+++ b/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
@@ -33,8 +33,9 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
-    "\n",
     "from showit import image as show_image\n",
+    "\n",
+    "import starfish.display\n",
     "from starfish import data, FieldOfView\n",
     "from starfish.types import Features, Axes"
    ]
@@ -72,8 +73,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# show all imaging rounds of channel 0\n",
-    "primary_image.show_stack({Axes.CH: 0})"
+    "# Display the data\n",
+    "starfish.display.stack(primary_image)"
    ]
   },
   {

--- a/notebooks/py/DARTFISH_Pipeline_-_Human_Occipital_Cortex_-_1_FOV.py
+++ b/notebooks/py/DARTFISH_Pipeline_-_Human_Occipital_Cortex_-_1_FOV.py
@@ -18,6 +18,7 @@ import matplotlib.pyplot as plt
 import seaborn as sns
 import os
 
+import starfish.display
 from starfish import data, FieldOfView
 from starfish.types import Features, Axes
 
@@ -48,7 +49,7 @@ print(stack.shape)
 # EPY: END code
 
 # EPY: START code
-stack.show_stack({Axes.CH:0}, rescale=True);
+starfish.display.stack(stack)
 # EPY: END code
 
 # EPY: START markdown

--- a/notebooks/py/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
+++ b/notebooks/py/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
@@ -23,8 +23,9 @@ import os
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
-
 from showit import image as show_image
+
+import starfish.display
 from starfish import data, FieldOfView
 from starfish.types import Features, Axes
 # EPY: END code
@@ -44,8 +45,8 @@ primary_image = experiment.fov()[FieldOfView.PRIMARY_IMAGES]
 # EPY: END code
 
 # EPY: START code
-# show all imaging rounds of channel 0
-primary_image.show_stack({Axes.CH: 0})
+# Display the data
+starfish.display.stack(primary_image)
 # EPY: END code
 
 # EPY: START markdown

--- a/starfish/display/__init__.py
+++ b/starfish/display/__init__.py
@@ -1,0 +1,1 @@
+from .stack import stack

--- a/starfish/display/stack.py
+++ b/starfish/display/stack.py
@@ -1,0 +1,223 @@
+import warnings
+from collections import OrderedDict
+from typing import Iterable, List, Optional, Set, Tuple, Union
+
+import numpy as np
+
+from starfish.imagestack.imagestack import ImageStack
+from starfish.intensity_table.intensity_table import IntensityTable
+from starfish.types import Axes, Features
+
+
+def _normalize_axes(axes: Iterable[Union[Axes, str]]) -> List[str]:
+    """convert all axes to strings"""
+
+    def _normalize(axes):
+        if isinstance(axes, str):
+            return axes
+        elif isinstance(axes, Axes):
+            return axes.value
+        else:
+            raise TypeError(f"passed axes must be str or Axes objects, not {type(axes)}")
+
+    return list(_normalize(i) for i in axes)
+
+
+def _max_intensity_table_maintain_dims(
+    intensity_table: IntensityTable, dimensions: Set[Axes],
+) -> IntensityTable:
+    """
+    Maximum project an IntensityTable over dimensions, retaining singletons in place of dimensions
+    reduced by the max operation.
+
+    For example, xarray.max(Axes.CH.value) would usually produce a 2-d (features, rounds) output.
+    This function ensures that the output is instead (features, 1, rounds), by inserting singleton
+    dimensions in place of any projected axes.
+
+    Parameters
+    ----------
+    intensity_table : IntensityTable
+        Input intensities
+    dimensions : Set[Axes]
+        Dimensions to project
+
+    Returns
+    -------
+    IntensityTable :
+        full-dimensionality (3-d) IntensityTable
+
+    """
+    str_dimensions = _normalize_axes(dimensions)
+    initial_dimensions = OrderedDict(intensity_table.sizes)
+    projected_intensities = intensity_table.max(str_dimensions)
+    expanded_intensities = projected_intensities.expand_dims(str_dimensions)
+    return expanded_intensities.transpose(*tuple(initial_dimensions.keys()))
+
+
+def _mask_low_intensity_spots(
+    intensity_table: IntensityTable,
+    intensity_threshold: float
+) -> np.ndarray:
+    """
+    returns a flattened boolean mask (c order flattening) that is True where
+    (feature, round, channel) combinations whose intensities are above or equal to intensity
+    threshold and where values are not nan
+    """
+    with warnings.catch_warnings():
+        # we expect to have invalid values (np.nan) in IntensityTable, hide the warnings from users
+        warnings.simplefilter('ignore', RuntimeWarning)
+        # reshape the values into a 1-d vector of length product(features, rounds, channels)
+        return np.ravel(intensity_table.values >= intensity_threshold)
+
+
+def _spots_to_markers(intensity_table: IntensityTable) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    convert each (r, c) combination for each spot into a 5-tuple (x, y, r, c, z) for plotting
+    with napari.
+    """
+    # get sizes which will be used to create the coordinates that correspond to the spots
+    n_rounds = intensity_table.sizes[Axes.ROUND.value]
+    n_channels = intensity_table.sizes[Axes.CH.value]
+    n_features = intensity_table.sizes[Features.AXIS]
+    code_length = n_rounds * n_channels
+
+    # create 5-d coordinates for plotting in (x, y, round. channel, z)
+    n_markers = np.product(intensity_table.shape)
+    coords = np.zeros((n_markers, 5), dtype=np.uint16)
+
+    # create the coordinates.
+    # X, Y, and Z are repeated once per (r, ch) pair (code_length).
+    # the cartesian product of (r, c) are created, and tiled once per feature (n_features)
+    # we ensure that (ch, round) cycle in c-order to match the order of the linearized
+    # array, used below for masking.
+    coords[:, 0] = np.repeat(intensity_table[Features.AXIS][Axes.X.value].values, code_length)
+    coords[:, 1] = np.repeat(intensity_table[Features.AXIS][Axes.Y.value].values, code_length)
+    coords[:, 2] = np.tile(np.tile(range(n_rounds), n_channels), n_features)
+    coords[:, 3] = np.tile(np.repeat(range(n_channels), n_rounds), n_features)
+    coords[:, 4] = np.repeat(intensity_table[Features.AXIS][Axes.ZPLANE.value].values, code_length)
+
+    sizes = np.repeat(intensity_table.radius.values, code_length)
+
+    return coords, sizes
+
+
+def stack(
+        stack: ImageStack,
+        spots: Optional[IntensityTable] = None,
+        project_axes: Optional[Set[Axes]] = None,
+        mask_intensities: float = 0.,
+        radius_multiplier: int = 1
+):
+    """
+    Displays the image stack using Napari (https://github.com/Napari).
+    Can optionally overlay detected spots if the corresponding IntensityTable
+    is provided.
+
+    Parameters
+    ----------
+    stack : ImageStack
+        ImageStack to display
+    spots : IntensityTable
+        IntensityTable containing spot information that was generated from the submitted stack.
+    project_axes : Optional[Set[Axes]]
+        If provided, both the ImageStack and the Spots will be maximum projected along the
+        selected axes. Useful for displaying spots across coded assays where spots may not
+        appear in specific rounds or channels.
+    mask_intensities : Float
+        hide markers that correspond to intensities below this threshold value; note that any
+        marker that is np.nan will ALSO be masked, allowing users to pre-mask the intensity table
+        (see documentation on IntensityTable.where() for more details) (default 0, no masking)
+    radius_multiplier : int
+        Multiplies the radius of the displayed spots (default 1, no scaling)
+
+    Examples
+    --------
+
+    1. Display a stack to evaluate a filtering result. Just pass any ImageStack!
+
+    >>> import starfish.display
+    >>> starfish.display.stack(stack)
+
+    2. Display spots of a single-molecule FISH experiment: smFISH will produce IntensityTables where
+    most values are np.NaN. These will be masked automatically, so passing an ImageStack +
+    IntensityTable will display spots in the rounds and channels that they are detected
+
+    >>> import starfish.display
+    >>> starfish.display.stack(stack, intensities)
+
+    3. Diagnose spot calls within each round and channel of a coded experiment. A user might want to
+    evaluate if spot calling is failing for a specific round/channel pair. To accomplish this,
+    pass the intensity threshold used by the spot called to eliminate sub-threshold spots from
+    channels. The user can additionally filter the IntensityTable to further mask additional spots
+    (any np.NaN value will not be displayed)
+
+    >>> import starfish.display
+    >>> mask_intensities = 0.3  # this was the spot calling intensity threshold
+    >>> starfish.display(stack, intensities, mask_intensities=mask_intensities)
+
+    4. Evaluate spot calls across rounds and channels by visualizing spots on a max projection of
+    The rounds and channels.
+
+    >>> import starfish.display
+    >>> from starfish import Axes
+    >>> starfish.display.stack(stack, intensities, project_axes={Axes.CH, Axes.ROUND})
+
+    Notes
+    -----
+    - To use in ipython, use the %gui qt5 magic.
+    - Napari axes currently cannot be labeled. Until such a time that they can, this function will
+      order them by Round, Channel, and Z.
+    - Requires napari 0.0.5.1: install starfish using `pip install starfish[napari]` to install all
+      necessary requirements
+    """
+    try:
+        import napari_gui
+    except ImportError:
+        print("Requires napari 0.0.5.1. Run `pip install starfish[napari]` to install the "
+              "necessary requirements.")
+        return
+
+    if project_axes is not None:
+        stack = stack.max_proj(*project_axes)
+
+    # Switch axes to match napari expected order [x, y, round, channel, z]
+    reordered_array: np.ndarray = stack.xarray.transpose(
+        Axes.Y.value,
+        Axes.X.value,
+        Axes.ROUND.value,
+        Axes.CH.value,
+        Axes.ZPLANE.value
+    ).values
+
+    # display the imagestack using napari
+    viewer = napari_gui.imshow(reordered_array, multichannel=False)
+    viewer._index = [0, 0, 0, 0, 0]  # initialize napari status bar
+
+    if spots is not None:
+
+        # _detect_per_round_spot_finding_intensity_tables(spots)
+        if project_axes is not None:
+            spots = _max_intensity_table_maintain_dims(spots, project_axes)
+
+        # TODO ambrosejcarr guard rails:
+        # 1. verify that x, y, z fit inside the imagestack (weird projections)
+        # 2. warn if whole tiles are missing spot calls (possible miss-use)
+
+        coords, sizes = _spots_to_markers(spots)
+
+        # mask low-intensity values
+        mask = _mask_low_intensity_spots(spots, mask_intensities)
+
+        if not np.sum(mask):
+            warnings.warn(f'No spots passed provided intensity threshold of {mask_intensities}')
+            return viewer
+
+        coords = coords[mask, :]
+        sizes = sizes[mask]
+
+        viewer.add_markers(
+            coords=coords, face_color='white', edge_color='white', symbol='ring',
+            size=sizes * radius_multiplier
+        )
+
+    return viewer

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -27,7 +27,6 @@ import numpy as np
 import pandas as pd
 import skimage.io
 import xarray as xr
-from matplotlib import get_backend as get_matplotlib_backend
 from scipy.ndimage.filters import gaussian_filter
 from scipy.stats import scoreatpercentile
 from skimage import exposure
@@ -596,109 +595,6 @@ class ImageStack:
 
         self._data.loc[slice_list] = data
 
-    def show_stack_napari(self, selector: Mapping[Axes, Union[int, slice]]):
-        """Displays the image stack using Napari (https://github.com/Napari)
-
-        Parameters
-        ----------
-        selector : Mapping[Axes, Union[int, slice]],
-            Axes to select a volume to visualize. Passed to `Image.get_slice()`.
-            See `Image.get_slice()` for examples.
-
-        Notes
-        -----
-        To use in a Jupyter notebook, use the %gui qt5 magic.
-        Axes currently cannot be labeled. Until such a time that they can, this function will
-        order them by Round, Channel, and Z.
-
-        """
-        try:
-            import napari_gui
-        except ImportError:
-            warnings.warn("Cannot find the napari library. "
-                          "Install it by running \"pip install napari\"")
-            return
-        # TODO ambrosejcarr: this should use updated imagestack slicing routines when they are added
-        # and selector should be optional to enable full stack viewing.
-        # Switch axes such that it is indexed [x, y, round, channel, z]
-        slices, axes = self.get_slice(selector)
-        reordered_array = np.moveaxis(slices, [-2, -1], [0, 1])
-
-        napari_gui.imshow(reordered_array, multichannel=False)
-
-    def show_stack(
-            self, selector: Mapping[Axes, Union[int, slice]],
-            color_map: str= 'gray', figure_size: Tuple[int, int]=(10, 10),
-            rescale: bool=False, p_min: Optional[float]=None, p_max: Optional[float]=None, **kwargs
-    ):
-        """Create an interactive visualization of an image stack
-
-        Produces a slider that flips through the selected volume tile-by-tile. Supports manual
-        adjustment of dynamic range.
-
-        Parameters
-        ----------
-        selector : Mapping[Axes, Union[int, slice]],
-            Axes to select a volume to visualize. Passed to `Image.get_slice()`.
-            See `Image.get_slice()` for examples.
-        color_map : str (default = 'gray')
-            string id of a matplotlib colormap
-        figure_size : Tuple[int, int] (default = (10, 10))
-            size of the figure in inches
-        rescale : bool (default = False)
-            if True, rescale the data to exclude high and low-value outliers
-            (see skimage.exposure.rescale_intensity).
-        p_min: float
-            clip values below this intensity percentile. If provided, overrides rescale, above.
-            (default = None)
-        p_max: float
-            clip values above this intensity percentile. If provided, overrides rescale, above.
-            (default = None)
-
-        Raises
-        ------
-        ValueError :
-            User must select one of rescale or p_min/p_max to adjust the image dynamic range.
-            If both are selected, a ValueError is raised.
-
-        Notes
-        -----
-        For this widget to function interactively in the notebook, after ipywidgets has been
-        installed, the user must register the widget with jupyter by typing the following command
-        into the terminal: jupyter nbextension enable --py widgetsnbextension
-
-        """
-
-        # infer if %matplotlib inline or notebook
-        mpl_is_notebook = 'nbAgg' in get_matplotlib_backend()
-
-        if not selector:
-            raise ValueError('selector may not be an empty dict or None')
-
-        # get linearized scaled and clipped tiles, along with title names, for plotting
-        linear_view, labels, n_tiles = self._get_scaled_clipped_linear_view(selector,
-                                                                            rescale,
-                                                                            p_min,
-                                                                            p_max
-                                                                            )
-
-        if mpl_is_notebook:
-            self._show_matplotlib_notebook(
-                linear_view,
-                labels,
-                n_tiles,
-                figure_size,
-                color_map
-            )
-        else:
-            return self._show_matplotlib_inline(
-                linear_view,
-                labels,
-                n_tiles,
-                figure_size,
-                color_map
-            )
-
     def _get_scaled_clipped_linear_view(self, selector, rescale, p_min, p_max):
 
         # get the requested chunk, linearize the remaining data into a sequence of tiles
@@ -1179,31 +1075,31 @@ class ImageStack:
         return self._tile_shape
 
     def to_multipage_tiff(self, filepath: str) -> None:
-            """save the ImageStack as a FIJI-compatible multi-page TIFF file
+        """save the ImageStack as a FIJI-compatible multi-page TIFF file
 
-            Parameters
-            ----------
-            filepath : str
-                filepath for a tiff FILE. "TIFF" suffix will be added if the provided path does not
-                end with .TIFF
+        Parameters
+        ----------
+        filepath : str
+            filepath for a tiff FILE. "TIFF" suffix will be added if the provided path does not
+            end with .TIFF
 
-            """
-            if not filepath.upper().endswith(".TIFF"):
-                filepath += ".TIFF"
+        """
+        if not filepath.upper().endswith(".TIFF"):
+            filepath += ".TIFF"
 
-            # RZCYX is the order expected by FIJI
-            data = self.xarray.transpose(
-                Axes.ROUND.value,
-                Axes.ZPLANE.value,
-                Axes.CH.value,
-                Axes.Y.value,
-                Axes.X.value)
+        # RZCYX is the order expected by FIJI
+        data = self.xarray.transpose(
+            Axes.ROUND.value,
+            Axes.ZPLANE.value,
+            Axes.CH.value,
+            Axes.Y.value,
+            Axes.X.value)
 
-            # Any float32 image with low dynamic range will provoke a warning that the image is
-            # low contrast because the data must be converted to uint16 for compatibility with FIJI.
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", UserWarning)
-                skimage.io.imsave(filepath, data.values, imagej=True)
+        # Any float32 image with low dynamic range will provoke a warning that the image is
+        # low contrast because the data must be converted to uint16 for compatibility with FIJI.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            skimage.io.imsave(filepath, data.values, imagej=True)
 
     def export(self,
                filepath: str,

--- a/starfish/test/display/stack.py
+++ b/starfish/test/display/stack.py
@@ -1,0 +1,76 @@
+from copy import deepcopy
+from functools import lru_cache
+
+import numpy as np
+
+from starfish.display.stack import (
+    _mask_low_intensity_spots,
+    _max_intensity_table_maintain_dims,
+    _spots_to_markers,
+)
+from starfish.intensity_table.intensity_table import IntensityTable
+from starfish.test import test_utils
+from starfish.types import Axes, Features
+
+
+@lru_cache(maxsize=1)
+def testing_data():
+    np.random.seed(1)
+    codebook = test_utils.codebook_array_factory()
+    num_z, height, width = 3, 4, 5
+    intensities = IntensityTable.synthetic_intensities(
+        codebook,
+        num_z=num_z,
+        height=height,
+        width=width,
+        n_spots=4
+    )
+    return intensities
+
+
+def test_max_intensity_maintains_each_combination_of_dimensions():
+    # Frozen(OrderedDict([('features', 4), ('c', 3), ('r', 2)]))
+    intensities = testing_data()
+    results = _max_intensity_table_maintain_dims(intensities, {Axes.CH})
+    assert results.shape == (4, 1, 2)
+    results = _max_intensity_table_maintain_dims(intensities, {Axes.ROUND})
+    assert results.shape == (4, 3, 1)
+    results = _max_intensity_table_maintain_dims(intensities, {Axes.ROUND, Axes.CH})
+    assert results.shape == (4, 1, 1)
+    results = _max_intensity_table_maintain_dims(intensities, {Features.AXIS, Axes.CH})
+    assert results.shape == (1, 1, 2)
+    results = _max_intensity_table_maintain_dims(
+        intensities, {Axes.ROUND, Axes.CH, Features.AXIS}
+    )
+    assert results.shape == (1, 1, 1)
+
+
+def test_mask_low_intensities_masks_preexisting_nans():
+    intensities = testing_data()
+    masked = _mask_low_intensity_spots(intensities, intensity_threshold=0)
+    # intensity_threshold == 0 should mean no spots are masked
+    assert np.sum(masked) == np.product(intensities.shape)
+
+    # with c-order ravel, this nan is in the 5th position (zero-based = 4)
+    intensities = deepcopy(intensities)
+    intensities[0, 2, 0] = np.nan
+    masked = _mask_low_intensity_spots(intensities, intensity_threshold=0)
+    assert np.array_equal(np.where(~masked)[0], np.array([4]))
+
+
+def test_mask_low_intensities():
+    intensities = testing_data()
+    masked = _mask_low_intensity_spots(intensities, intensity_threshold=0.1)
+    expected = np.where(np.ravel(intensities.values >= 0.1))
+    passing = np.where(masked)
+    assert np.array_equal(passing, expected)
+
+
+def test_spots_to_markers():
+    intensities = testing_data()
+    markers, sizes = _spots_to_markers(intensities)
+    assert len(markers) == np.product(intensities.shape)
+
+    # check that intensities are being flattened into markers with r rotating fastest, then c
+    assert np.all(markers[:2, 2] == [0, 1])  # rounds
+    assert np.all(markers[:2, 3] == [0, 0])  # channels


### PR DESCRIPTION
- [x] features complete
- [x] testing complete
- [x] code style
- [x] complete code documentation
- [ ] add to sphinx/readthedocs

Features:
- Displays ImageStacks using Napari
- If provided with an IntensityTable generated from the provided ImageStack, will display spots
- will max project over selected indices
- will hide spots (per round and channel) to display spots above a threshold in individual tiles. 
- will hide any pre-existing entries in the IntensityTable that are `np.NaN` (enables pre-masking). This also solves the smFISH use case where there is only one entry per intensitytable feature and the rest are `np.NaN`. 
- all combinations of the above are functional (e.g. masking over max projections)

@kevinyamauchi it should have everything you need for showing spots. Let me know if anything is confusing. This should get you started: 
cc @berl in case there's interest. 

install: 
```
$ pip install -e .[napari]
```

use:
```python
import starfish.display
help(starfish.display.stack)
```