### PR TITLE
Increase parallelization for travis runs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,12 @@ stages:
 - test
 jobs:
   include:
-    - name: Syntax and Tests
-      script: make check_notebooks install-src fast
+    - name: Syntax and Fast Tests
+      script: make install-src fast
+      after_success:
+        - bash <(curl -s https://codecov.io/bash)
+    - name: Slow Tests
+      script: make install-src && make -j check-notebooks slow-test
       after_success:
         - bash <(curl -s https://codecov.io/bash)
     - name: Install Napari

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ all:	fast
 
 ### UNIT #####################################################
 #
-fast:	lint mypy test docs-html
+fast:	lint mypy fast-test docs-html
 
 lint:   lint-non-init lint-init
 
@@ -34,6 +34,12 @@ lint-init:
 
 test:
 	pytest -v -n 8 --cov starfish --cov sptx_format
+
+fast-test:
+	pytest -v -n 8 --cov starfish --cov sptx_format -m 'not slow'
+
+slow-test:
+	pytest -v -n 8 --cov starfish --cov sptx_format -m 'slow'
 
 mypy:
 	mypy --ignore-missing-imports $(MODULES)
@@ -59,12 +65,12 @@ help-docs:
 
 ### REQUIREMENTS #############################################
 #
-check_requirements:
+check-requirements:
 	if [[ $$(git status --porcelain REQUIREMENTS*) ]]; then \
 	    echo "Modifications found in REQUIREMENTS files"; exit 2; \
 	fi
 
-refresh_all_requirements:
+refresh-all-requirements:
 	@echo -n '' >| REQUIREMENTS.txt
 	@if [ $$(uname -s) == "Darwin" ]; then sleep 1; fi  # this is require because Darwin HFS+ only has second-resolution for timestamps.
 	@touch REQUIREMENTS.txt.in

--- a/notebooks/subdir.mk
+++ b/notebooks/subdir.mk
@@ -8,11 +8,11 @@ py_regenerate_targets := $(addprefix regenerate__notebooks/py/, $(addsuffix .py,
 PYTHON := python
 
 fast: $(ipynb_validate_targets)
-run_notebooks: $(py_run_targets)
-check_notebooks: $(py_check_targets)
-validate_notebooks: $(ipynb_validate_targets)
-regenerate_ipynb: $(ipynb_regenerate_targets)
-regenerate_py: $(py_regenerate_targets)
+run-notebooks: $(py_run_targets)
+check-notebooks: $(py_check_targets)
+validate-notebooks: $(ipynb_validate_targets)
+regenerate-ipynb: $(ipynb_regenerate_targets)
+regenerate-py: $(py_regenerate_targets)
 
 $(py_run_targets): run__%.py :
 	[ -e $*.py.skip ] || $(PYTHON) $*.py

--- a/starfish/test/full_pipelines/api/test_iss_doc_pipeline.py
+++ b/starfish/test/full_pipelines/api/test_iss_doc_pipeline.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+import pytest
+
 import starfish
 
 
@@ -9,6 +11,7 @@ os.environ["TESTING"] = "1"
 sys.path.append(os.path.join(ROOT_DIR, "docs", "source", "usage", "iss"))
 
 
+@pytest.mark.slow
 def test_iss_pipeline_in_docs():
     # Just importing the file and verifying it runs for now
     __import__('iss_pipeline')

--- a/starfish/test/full_pipelines/cli/test_dartfish_cli.py
+++ b/starfish/test/full_pipelines/cli/test_dartfish_cli.py
@@ -4,12 +4,14 @@ import unittest
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from starfish import IntensityTable
 from starfish.test.full_pipelines.cli._base_cli_test import CLITest
 from starfish.types import Features
 
 
+@pytest.mark.slow
 class TestWithDartfishData(CLITest, unittest.TestCase):
 
     @property

--- a/starfish/test/full_pipelines/cli/test_iss.py
+++ b/starfish/test/full_pipelines/cli/test_iss.py
@@ -10,11 +10,13 @@ import unittest
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from starfish.test.full_pipelines.cli._base_cli_test import CLITest
 from starfish.types import Features
 
 
+@pytest.mark.slow
 class TestWithIssData(CLITest, unittest.TestCase):
 
     @property

--- a/starfish/test/test_synthetic_data.py
+++ b/starfish/test/test_synthetic_data.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from starfish.spots._detector.blob import BlobDetector
 from starfish.types import Features, Indices
@@ -49,7 +50,7 @@ def test_round_trip_synthetic_data():
     )
 
 
-# @pytest.mark.skip('long-running integration test, for debugging only')
+@pytest.mark.slow
 def test_medium_synthetic_stack():
     np.random.seed(0)
 


### PR DESCRIPTION
Introduce a slow test marker.  This breaks out check-notebooks and slow-test into a parallel travis run.  If travis has sufficient compute, this allows us to complete a test for a PR in ~9 minutes instead of 15 (see https://travis-ci.com/spacetx/starfish/builds/96790705).

Small change I snuck in: all makefile targets are hyphenated instead of underscored.