### PR TITLE
Support crop-on-load for TileSet -> ImageStack construction

### DIFF
--- a/starfish/imagestack/parser/crop.py
+++ b/starfish/imagestack/parser/crop.py
@@ -1,0 +1,200 @@
+from typing import Collection, Mapping, MutableSequence, Optional, Tuple, Union
+
+import numpy as np
+
+from starfish.imagestack.parser import TileCollectionData, TileData, TileKey
+from starfish.imagestack.physical_coordinate_calculator import recalculate_physical_coordinate_range
+from starfish.types import Coordinates, Indices, Number
+
+
+class CropParameters:
+    """Parameters for cropping an ImageStack at load time."""
+    def __init__(
+            self,
+            *,
+            permitted_rounds: Optional[Collection[int]]=None,
+            permitted_chs: Optional[Collection[int]]=None,
+            permitted_zlayers: Optional[Collection[int]]=None,
+            x_slice: Optional[Union[int, slice]]=None,
+            y_slice: Optional[Union[int, slice]]=None,
+    ):
+        """
+        Parameters
+        ----------
+        permitted_rounds : Optional[Collection[int]]
+            The rounds in the original dataset to load into the ImageStack.  If this is not set,
+            then all rounds are loaded into the ImageStack.
+        permitted_chs : Optional[Collection[int]]
+            The channels in the original dataset to load into the ImageStack.  If this is not set,
+            then all channels are loaded into the ImageStack.
+        permitted_zlayers : Optional[Collection[int]]
+            The z-layers in the original dataset to load into the ImageStack.  If this is not set,
+            then all z-layers are loaded into the ImageStack.
+        x_slice : Optional[Union[int, slice]]
+            The x-range in the x-y tile that is loaded into the ImageStack.  If this is not set,
+            then the entire x-y tile is loaded into the ImageStack.
+        y_slice : Optional[Union[int, slice]]
+            The y-range in the x-y tile that is loaded into the ImageStack.  If this is not set,
+            then the entire x-y tile is loaded into the ImageStack.
+        """
+        self._permitted_rounds = set(permitted_rounds) if permitted_rounds else None
+        self._permitted_chs = set(permitted_chs) if permitted_chs else None
+        self._permitted_zlayers = set(permitted_zlayers) if permitted_zlayers else None
+        self._x_slice = x_slice
+        self._y_slice = y_slice
+
+    def filter_tilekeys(self, tilekeys: Collection[TileKey]) -> Collection[TileKey]:
+        """
+        Filters tilekeys for those that should be included in the resulting ImageStack.
+        """
+        results: MutableSequence[TileKey] = list()
+        for tilekey in tilekeys:
+            if self._permitted_rounds is not None and tilekey.round not in self._permitted_rounds:
+                continue
+            if self._permitted_chs is not None and tilekey.ch not in self._permitted_chs:
+                continue
+            if self._permitted_zlayers is not None and tilekey.z not in self._permitted_zlayers:
+                continue
+
+            results.append(tilekey)
+
+        return results
+
+    @staticmethod
+    def _crop_axis(size: int, crop: Optional[Union[int, slice]]) -> Tuple[int, int]:
+        """
+        Given the size of along an axis, and an optional cropping, return the start index
+        (inclusive) and end index (exclusive) of the crop.  If no crop is specified, then the
+        original size (0, size) is returned.
+        """
+        # convert int crops to a slice operation.
+        if isinstance(crop, int):
+            if crop < 0 or crop >= size:
+                raise IndexError("crop index out of range")
+            return crop, crop + 1
+
+        # convert start and stop to absolute values.
+        start: int
+        if crop is None or crop.start is None:
+            start = 0
+        elif crop.start is not None and crop.start < 0:
+            start = max(0, size + crop.start)
+        else:
+            start = min(size, crop.start)
+
+        stop: int
+        if crop is None or crop.stop is None:
+            stop = size
+        elif crop.stop is not None and crop.stop < 0:
+            stop = max(0, size + crop.stop)
+        else:
+            stop = min(size, crop.stop)
+
+        return start, stop
+
+    def crop_shape(self, shape: Tuple[int, int]) -> Tuple[int, int]:
+        """
+        Given the shape of the original tile, return the shape of the cropped tile.
+        """
+        output_x_shape = CropParameters._crop_axis(shape[1], self._x_slice)
+        output_y_shape = CropParameters._crop_axis(shape[0], self._y_slice)
+        width = output_x_shape[1] - output_x_shape[0]
+        height = output_y_shape[1] - output_y_shape[0]
+
+        return height, width
+
+    def crop_image(self, image: np.ndarray) -> np.ndarray:
+        """
+        Given the original image, return the cropped image.
+        """
+        output_x_shape = CropParameters._crop_axis(image.shape[1], self._x_slice)
+        output_y_shape = CropParameters._crop_axis(image.shape[0], self._y_slice)
+
+        return image[output_y_shape[0]:output_y_shape[1], output_x_shape[0]:output_x_shape[1]]
+
+    def crop_coordinates(
+            self,
+            coordinates: Mapping[Coordinates, Tuple[Number, Number]],
+            shape: Tuple[int, int],
+    ) -> Mapping[Coordinates, Tuple[Number, Number]]:
+        """
+        Given a mapping of coordinate to coordinate values, return a mapping of the coordinate to
+        cropped coordinate values.
+        """
+        xmin, xmax = coordinates[Coordinates.X]
+        ymin, ymax = coordinates[Coordinates.Y]
+        if self._x_slice is not None:
+            xmin, xmax = recalculate_physical_coordinate_range(
+                xmin, xmax,
+                shape[1],
+                self._x_slice)
+        if self._y_slice is not None:
+            ymin, ymax = recalculate_physical_coordinate_range(
+                ymin, ymax,
+                shape[0],
+                self._y_slice)
+
+        return {
+            Coordinates.X: (xmin, xmax),
+            Coordinates.Y: (ymin, ymax),
+            Coordinates.Z: coordinates[Coordinates.Z],
+        }
+
+
+class CroppedTileData(TileData):
+    """Represent a cropped view of a TileData object."""
+    def __init__(self, tile_data: TileData, cropping_parameters: CropParameters):
+        self.backing_tile_data = tile_data
+        self.cropping_parameters = cropping_parameters
+
+    @property
+    def tile_shape(self) -> Tuple[int, int]:
+        return self.cropping_parameters.crop_shape(self.backing_tile_data.tile_shape)
+
+    @property
+    def numpy_array(self) -> np.ndarray:
+        return self.cropping_parameters.crop_image(self.backing_tile_data.numpy_array)
+
+    @property
+    def coordinates(self) -> Mapping[Coordinates, Tuple[Number, Number]]:
+        return self.cropping_parameters.crop_coordinates(
+            self.backing_tile_data.coordinates,
+            self.backing_tile_data.tile_shape,
+        )
+
+    @property
+    def indices(self) -> Mapping[Indices, int]:
+        return self.backing_tile_data.indices
+
+
+class CroppedTileCollectionData(TileCollectionData):
+    """Represent a cropped view of a TileCollectionData object."""
+    def __init__(
+            self,
+            backing_tile_collection_data: TileCollectionData,
+            crop_parameters: CropParameters,
+    ) -> None:
+        self.backing_tile_collection_data = backing_tile_collection_data
+        self.crop_parameters = crop_parameters
+
+    def __getitem__(self, tilekey: TileKey) -> dict:
+        return self.backing_tile_collection_data[tilekey]
+
+    def keys(self) -> Collection[TileKey]:
+        return self.crop_parameters.filter_tilekeys(self.backing_tile_collection_data.keys())
+
+    @property
+    def extras(self) -> dict:
+        return self.backing_tile_collection_data.extras
+
+    def get_tile_by_key(self, tilekey: TileKey) -> TileData:
+        return CroppedTileData(
+            self.backing_tile_collection_data.get_tile_by_key(tilekey),
+            self.crop_parameters,
+        )
+
+    def get_tile(self, r: int, ch: int, z: int) -> TileData:
+        return CroppedTileData(
+            self.backing_tile_collection_data.get_tile(r, ch, z),
+            self.crop_parameters,
+        )

