### PR TITLE
Add version to starfish module.

### DIFF
--- a/starfish/__init__.py
+++ b/starfish/__init__.py
@@ -5,6 +5,8 @@ import warnings
 warnings.filterwarnings("ignore", message="numpy.dtype size changed")  # noqa
 warnings.filterwarnings("ignore", message="numpy.ufunc size changed")  # noqa
 
+import pkg_resources
+
 # image processing methods and objects
 from . import image
 # spot detection and manipulation
@@ -15,6 +17,11 @@ from .experiment.experiment import Experiment, FieldOfView
 from .imagestack.imagestack import ImageStack
 from .intensity_table.intensity_table import IntensityTable
 from .starfish import starfish
+
+
+# NOTE: if we move to python 3.7, we can produce this value at call time via __getattr__
+__version__ = pkg_resources.require("starfish")[0].version
+
 
 if __name__ == "__main__":
     starfish()

--- a/starfish/starfish.py
+++ b/starfish/starfish.py
@@ -62,9 +62,8 @@ def starfish(ctx, profile):
 
 @starfish.command()
 def version():
-    import pkg_resources
-    version = pkg_resources.require("starfish")[0].version
-    print(version)
+    from starfish import __version__
+    print(__version__)
 version.no_art = True  # type: ignore
 
 


### PR DESCRIPTION
Test plan:

```
% starfish version
0.0.31
% python
Python 3.6.6 (default, Jun 28 2018, 05:43:53)
[GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import starfish
>>> starfish.__version__
'0.0.31'
```