### PR TITLE
ease dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
         'semantic-version',
         'trackpy',
         'showit',
-        'slicedimage',
+        'slicedimage==1.0.3',
         'tqdm',
         'sympy',
         'jsonschema',

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,6 @@ CLASSIFIERS = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 
-install_requires = [
-    line.rstrip() for line in open(os.path.join(os.path.dirname(__file__), "REQUIREMENTS.txt"))
-]
-
 setuptools.setup(
     name="starfish",
     version="0.0.31",
@@ -26,7 +22,23 @@ setuptools.setup(
     author_email="dganguli@chanzuckerberg.com",
     license="MIT",
     packages=setuptools.find_packages(),
-    install_requires=install_requires,
+    install_requires=[
+        'numpy>=0.15.1',
+        'scipy>=1.1.0',
+        'pandas>=0.23.4',
+        'xarray>=0.10.8',
+        'scikit-image>=0.14.0',
+        'scikit-learn>=0.19.2',
+        'semantic-version',
+        'trackpy',
+        'showit',
+        'slicedimage',
+        'tqdm',
+        'sympy',
+        'jsonschema',
+        'click',
+        'regional',
+    ],
     extras_require={
         'napari': ['napari-gui==0.0.5.1', 'matplotlib==2.1.2']
     },

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
         'regional',
     ],
     extras_require={
-        'napari': ['napari-gui==0.0.5.1', 'matplotlib==2.1.2']
+        'napari': ['napari-gui']
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This PR allows starfish to be installed via pip with a looser set of dependencies, while leaving the pinned requirements.txt and other dev tooling for careful dependency control.

Note: I was able to use this method to cleanly installed napari with no version collisions.

cc @sofroniewn 