### PR TITLE
[2/3] Refactor spot finding tests, add new examples

### DIFF
--- a/starfish/spots/_detector/blob.py
+++ b/starfish/spots/_detector/blob.py
@@ -108,6 +108,9 @@ class BlobDetector(SpotFinderAlgorithmBase):
             self.overlap
         )
 
+        if fitted_blobs_array.shape[0] == 0:
+            return SpotAttributes.empty(extra_fields=['intensity', 'spot_id'])
+
         # create the SpotAttributes Table
         columns = [Axes.ZPLANE.value, Axes.Y.value, Axes.X.value, Features.SPOT_RADIUS]
         fitted_blobs = pd.DataFrame(data=fitted_blobs_array, columns=columns)

--- a/starfish/spots/_detector/detect.py
+++ b/starfish/spots/_detector/detect.py
@@ -104,6 +104,10 @@ def measure_spot_intensities(
         n_round=n_round,
     )
 
+    # if no spots were detected, return the empty IntensityTable
+    if intensity_table.sizes[Features.AXIS] == 0:
+        return intensity_table
+
     # fill the intensity table
     indices = product(range(n_ch), range(n_round))
     for c, r in indices:
@@ -141,7 +145,7 @@ def concatenate_spot_attributes_to_intensities(
     n_ch: int = max(inds[Axes.CH] for _, inds in spot_attributes) + 1
     n_round: int = max(inds[Axes.ROUND] for _, inds in spot_attributes) + 1
 
-    all_spots = pd.concat([sa.data for sa, inds in spot_attributes])
+    all_spots = pd.concat([sa.data for sa, inds in spot_attributes], sort=True)
     # this drop call ensures only x, y, z, radius, and quality, are passed to the IntensityTable
     features_coordinates = all_spots.drop(['spot_id', 'intensity'], axis=1)
 
@@ -242,7 +246,7 @@ def detect_spots(data_stack: ImageStack,
         spot_finding_method = partial(spot_finding_method, **spot_finding_kwargs)
         spot_attributes_list = data_stack.transform(
             func=spot_finding_method,
-            group_by=group_by
+            group_by=group_by,
         )
         intensity_table = concatenate_spot_attributes_to_intensities(spot_attributes_list)
 

--- a/starfish/spots/_detector/trackpy_local_max_peak_finder.py
+++ b/starfish/spots/_detector/trackpy_local_max_peak_finder.py
@@ -101,6 +101,7 @@ class TrackpyLocalMaxPeakFinder(SpotFinderAlgorithmBase):
         """
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', FutureWarning)  # trackpy numpy indexing warning
+            warnings.simplefilter('ignore', UserWarning)  # yielded if black images
             attributes = locate(
                 image,
                 diameter=self.diameter,
@@ -113,6 +114,10 @@ class TrackpyLocalMaxPeakFinder(SpotFinderAlgorithmBase):
                 percentile=self.percentile,
                 preprocess=self.preprocess
             )
+
+        # when zero spots are detected, 'ep' is missing from the trackpy locate results.
+        if attributes.shape[0] == 0:
+            attributes['ep'] = []
 
         # TODO ambrosejcarr: data should always be at least pseudo-3d, this may not be necessary
         # TODO ambrosejcarr: this is where max vs. sum vs. mean would be parametrized.

--- a/starfish/test/spots/detector/test_spot_detection.py
+++ b/starfish/test/spots/detector/test_spot_detection.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-from scipy.ndimage.filters import gaussian_filter
 
 from starfish.imagestack.imagestack import ImageStack
 from starfish.spots._detector._base import SpotFinderAlgorithmBase
@@ -8,7 +7,16 @@ from starfish.spots._detector.blob import BlobDetector
 from starfish.spots._detector.detect import detect_spots
 from starfish.spots._detector.local_max_peak_finder import LocalMaxPeakFinder
 from starfish.spots._detector.trackpy_local_max_peak_finder import TrackpyLocalMaxPeakFinder
-from starfish.types import Axes
+from starfish.test.test_utils import (
+    two_spot_informative_blank_coded_data_factory,
+    two_spot_one_hot_coded_data_factory,
+    two_spot_sparse_coded_data_factory,
+)
+from starfish.types import Axes, Features
+
+_, ONE_HOT_IMAGESTACK, ONE_HOT_MAX_INTENSITY = two_spot_one_hot_coded_data_factory()
+_, SPARSE_IMAGESTACK, SPARSE_MAX_INTENSITY = two_spot_sparse_coded_data_factory()
+_, BLANK_IMAGESTACK, BLANK_MAX_INTENSITY = two_spot_informative_blank_coded_data_factory()
 
 
 def simple_gaussian_spot_detector() -> BlobDetector:
@@ -41,69 +49,31 @@ gaussian_spot_detector = simple_gaussian_spot_detector()
 trackpy_local_max_spot_detector = simple_trackpy_local_max_spot_detector()
 local_max_spot_detector = simple_local_max_spot_detector()
 
-
-def synthetic_two_spot_3d_2round_2ch() -> ImageStack:
-    """produce a 2-channel 2-round ImageStack
-
-    Notes
-    -----
-    - After Gaussian filtering, all max intensities are 7
-    - Two spots are located at (4, 10, 90) and (6, 90, 10)
-    - Both spots are 1-hot, and decode to:
-        - spot 1: (round 0, ch 0), (round 1, ch 1)
-        - spot 2: (round 0, ch 1), (round 1, ch 0)
-
-    Returns
-    -------
-    ImageStack :
-        noiseless ImageStack containing two spots
-
-    """
-
-    # blank data_image
-    data = np.zeros((2, 2, 10, 100, 100), dtype=np.float32)
-
-    # round 0 channel 0
-    data[0, 0, 4, 10, 90] = 1.0
-    data[0, 0, 5, 90, 10] = 0
-
-    # round 0 channel 1
-    data[0, 1, 4, 10, 90] = 0
-    data[0, 1, 5, 90, 10] = 1.0
-
-    # round 1 channel 0
-    data[1, 0, 4, 10, 90] = 0
-    data[1, 0, 5, 90, 10] = 1.0
-
-    # round 1 channel 1
-    data[1, 1, 4, 10, 90] = 1.0
-    data[1, 1, 5, 90, 10] = 0
-
-    data = gaussian_filter(data, sigma=(0, 0, 2, 2, 2))
-    return ImageStack.from_numpy_array(data)
+# test parameterization
+test_parameters = (
+    'data_stack, spot_detector, radius_is_gyration, max_intensity',
+    [
+        (ONE_HOT_IMAGESTACK, gaussian_spot_detector, False, ONE_HOT_MAX_INTENSITY),
+        (ONE_HOT_IMAGESTACK, trackpy_local_max_spot_detector, True, ONE_HOT_MAX_INTENSITY),
+        (ONE_HOT_IMAGESTACK, local_max_spot_detector, False, ONE_HOT_MAX_INTENSITY),
+        (SPARSE_IMAGESTACK, gaussian_spot_detector, False, SPARSE_MAX_INTENSITY),
+        (SPARSE_IMAGESTACK, trackpy_local_max_spot_detector, True, SPARSE_MAX_INTENSITY),
+        (SPARSE_IMAGESTACK, local_max_spot_detector, False, SPARSE_MAX_INTENSITY),
+        (BLANK_IMAGESTACK, gaussian_spot_detector, False, BLANK_MAX_INTENSITY),
+        (BLANK_IMAGESTACK, trackpy_local_max_spot_detector, True, BLANK_MAX_INTENSITY),
+        (BLANK_IMAGESTACK, local_max_spot_detector, False, BLANK_MAX_INTENSITY),
+    ]
+)
 
 
-# create the data_stack
-data_stack = synthetic_two_spot_3d_2round_2ch()
-
-
-@pytest.mark.parametrize('data_stack, spot_detector, radius_is_gyration', [
-    (data_stack, gaussian_spot_detector, False),
-    (data_stack, trackpy_local_max_spot_detector, True),
-    (data_stack, local_max_spot_detector, False)
-])
+@pytest.mark.parametrize(*test_parameters)
 def test_spot_detection_with_reference_image(
         data_stack: ImageStack,
         spot_detector: SpotFinderAlgorithmBase,
         radius_is_gyration: bool,
+        max_intensity: float,
 ):
-    """
-    This testing method uses a reference image to identify spot locations. Thus, it should detect
-    two spots, each with max intensity 7. Because the channels and rounds are aggregated, this
-    method should recognize the 1-hot code used in the testing data, and see one channel "on" per
-    round. Thus, the total intensity across all channels and round for each spot should be 14.
-
-    """
+    """This testing method uses a reference image to identify spot locations."""
     reference_image_mp = data_stack.max_proj(Axes.CH, Axes.ROUND)
     reference_image_mp_numpy = reference_image_mp._squeezed_numpy(Axes.CH, Axes.ROUND)
 
@@ -112,61 +82,47 @@ def test_spot_detection_with_reference_image(
                                    reference_image=reference_image_mp_numpy,
                                    measurement_function=np.max,
                                    radius_is_gyration=radius_is_gyration)
-    assert intensity_table.shape == (2, 2, 2), "wrong number of spots detected"
-    expected = [0.01587425, 0.01587425]
+    assert intensity_table.sizes[Features.AXIS] == 2, "wrong number of spots detected"
+    expected = [max_intensity * 2, max_intensity * 2]
     assert np.allclose(intensity_table.sum((Axes.ROUND, Axes.CH)).values, expected), \
         "wrong spot intensities detected"
 
 
-@pytest.mark.parametrize('data_stack, spot_detector, radius_is_gyration', [
-    (data_stack, gaussian_spot_detector, False),
-    (data_stack, trackpy_local_max_spot_detector, True),
-    (data_stack, local_max_spot_detector, False)
-])
+@pytest.mark.parametrize(*test_parameters)
 def test_spot_detection_with_reference_image_from_max_projection(
         data_stack: ImageStack,
         spot_detector: SpotFinderAlgorithmBase,
         radius_is_gyration: bool,
+        max_intensity: float,
 ):
-    """
-    This testing method builds a reference image to identify spot locations. Thus, it should detect
-    two spots, each with max intensity 7. Because the channels and rounds are aggregated, this
-    method should recognize the 1-hot code used in the testing data, and see one channel "on" per
-    round. Thus, the total intensity across all channels and round for each spot should be 14.
-    """
+    """This testing method builds a reference image to identify spot locations."""
     intensity_table = detect_spots(data_stack=data_stack,
                                    spot_finding_method=spot_detector.image_to_spots,
                                    reference_image_from_max_projection=True,
                                    measurement_function=np.max,
                                    radius_is_gyration=radius_is_gyration)
-    assert intensity_table.shape == (2, 2, 2), "wrong number of spots detected"
-    expected = [0.01587425, 0.01587425]
+    assert intensity_table.sizes[Features.AXIS] == 2, "wrong number of spots detected"
+    expected = [max_intensity * 2, max_intensity * 2]
     assert np.allclose(intensity_table.sum((Axes.ROUND, Axes.CH)).values, expected), \
         "wrong spot intensities detected"
 
 
-@pytest.mark.parametrize('data_stack, spot_detector, radius_is_gyration', [
-    (data_stack, gaussian_spot_detector, False),
-    (data_stack, trackpy_local_max_spot_detector, True),
-    (data_stack, local_max_spot_detector, False)
-])
+@pytest.mark.parametrize(*test_parameters)
 def test_spot_finding_no_reference_image(
         data_stack: ImageStack,
         spot_detector: SpotFinderAlgorithmBase,
         radius_is_gyration: bool,
+        max_intensity: float,
 ):
     """
     This testing method does not provide a reference image, and should therefore check for spots
-    in each (round, ch) combination in sequence. With the given input, it should detect 4 spots,
-    each with a max value of 7. Because each (round, ch) are measured sequentially, each spot only
-    measures a single channel. Thus the total intensity across all rounds and channels for each
-    spot should be 7.
+    in each (round, ch) combination in sequence. With the given input, it should detect 4 spots.
     """
     intensity_table = detect_spots(data_stack=data_stack,
                                    spot_finding_method=spot_detector.image_to_spots,
                                    measurement_function=np.max,
                                    radius_is_gyration=radius_is_gyration)
-    assert intensity_table.shape == (4, 2, 2), "wrong number of spots detected"
-    expected = [0.00793712] * 4
+    assert intensity_table.sizes[Features.AXIS] == 4, "wrong number of spots detected"
+    expected = [max_intensity] * 4
     assert np.allclose(intensity_table.sum((Axes.ROUND, Axes.CH)).values, expected), \
         "wrong spot intensities detected"

--- a/starfish/test/test_utils.py
+++ b/starfish/test/test_utils.py
@@ -1,6 +1,8 @@
 from collections import OrderedDict
+from typing import Tuple, Sequence
 
 import numpy as np
+from scipy.ndimage.filters import gaussian_filter
 
 from starfish import Codebook, ImageStack
 from starfish.types import Axes, Features, PhysicalCoordinateTypes
@@ -70,3 +72,171 @@ def codebook_array_factory() -> Codebook:
         },
     ]
     return Codebook.from_code_array(data)
+
+
+def _create_dataset(
+    pixel_dimensions: Tuple[int, int, int],
+    spot_coordinates: Sequence[Tuple[int, int, int]],
+    codebook: Codebook
+) -> ImageStack:
+    """
+    creates a numpy array containing one spot per codebook entry at spot_coordinates. length of
+    spot_coordinates must therefore match the number of codes in Codebook.
+    """
+    assert len(spot_coordinates) == codebook.sizes[Features.TARGET]
+
+    data_shape = (
+        codebook.sizes[Axes.ROUND.value],
+        codebook.sizes[Axes.CH.value],
+        *pixel_dimensions
+    )
+    imagestack_data = np.zeros((data_shape), dtype=np.float32)
+
+    for ((z, y, x), f) in zip(spot_coordinates, range(codebook.sizes[Features.TARGET])):
+        imagestack_data[:, :, z, y, x] = codebook[f].transpose(Axes.ROUND.value, Axes.CH.value)
+
+    # blur with a small non-isotropic kernel TODO make kernel smaller.
+    imagestack_data = gaussian_filter(imagestack_data, sigma=(0, 0, 0.7, 1.5, 1.5))
+    return ImageStack.from_numpy_array(imagestack_data)
+
+
+def two_spot_one_hot_coded_data_factory() -> Tuple[Codebook, ImageStack, float]:
+    """
+    Produce a 2-channel 2-round Codebook with two codes and an ImageStack containing one spot from
+    each code. The spots do not overlap and the data are noiseless.
+
+    The encoding of this data is similar to that used in In-situ Sequencing, FISSEQ,
+    BaristaSeq, STARMAP, MExFISH, or SeqFISH.
+
+    Returns
+    -------
+    Codebook :
+        codebook containing codes that match the data
+    ImageStack :
+        noiseless ImageStack containing one spot per code in codebook
+    float :
+        the maximum intensity found in the created ImageStack
+
+    """
+
+    codebook_data = [
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 0, Axes.CH.value: 0, Features.CODE_VALUE: 1},
+                {Axes.ROUND.value: 1, Axes.CH.value: 1, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_A"
+        },
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 0, Axes.CH.value: 1, Features.CODE_VALUE: 1},
+                {Axes.ROUND.value: 1, Axes.CH.value: 0, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_B"
+        },
+    ]
+    codebook = Codebook.from_code_array(codebook_data)
+
+    imagestack = _create_dataset(
+        pixel_dimensions=(10, 100, 100),
+        spot_coordinates=((4, 10, 90), (5, 90, 10)),
+        codebook=codebook
+    )
+
+    max_intensity = np.max(imagestack.xarray.values)
+
+    return codebook, imagestack, max_intensity
+
+
+def two_spot_sparse_coded_data_factory() -> Tuple[Codebook, ImageStack, float]:
+    """
+    Produce a 3-channel 3-round Codebook with two codes and an ImageStack containing one spot from
+    each code. The spots do not overlap and the data are noiseless.
+
+    These spots display sparsity in both rounds and channels, similar to the sparse encoding of
+    MERFISH
+
+    Returns
+    -------
+    ImageStack :
+        noiseless ImageStack containing two spots
+
+    """
+
+    codebook_data = [
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 0, Axes.CH.value: 0, Features.CODE_VALUE: 1},
+                {Axes.ROUND.value: 2, Axes.CH.value: 1, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_A"
+        },
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 0, Axes.CH.value: 1, Features.CODE_VALUE: 1},
+                {Axes.ROUND.value: 1, Axes.CH.value: 2, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_B"
+        },
+    ]
+    codebook = Codebook.from_code_array(codebook_data)
+
+    imagestack = _create_dataset(
+        pixel_dimensions=(10, 100, 100),
+        spot_coordinates=((4, 10, 90), (5, 90, 10)),
+        codebook=codebook
+    )
+
+    max_intensity = np.max(imagestack.xarray.values)
+
+    return codebook, imagestack, max_intensity
+
+
+def two_spot_informative_blank_coded_data_factory() -> Tuple[Codebook, ImageStack, float]:
+    """
+    Produce a 4-channel 2-round Codebook with two codes and an ImageStack containing one spot from
+    each code. The spots do not overlap and the data are noiseless.
+
+    The encoding of this data is essentially a one-hot encoding, but where one of the channels is a
+    intentionally and meaningfully "blank".
+
+    Returns
+    -------
+    Codebook :
+        codebook containing codes that match the data
+    ImageStack :
+        noiseless ImageStack containing one spot per code in codebook
+    float :
+        the maximum intensity found in the created ImageStack
+
+    """
+
+    codebook_data = [
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 0, Axes.CH.value: 0, Features.CODE_VALUE: 1},
+                {Axes.ROUND.value: 1, Axes.CH.value: 1, Features.CODE_VALUE: 1},
+                # round 3 is blank and channel 3 is not used
+            ],
+            Features.TARGET: "GENE_A"
+        },
+        {
+            Features.CODEWORD: [
+                # round 0 is blank and channel 0 is not used
+                {Axes.ROUND.value: 1, Axes.CH.value: 3, Features.CODE_VALUE: 1},
+                {Axes.ROUND.value: 2, Axes.CH.value: 2, Features.CODE_VALUE: 1},
+            ],
+            Features.TARGET: "GENE_B"
+        },
+    ]
+    codebook = Codebook.from_code_array(codebook_data)
+
+    imagestack = _create_dataset(
+        pixel_dimensions=(10, 100, 100),
+        spot_coordinates=((4, 10, 90), (5, 90, 10)),
+        codebook=codebook
+    )
+
+    max_intensity = np.max(imagestack.xarray.values)
+
+    return codebook, imagestack, max_intensity

--- a/starfish/test/test_utils.py
+++ b/starfish/test/test_utils.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Tuple, Sequence
+from typing import Sequence, Tuple
 
 import numpy as np
 from scipy.ndimage.filters import gaussian_filter

--- a/starfish/types/_spot_attributes.py
+++ b/starfish/types/_spot_attributes.py
@@ -1,4 +1,5 @@
 import json
+from typing import Iterable
 
 import numpy as np
 import pandas as pd
@@ -25,6 +26,13 @@ class SpotAttributes(ValidatedTable):
 
         """
         super().__init__(spot_attributes, SpotAttributes.required_fields)
+
+    @classmethod
+    def empty(cls, extra_fields: Iterable=tuple()) -> "SpotAttributes":
+        """return an empty SpotAttributes object"""
+        fields = list(cls.required_fields.union(extra_fields))
+        dtype = list(zip(fields, [np.object] * len(fields)))
+        return cls(pd.DataFrame(np.array([], dtype=dtype)))
 
     def save_geojson(self, output_file_name: str) -> None:
         """Save to geojson for web visualization


### PR DESCRIPTION
This PR refactors testing data that was found in `pixel_spot_detector.py`, moving it to `test_utils.py`. In addition, it makes the produced testing data more robust by returning, in addition to an `ImageStack`, a `Codebook` that could have generated the data (enables use with `PixelSpotDecoder`) and the `max_intensity` value for the `ImageStack` (removes magic numbers from the tests). 

The data that was originally found in `pixel_spot_detector.py` was specific to in-situ sequencing datasets, which left some testing holes in our input data types. This PR replicates the above testing construct of `Codebook, ImageStack, max_intensity` for sparse codebooks (MERFISH) and codebooks with informative blanks (DARTFISH). This covers the data types we currently have access to, and passes these data types to the spot detectors. 

Not all tests pass. These are fixed in [3/3] 