--- a/starfish/test/image/test_imagestack_cropped_load.py
+++ b/starfish/test/image/test_imagestack_cropped_load.py
@@ -1,0 +1,191 @@
+"""
+These tests center around creating an ImageStack but selectively loading data from the original
+TileSet.
+"""
+from typing import Mapping, Optional, Tuple, Union
+
+import numpy as np
+from skimage import img_as_float32
+from slicedimage import ImageFormat
+
+from starfish.experiment.builder import build_image, FetchedTile, tile_fetcher_factory
+from starfish.imagestack.imagestack import ImageStack
+from starfish.imagestack.parser.crop import CropParameters
+from starfish.imagestack.physical_coordinate_calculator import recalculate_physical_coordinate_range
+from starfish.types import Coordinates, Indices, Number
+from .imagestack_test_utils import verify_physical_coordinates, verify_stack_data
+
+NUM_ROUND = 3
+NUM_CH = 4
+NUM_Z = 2
+
+ROUND_LABELS = list(range(NUM_ROUND))
+CH_LABELS = list(range(NUM_CH))
+Z_LABELS = list(range(NUM_Z))
+HEIGHT = 40
+WIDTH = 60
+
+
+def data(round_: int, ch: int, z: int) -> np.ndarray:
+    """Return the data for a given tile."""
+    result = np.empty((HEIGHT, WIDTH), dtype=np.uint32)
+    for row in range(HEIGHT):
+        base_val = ((((((round_ * NUM_CH) + ch) * NUM_Z) + z) * HEIGHT) + row) * WIDTH
+
+        result[row:] = np.linspace(base_val, base_val + WIDTH, WIDTH, False)
+    return img_as_float32(result)
+
+
+def x_coordinates(round_: int, ch: int) -> Tuple[float, float]:
+    """Return the expected physical x coordinate value for a given round/ch tuple.  Note that in
+    real life, physical coordinates are not expected to vary for different ch values.  However, for
+    completeness of the tests, we are pretending they will."""
+    return min(round_, ch) * 0.01, max(round_, ch) * 0.01
+
+
+def y_coordinates(round_: int, ch: int) -> Tuple[float, float]:
+    """Return the expected physical y coordinate value for a given round/ch tuple.  Note that in
+    real life, physical coordinates are not expected to vary for different ch values.  However, for
+    completeness of the tests, we are pretending they will."""
+    return min(round_, ch) * 0.001, max(round_, ch) * 0.001
+
+
+def z_coordinates(z: int) -> Tuple[float, float]:
+    """Return the expected physical z coordinate value for a given zlayer index."""
+    return z * 0.0001, (z + 1) * 0.0001
+
+
+class UniqueTiles(FetchedTile):
+    """Tiles where the pixel values are unique per round/ch/z."""
+    def __init__(self, fov: int, _round: int, ch: int, z: int) -> None:
+        super().__init__()
+        self._round = _round
+        self._ch = ch
+        self._z = z
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        return HEIGHT, WIDTH
+
+    @property
+    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+        return {
+            Coordinates.X: x_coordinates(self._round, self._ch),
+            Coordinates.Y: y_coordinates(self._round, self._ch),
+            Coordinates.Z: z_coordinates(self._z),
+        }
+
+    @property
+    def format(self) -> ImageFormat:
+        return ImageFormat.TIFF
+
+    def tile_data(self) -> np.ndarray:
+        return data(self._round, self._ch, self._z)
+
+
+def setup_imagestack(crop_parameters: Optional[CropParameters]) -> ImageStack:
+    """Build an imagestack with labeled indices (i.e., indices that do not start at 0 or are not
+    sequential non-negative integers).
+    """
+    collection = build_image(
+        range(1),
+        ROUND_LABELS,
+        CH_LABELS,
+        Z_LABELS,
+        tile_fetcher_factory(UniqueTiles, True),
+    )
+    tileset = list(collection.all_tilesets())[0][1]
+
+    return ImageStack.from_tileset(tileset, crop_parameters)
+
+
+def test_crop_rcz():
+    """Build an imagestack that contains a crop in r/c/z.  Verify that the appropriate tiles are
+    loaded.
+    """
+    rounds = [1]
+    chs = [2, 3]
+
+    crop_parameters = CropParameters(
+        permitted_rounds=rounds,
+        permitted_chs=chs,
+    )
+    stack = setup_imagestack(crop_parameters)
+
+    assert stack.index_labels(Indices.ROUND) == rounds
+    assert stack.index_labels(Indices.CH) == chs
+    assert stack.index_labels(Indices.Z) == Z_LABELS
+
+    for round_ in stack.index_labels(Indices.ROUND):
+        for ch in stack.index_labels(Indices.CH):
+            for zlayer in stack.index_labels(Indices.Z):
+                expected_data = data(round_, ch, zlayer)
+
+                verify_stack_data(
+                    stack,
+                    {Indices.ROUND: round_, Indices.CH: ch, Indices.Z: zlayer},
+                    expected_data,
+                )
+
+                verify_physical_coordinates(
+                    stack,
+                    {Indices.ROUND: round_, Indices.CH: ch, Indices.Z: zlayer},
+                    x_coordinates(round_, ch),
+                    y_coordinates(round_, ch),
+                    z_coordinates(zlayer),
+                )
+
+
+def test_crop_xy():
+    """Build an imagestack that contains a crop in x/y.  Verify that the data is sliced correctly.
+    """
+    X_SLICE = (10, 30)
+    Y_SLICE = (15, 40)
+    crop_parameters = CropParameters(
+        x_slice=slice(*X_SLICE),
+        y_slice=slice(*Y_SLICE),
+    )
+    stack = setup_imagestack(crop_parameters)
+
+    assert stack.index_labels(Indices.ROUND) == ROUND_LABELS
+    assert stack.index_labels(Indices.CH) == CH_LABELS
+    assert stack.index_labels(Indices.Z) == Z_LABELS
+
+    assert stack.raw_shape[3] == Y_SLICE[1] - Y_SLICE[0]
+    assert stack.raw_shape[4] == X_SLICE[1] - X_SLICE[0]
+
+    for round_ in stack.index_labels(Indices.ROUND):
+        for ch in stack.index_labels(Indices.CH):
+            for zlayer in stack.index_labels(Indices.Z):
+                expected_data = data(round_, ch, zlayer)
+                expected_data = expected_data[Y_SLICE[0]:Y_SLICE[1], X_SLICE[0]:X_SLICE[1]]
+
+                verify_stack_data(
+                    stack,
+                    {Indices.ROUND: round_, Indices.CH: ch, Indices.Z: zlayer},
+                    expected_data,
+                )
+
+                # the coordinates should be rescaled.  verify that the coordinates on the ImageStack
+                # are also rescaled.
+                original_x_coordinates = x_coordinates(round_, ch)
+                expected_x_coordinates = recalculate_physical_coordinate_range(
+                    original_x_coordinates[0], original_x_coordinates[1],
+                    WIDTH,
+                    slice(*X_SLICE),
+                )
+
+                original_y_coordinates = y_coordinates(round_, ch)
+                expected_y_coordinates = recalculate_physical_coordinate_range(
+                    original_y_coordinates[0], original_y_coordinates[1],
+                    HEIGHT,
+                    slice(*Y_SLICE),
+                )
+
+                verify_physical_coordinates(
+                    stack,
+                    {Indices.ROUND: round_, Indices.CH: ch, Indices.Z: zlayer},
+                    expected_x_coordinates,
+                    expected_y_coordinates,
+                    z_coordinates(zlayer),
+                )


### PR DESCRIPTION
Create new classes (CroppedTileCollectionData, CroppedTileData) for representing a cropped view of a (TileCollectionData, TileData).  Because cropping happens at the time of ImageStack construction, the memory requirements are significantly lowered to O(number-of-cropped-tiles * size-of-one-cropped-tile + size-of-one-original-tile).

This is #902, except github mysteriously closed that PR. :(

Depends on #828 

Test plan: new imagestack construction tests that verify that the cropping occurs as expected.

Fixes #832