### PR TITLE
[3/3] fix no-spots-detected errors

### DIFF
--- a/starfish/spots/_detector/blob.py
+++ b/starfish/spots/_detector/blob.py
@@ -108,6 +108,9 @@ class BlobDetector(SpotFinderAlgorithmBase):
             self.overlap
         )
 
+        if fitted_blobs_array.shape[0] == 0:
+            return SpotAttributes.empty(extra_fields=['intensity', 'spot_id'])
+
         # create the SpotAttributes Table
         columns = [Axes.ZPLANE.value, Axes.Y.value, Axes.X.value, Features.SPOT_RADIUS]
         fitted_blobs = pd.DataFrame(data=fitted_blobs_array, columns=columns)

--- a/starfish/spots/_detector/detect.py
+++ b/starfish/spots/_detector/detect.py
@@ -104,6 +104,10 @@ def measure_spot_intensities(
         n_round=n_round,
     )
 
+    # if no spots were detected, return the empty IntensityTable
+    if intensity_table.sizes[Features.AXIS] == 0:
+        return intensity_table
+
     # fill the intensity table
     indices = product(range(n_ch), range(n_round))
     for c, r in indices:
@@ -141,7 +145,7 @@ def concatenate_spot_attributes_to_intensities(
     n_ch: int = max(inds[Axes.CH] for _, inds in spot_attributes) + 1
     n_round: int = max(inds[Axes.ROUND] for _, inds in spot_attributes) + 1
 
-    all_spots = pd.concat([sa.data for sa, inds in spot_attributes])
+    all_spots = pd.concat([sa.data for sa, inds in spot_attributes], sort=True)
     # this drop call ensures only x, y, z, radius, and quality, are passed to the IntensityTable
     features_coordinates = all_spots.drop(['spot_id', 'intensity'], axis=1)
 
@@ -242,7 +246,7 @@ def detect_spots(data_stack: ImageStack,
         spot_finding_method = partial(spot_finding_method, **spot_finding_kwargs)
         spot_attributes_list = data_stack.transform(
             func=spot_finding_method,
-            group_by=group_by
+            group_by=group_by,
         )
         intensity_table = concatenate_spot_attributes_to_intensities(spot_attributes_list)
 

--- a/starfish/spots/_detector/trackpy_local_max_peak_finder.py
+++ b/starfish/spots/_detector/trackpy_local_max_peak_finder.py
@@ -101,6 +101,7 @@ class TrackpyLocalMaxPeakFinder(SpotFinderAlgorithmBase):
         """
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', FutureWarning)  # trackpy numpy indexing warning
+            warnings.simplefilter('ignore', UserWarning)  # yielded if black images
             attributes = locate(
                 image,
                 diameter=self.diameter,
@@ -113,6 +114,10 @@ class TrackpyLocalMaxPeakFinder(SpotFinderAlgorithmBase):
                 percentile=self.percentile,
                 preprocess=self.preprocess
             )
+
+        # when zero spots are detected, 'ep' is missing from the trackpy locate results.
+        if attributes.shape[0] == 0:
+            attributes['ep'] = []
 
         # TODO ambrosejcarr: data should always be at least pseudo-3d, this may not be necessary
         # TODO ambrosejcarr: this is where max vs. sum vs. mean would be parametrized.

--- a/starfish/test/test_utils.py
+++ b/starfish/test/test_utils.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Tuple, Sequence
+from typing import Sequence, Tuple
 
 import numpy as np
 from scipy.ndimage.filters import gaussian_filter

--- a/starfish/types/_spot_attributes.py
+++ b/starfish/types/_spot_attributes.py
@@ -1,4 +1,5 @@
 import json
+from typing import Iterable
 
 import numpy as np
 import pandas as pd
@@ -25,6 +26,13 @@ class SpotAttributes(ValidatedTable):
 
         """
         super().__init__(spot_attributes, SpotAttributes.required_fields)
+
+    @classmethod
+    def empty(cls, extra_fields: Iterable=tuple()) -> "SpotAttributes":
+        """return an empty SpotAttributes object"""
+        fields = list(cls.required_fields.union(extra_fields))
+        dtype = list(zip(fields, [np.object] * len(fields)))
+        return cls(pd.DataFrame(np.array([], dtype=dtype)))
 
     def save_geojson(self, output_file_name: str) -> None:
         """Save to geojson for web visualization


### PR DESCRIPTION
This PR fixes errors in each SpotFinder that occur when no spots are detected, and catches warnings that are otherwise repeatedly emitted for every application of a spot-finding call (many times per `ImageStack`). 

It also adds tests that verify that each way of calling each spot detectors works in the case where the `ImageStack` contains no detectable spots, and fixes the two failing tests from the previous PR that resulted from related problems (where _some_ but not _all_ slices of the ImageStack contained no spots). 

