### PR TITLE
Multiprocessing module for debugging

### DIFF
--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -49,7 +49,7 @@ from starfish.imagestack.parser.crop import CropParameters, CroppedTileCollectio
 from starfish.imagestack.parser.numpy import NumpyData
 from starfish.imagestack.parser.tileset import parse_tileset
 from starfish.intensity_table.intensity_table import IntensityTable
-from starfish.multiprocessing.pool import StarfishPool
+from starfish.multiprocessing.pool import Spool
 from starfish.multiprocessing.shmem import SharedMemory
 from starfish.types import (
     Axes,
@@ -847,7 +847,7 @@ class ImageStack:
         if verbose and StarfishConfig().verbose:
             selectors_and_slice_lists = tqdm(selectors_and_slice_lists)
 
-        with StarfishPool(
+        with Spool(
                 processes=n_processes,
                 initializer=SharedMemory.initializer,
                 initargs=((self._data._backing_mp_array,

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -853,32 +853,13 @@ class ImageStack:
                 initargs=((self._data._backing_mp_array,
                            self._data._data.shape,
                            self._data._data.dtype),)) as pool:
-            if n_processes == 1:
-                sp_applyfunc: Callable = partial(
-                    self._singleprocessing_workflow,
-                    partial(func, **kwargs),
-                    self._data.data.values,
-                )
-                results = pool.map(sp_applyfunc, selectors_and_slice_lists)
-            else:
-                mp_applyfunc: Callable = partial(
-                    self._multiprocessing_workflow, partial(func, **kwargs))
-                results = pool.imap(mp_applyfunc, selectors_and_slice_lists)
+            mp_applyfunc: Callable = partial(
+                self._processing_workflow, partial(func, **kwargs))
+            results = pool.imap(mp_applyfunc, selectors_and_slice_lists)
             return list(zip(results, selectors))
 
     @staticmethod
-    def _singleprocessing_workflow(
-            worker_callable: Callable[[np.ndarray], Any],
-            numpy_array: np.ndarray,
-            selector_and_slice_list: Tuple[Mapping[Axes, int],
-                                           Tuple[Union[int, slice], ...]],
-    ):
-        sliced = numpy_array[selector_and_slice_list[1]]
-
-        return worker_callable(sliced)
-
-    @staticmethod
-    def _multiprocessing_workflow(
+    def _processing_workflow(
             worker_callable: Callable[[np.ndarray], Any],
             selector_and_slice_list: Tuple[Mapping[Axes, int],
                                            Tuple[Union[int, slice], ...]],

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -1,5 +1,4 @@
 import collections
-import multiprocessing
 import os
 import warnings
 from copy import deepcopy
@@ -50,6 +49,7 @@ from starfish.imagestack.parser.crop import CropParameters, CroppedTileCollectio
 from starfish.imagestack.parser.numpy import NumpyData
 from starfish.imagestack.parser.tileset import parse_tileset
 from starfish.intensity_table.intensity_table import IntensityTable
+from starfish.multiprocessing.pool import StarfishPool
 from starfish.multiprocessing.shmem import SharedMemory
 from starfish.types import (
     Axes,
@@ -863,8 +863,8 @@ class ImageStack:
             mp_applyfunc: Callable = partial(
                 self._multiprocessing_workflow, partial(func, **kwargs))
 
-            with multiprocessing.Pool(
-                    n_processes,
+            with StarfishPool(
+                    processes=n_processes,
                     initializer=SharedMemory.initializer,
                     initargs=((self._data._backing_mp_array,
                                self._data._data.shape,

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -49,7 +49,7 @@ from starfish.imagestack.parser.crop import CropParameters, CroppedTileCollectio
 from starfish.imagestack.parser.numpy import NumpyData
 from starfish.imagestack.parser.tileset import parse_tileset
 from starfish.intensity_table.intensity_table import IntensityTable
-from starfish.multiprocessing.pool import Spool
+from starfish.multiprocessing.pool import Pool
 from starfish.multiprocessing.shmem import SharedMemory
 from starfish.types import (
     Axes,
@@ -847,7 +847,7 @@ class ImageStack:
         if verbose and StarfishConfig().verbose:
             selectors_and_slice_lists = tqdm(selectors_and_slice_lists)
 
-        with Spool(
+        with Pool(
                 processes=n_processes,
                 initializer=SharedMemory.initializer,
                 initargs=((self._data._backing_mp_array,

--- a/starfish/multiprocessing/pool.py
+++ b/starfish/multiprocessing/pool.py
@@ -3,8 +3,8 @@ from typing import Optional
 
 
 class Spool(Pool):
-    """Wrapper class for multiprocessing pool. If n_processes=1 just use map on main thread for debugging
-    purposes """
+    """Wrapper class for multiprocessing pool. If n_processes=1 just use map on main
+    thread for debugging purposes """
 
     def __init__(self, processes: Optional[int]=None, **kwargs):
         Pool.__init__(self, **kwargs)

--- a/starfish/multiprocessing/pool.py
+++ b/starfish/multiprocessing/pool.py
@@ -16,5 +16,11 @@ class Pool(mp.Pool):
             return map(func, iterable)
         return mp.Pool.map(self, func, iterable, chunksize)
 
+    def imap(self, func, iterable, chunksize=1):
+        if self.n_processes == 1:
+            self._initializer(*self._initargs)
+            return map(func, iterable)
+        return mp.Pool.imap(self, func, iterable, chunksize)
+
     def __reduce__(self):
         pass

--- a/starfish/multiprocessing/pool.py
+++ b/starfish/multiprocessing/pool.py
@@ -1,0 +1,18 @@
+from multiprocessing.pool import Pool
+from typing import Optional
+
+
+class StarfishPool(Pool):
+    """Wrapper class for multiprocessing pool. When numper of processes = 1...."""
+
+    def __init__(self, processes: Optional[int]=None, **kwargs):
+        Pool.__init__(self, **kwargs)
+        self.n_processes = processes
+
+    def map(self, func, iterable, chunksize=None):
+        if self.n_processes == 1:
+            return map(func, iterable)
+        return Pool.map(self, func, iterable, chunksize)
+
+    def __reduce__(self):
+        pass

--- a/starfish/multiprocessing/pool.py
+++ b/starfish/multiprocessing/pool.py
@@ -1,20 +1,20 @@
-from multiprocessing.pool import Pool
+import multiprocessing.pool as mp
 from typing import Optional
 
 
-class Spool(Pool):
+class Pool(mp.Pool):
     """Wrapper class for multiprocessing pool. If n_processes=1 just use map on main
     thread for debugging purposes """
 
     def __init__(self, processes: Optional[int]=None, **kwargs):
-        Pool.__init__(self, **kwargs)
+        mp.Pool.__init__(self, **kwargs)
         self.n_processes = processes
 
     def map(self, func, iterable, chunksize=None):
         if self.n_processes == 1:
             self._initializer(*self._initargs)
             return map(func, iterable)
-        return Pool.map(self, func, iterable, chunksize)
+        return mp.Pool.map(self, func, iterable, chunksize)
 
     def __reduce__(self):
         pass

--- a/starfish/multiprocessing/pool.py
+++ b/starfish/multiprocessing/pool.py
@@ -2,8 +2,9 @@ from multiprocessing.pool import Pool
 from typing import Optional
 
 
-class StarfishPool(Pool):
-    """Wrapper class for multiprocessing pool. When numper of processes = 1...."""
+class Spool(Pool):
+    """Wrapper class for multiprocessing pool. If n_processes=1 just use map on main thread for debugging
+    purposes """
 
     def __init__(self, processes: Optional[int]=None, **kwargs):
         Pool.__init__(self, **kwargs)

--- a/starfish/multiprocessing/pool.py
+++ b/starfish/multiprocessing/pool.py
@@ -12,6 +12,7 @@ class Spool(Pool):
 
     def map(self, func, iterable, chunksize=None):
         if self.n_processes == 1:
+            self._initializer(*self._initargs)
             return map(func, iterable)
         return Pool.map(self, func, iterable, chunksize)
 

--- a/starfish/spots/_detector/combine_adjacent_features.py
+++ b/starfish/spots/_detector/combine_adjacent_features.py
@@ -9,7 +9,7 @@ from tqdm import tqdm
 
 from starfish.config import StarfishConfig
 from starfish.intensity_table.intensity_table import IntensityTable
-from starfish.multiprocessing.pool import Spool
+from starfish.multiprocessing.pool import Pool
 from starfish.types import Axes, Features, Number, SpotAttributes
 
 
@@ -274,7 +274,7 @@ class CombineAdjacentFeatures:
             An array with length equal to the number of features. If zero, indicates that a feature
             has failed area filters.
         """
-        pool = Spool(processes=n_processes)
+        pool = Pool(processes=n_processes)
         mapfunc = pool.map
         applyfunc = partial(
             self._single_spot_attributes,

--- a/starfish/spots/_detector/combine_adjacent_features.py
+++ b/starfish/spots/_detector/combine_adjacent_features.py
@@ -1,5 +1,4 @@
 from functools import partial
-from multiprocessing import Pool
 from typing import Dict, List, NamedTuple, Optional, Tuple
 
 import numpy as np
@@ -10,6 +9,7 @@ from tqdm import tqdm
 
 from starfish.config import StarfishConfig
 from starfish.intensity_table.intensity_table import IntensityTable
+from starfish.multiprocessing.pool import StarfishPool
 from starfish.types import Axes, Features, Number, SpotAttributes
 
 
@@ -274,7 +274,7 @@ class CombineAdjacentFeatures:
             An array with length equal to the number of features. If zero, indicates that a feature
             has failed area filters.
         """
-        pool = Pool(n_processes)
+        pool = StarfishPool(processes=n_processes)
         mapfunc = pool.map
         applyfunc = partial(
             self._single_spot_attributes,
@@ -285,7 +285,7 @@ class CombineAdjacentFeatures:
         )
 
         iterable = tqdm(region_properties, disable=(not StarfishConfig().verbose))
-        results = mapfunc(applyfunc, iterable)
+        results = mapfunc(func=applyfunc, iterable=iterable)
         spot_attrs, passes_area_filter = zip(*results)
 
         # update passes filter

--- a/starfish/spots/_detector/combine_adjacent_features.py
+++ b/starfish/spots/_detector/combine_adjacent_features.py
@@ -295,7 +295,8 @@ class CombineAdjacentFeatures:
         return spot_attributes, passes_filter
 
     def run(
-            self, intensities: IntensityTable
+            self, intensities: IntensityTable,
+            n_processes: Optional[int] = None
     ) -> Tuple[IntensityTable, ConnectedComponentDecodingResult]:
         """
         Execute the combine_adjacent_features method on an IntensityTable containing pixel
@@ -353,6 +354,7 @@ class CombineAdjacentFeatures:
             props,
             decoded_image,
             target_map,
+            n_processes=n_processes
         )
 
         # augment the SpotAttributes with filtering results and distances from nearest codes

--- a/starfish/spots/_detector/combine_adjacent_features.py
+++ b/starfish/spots/_detector/combine_adjacent_features.py
@@ -9,7 +9,7 @@ from tqdm import tqdm
 
 from starfish.config import StarfishConfig
 from starfish.intensity_table.intensity_table import IntensityTable
-from starfish.multiprocessing.pool import StarfishPool
+from starfish.multiprocessing.pool import Spool
 from starfish.types import Axes, Features, Number, SpotAttributes
 
 
@@ -274,7 +274,7 @@ class CombineAdjacentFeatures:
             An array with length equal to the number of features. If zero, indicates that a feature
             has failed area filters.
         """
-        pool = StarfishPool(processes=n_processes)
+        pool = Spool(processes=n_processes)
         mapfunc = pool.map
         applyfunc = partial(
             self._single_spot_attributes,
@@ -285,7 +285,7 @@ class CombineAdjacentFeatures:
         )
 
         iterable = tqdm(region_properties, disable=(not StarfishConfig().verbose))
-        results = mapfunc(func=applyfunc, iterable=iterable)
+        results = mapfunc(applyfunc, iterable)
         spot_attrs, passes_area_filter = zip(*results)
 
         # update passes filter

--- a/starfish/spots/_detector/detect.py
+++ b/starfish/spots/_detector/detect.py
@@ -210,7 +210,6 @@ def detect_spots(data_stack: ImageStack,
     IntensityTable :
         IntensityTable containing the intensity of each spot, its radius, and location in pixel
         coordinates
-        :param n_processes:
 
     """
 

--- a/starfish/spots/_detector/detect.py
+++ b/starfish/spots/_detector/detect.py
@@ -1,6 +1,6 @@
 from functools import partial
 from itertools import product
-from typing import Callable, Dict, Sequence, Tuple, Union
+from typing import Callable, Dict, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -164,7 +164,8 @@ def detect_spots(data_stack: ImageStack,
                  reference_image: Union[xr.DataArray, np.ndarray] = None,
                  reference_image_from_max_projection: bool = False,
                  measurement_function: Callable[[Sequence], Number] = np.max,
-                 radius_is_gyration: bool = False) -> IntensityTable:
+                 radius_is_gyration: bool = False,
+                 n_processes: Optional[int] = None) -> IntensityTable:
     """Apply a spot_finding_method to a ImageStack
 
     Parameters
@@ -192,6 +193,9 @@ def detect_spots(data_stack: ImageStack,
     is_volume: bool
         If True, pass 3d volumes (x, y, z) to func, else pass 2d tiles (x, y) to func. (default
         True)
+    n_processes : Optional[int]
+        The number of processes to use in stack.transform if reference image is None.
+        If None, uses the output of os.cpu_count() (default = None).
 
     Notes
     -----
@@ -206,6 +210,7 @@ def detect_spots(data_stack: ImageStack,
     IntensityTable :
         IntensityTable containing the intensity of each spot, its radius, and location in pixel
         coordinates
+        :param n_processes:
 
     """
 
@@ -242,7 +247,8 @@ def detect_spots(data_stack: ImageStack,
         spot_finding_method = partial(spot_finding_method, **spot_finding_kwargs)
         spot_attributes_list = data_stack.transform(
             func=spot_finding_method,
-            group_by=group_by
+            group_by=group_by,
+            n_processes=n_processes
         )
         intensity_table = concatenate_spot_attributes_to_intensities(spot_attributes_list)
 

--- a/starfish/spots/_detector/pixel_spot_detector.py
+++ b/starfish/spots/_detector/pixel_spot_detector.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Optional, Tuple
 
 import numpy as np
 
@@ -55,6 +55,7 @@ class PixelSpotDetector(SpotFinderAlgorithmBase):
 
     def run(
         self, stack: ImageStack,
+        n_processes: Optional[int] = None
     ) -> Tuple[IntensityTable, ConnectedComponentDecodingResult]:
         """decode pixels and combine them into spots using connected component labeling
 
@@ -62,6 +63,9 @@ class PixelSpotDetector(SpotFinderAlgorithmBase):
         ----------
         stack : ImageStack
             ImageStack containing spots
+        n_processes : Optional[int]
+            The number of processes to use for CombineAdjacentFeatures.
+             If None, uses the output of os.cpu_count() (default = None).
 
         Returns
         -------
@@ -85,7 +89,8 @@ class PixelSpotDetector(SpotFinderAlgorithmBase):
             max_area=self.max_area,
             mask_filtered_features=True
         )
-        decoded_spots, image_decoding_results = caf.run(intensities=decoded_intensities)
+        decoded_spots, image_decoding_results = caf.run(intensities=decoded_intensities,
+                                                        n_processes=n_processes)
 
         transfer_physical_coords_from_imagestack_to_intensity_table(image_stack=stack,
                                                                     intensity_table=decoded_spots)

--- a/starfish/test/pipeline/test_filter.py
+++ b/starfish/test/pipeline/test_filter.py
@@ -23,7 +23,7 @@ def test_gaussian_high_pass(sigma: Union[Number, Tuple[Number]], is_volume: bool
     image_stack = random_data_image_stack_factory()
     sum_before = np.sum(image_stack.xarray)
     ghp = gaussian_high_pass.GaussianHighPass(sigma=sigma, is_volume=is_volume)
-    result = ghp.run(image_stack)
+    result = ghp.run(image_stack, n_processes=1)
     assert np.sum(result.xarray) < sum_before
 
 @pytest.mark.parametrize('size, is_volume', [

--- a/starfish/test/spots/detector/test_spot_detection.py
+++ b/starfish/test/spots/detector/test_spot_detection.py
@@ -165,7 +165,8 @@ def test_spot_finding_no_reference_image(
     intensity_table = detect_spots(data_stack=data_stack,
                                    spot_finding_method=spot_detector.image_to_spots,
                                    measurement_function=np.max,
-                                   radius_is_gyration=radius_is_gyration)
+                                   radius_is_gyration=radius_is_gyration,
+                                   n_processes=1)
     assert intensity_table.shape == (4, 2, 2), "wrong number of spots detected"
     expected = [0.00793712] * 4
     assert np.allclose(intensity_table.sum((Axes.ROUND, Axes.CH)).values, expected), \


### PR DESCRIPTION
This PR:
-Creates a multiprocessing.pool wrapper class called Spool (starfish+pool, but definitely open for suggestions) that, when given n_processes=1 overrides the map function to use a non-mulitprocessed map. 
-Adds n_processes as a parameter in detect.py and pixel_spot_detector.py
-refactors imagestack.transform to use the spool class in a n_processes=1 scenario
-Modified a couple filter/detect tests to verify everything still works with spool. 

With these changes we should be able to attach the debugger to any Filter/detect step when n_processes=1.
 

fixes: #941 