### PR TITLE
Move _cli_register boilerplate into metaclass.

### DIFF
--- a/starfish/image/_filter/__init__.py
+++ b/starfish/image/_filter/__init__.py
@@ -34,6 +34,3 @@ class Filter(PipelineComponent):
             output=output,
             stack=ImageStack.from_path_or_url(input),
         )
-
-
-Filter._cli_register()

--- a/starfish/image/_registration/__init__.py
+++ b/starfish/image/_registration/__init__.py
@@ -34,6 +34,3 @@ class Registration(PipelineComponent):
             output=output,
             stack=ImageStack.from_path_or_url(input),
         )
-
-
-Registration._cli_register()

--- a/starfish/image/_segmentation/__init__.py
+++ b/starfish/image/_segmentation/__init__.py
@@ -41,6 +41,3 @@ class Segmentation(PipelineComponent):
             primary_images=ImageStack.from_path_or_url(primary_images),
             nuclei=ImageStack.from_path_or_url(nuclei),
         )
-
-
-Segmentation._cli_register()

--- a/starfish/pipeline/pipelinecomponent.py
+++ b/starfish/pipeline/pipelinecomponent.py
@@ -16,6 +16,7 @@ class PipelineComponentType(type):
         if len(bases) != 0:
             # this is _not_ PipelineComponent.  Instead, it's a subclass of PipelineComponent.
             PipelineComponentType._ensure_algorithms_setup(cls)
+            PipelineComponentType._cli_register(cls)
 
     @classmethod
     def _ensure_algorithms_setup(mcs, cls):
@@ -30,6 +31,11 @@ class PipelineComponentType(type):
                 cls._algorithm_to_class_map_int[algorithm_cls.__name__] = algorithm_cls
 
                 setattr(cls, algorithm_cls._get_algorithm_name(), algorithm_cls)
+
+    @classmethod
+    def _cli_register(mcs, cls):
+        for algorithm_cls in cls._algorithm_to_class_map().values():
+            cls._cli.add_command(algorithm_cls._cli)
 
 
 class PipelineComponent(metaclass=PipelineComponentType):
@@ -74,11 +80,6 @@ class PipelineComponent(metaclass=PipelineComponentType):
     @classmethod
     def _cli_run(cls, ctx, instance, *args, **kwargs):
         raise NotImplementedError()
-
-    @classmethod
-    def _cli_register(cls):
-        for algorithm_cls in cls._algorithm_to_class_map().values():
-            cls._cli.add_command(algorithm_cls._cli)
 
 
 def import_all_submodules(path_str: str, package: str, excluded: Optional[Set[str]]=None) -> None:

--- a/starfish/spots/_decoder/__init__.py
+++ b/starfish/spots/_decoder/__init__.py
@@ -38,6 +38,3 @@ class Decoder(PipelineComponent):
             intensities=IntensityTable.load(input),
             codebook=Codebook.from_json(codebook),
         )
-
-
-Decoder._cli_register()

--- a/starfish/spots/_detector/__init__.py
+++ b/starfish/spots/_detector/__init__.py
@@ -78,6 +78,3 @@ class SpotFinder(PipelineComponent):
 
         if codebook is not None:
             ctx.obj["codebook"] = Codebook.from_json(codebook)
-
-
-SpotFinder._cli_register()

--- a/starfish/spots/_target_assignment/__init__.py
+++ b/starfish/spots/_target_assignment/__init__.py
@@ -41,6 +41,3 @@ class TargetAssignment(PipelineComponent):
             intensity_table=IntensityTable.load(intensities),
             label_image=imread(label_image)
         )
-
-
-TargetAssignment._cli_register()


### PR DESCRIPTION
This can be handled in the metaclass to avoid a bunch of boilerplate.

Test plan: `pytest -v -n4 starfish/test/full_pipelines/cli`