### PR TITLE
[RFC] Add ElementWiseMult

### DIFF
--- a/starfish/image/_filter/element_wise_mult.py
+++ b/starfish/image/_filter/element_wise_mult.py
@@ -26,8 +26,10 @@ class ElementWiseMult(FilterAlgorithmBase):
         self.mult_mat = mult_mat
 
     _DEFAULT_TESTING_PARAMETERS = {
-        "mult_mat": xr.DataArray(np.array([[[[[1]]], [[[0.5]]]]]),
-            dims=('r', 'c', 'z', 'y', 'x'))
+        "mult_mat": xr.DataArray(
+            np.array([[[[[1]]], [[[0.5]]]]]),
+            dims=('r', 'c', 'z', 'y', 'x')
+        )
     }
 
     @staticmethod

--- a/starfish/image/_filter/element_wise_mult.py
+++ b/starfish/image/_filter/element_wise_mult.py
@@ -1,19 +1,17 @@
-from functools import partial
-from typing import Optional
+from copy import deepcopy
 
 import numpy as np
 import xarray as xr
 
 from starfish.imagestack.imagestack import ImageStack
-from starfish.types import Axes
 from starfish.util import click
 from ._base import FilterAlgorithmBase
 from .util import preserve_float_range
 
 
-class ElementWiseMult(FilterAlgorithmBase):
+class ElementWiseMultiply(FilterAlgorithmBase):
 
-    def __init__(self, mult_mat: xr.core.dataarray.DataArray) -> None:
+    def __init__(self, mult_array: xr.core.dataarray.DataArray) -> None:
         """Perform elementwise multiplication on the image tensor. This is useful for
         performing operations such as image normalization or field flatness correction
 
@@ -23,54 +21,17 @@ class ElementWiseMult(FilterAlgorithmBase):
             the image is element-wise multiplied with this array
 
         """
-        self.mult_mat = mult_mat
+        self.mult_array = mult_array
 
     _DEFAULT_TESTING_PARAMETERS = {
-        "mult_mat": xr.DataArray(
+        "mult_array": xr.DataArray(
             np.array([[[[[1]]], [[[0.5]]]]]),
             dims=('r', 'c', 'z', 'y', 'x')
         )
     }
 
-    @staticmethod
-    def _mult(image: np.ndarray, mult_mat: np.ndarray) -> np.ndarray:
-        """Perform elementwise multiplication on the image tensor. This is useful for
-        performing operations such as image normalization or field flatness correction
-
-        Parameters
-        ----------
-        image : np.ndarray
-            image to be scaled
-
-        mult_mat : np.ndarray
-            each image in the stack is element-wise multiplied by this matrix.
-
-
-        Returns
-        -------
-        np.ndarray :
-          Numpy array of same shape as img
-
-        """
-
-        # Get the axes to squeeze and squeeze the mult_mat while
-        # preserving the X, Y axes
-        to_squeeze = np.isin(mult_mat.shape[0:3], 1)
-        squeezable_axes = np.array([0, 1, 2])
-        axes_to_squeeze = tuple(squeezable_axes[to_squeeze])
-
-        squeezed_mult_mat = np.squeeze(mult_mat, axis=axes_to_squeeze)
-
-        # Element-wise mult
-        image = np.multiply(image, squeezed_mult_mat)
-
-        image = preserve_float_range(image)
-
-        return image
-
     def run(
-            self, stack: ImageStack, in_place: bool=False, verbose: bool=False,
-            n_processes: Optional[int]=None
+            self, stack: ImageStack, in_place: bool=False, verbose=None, n_processes=None
     ) -> ImageStack:
         """Perform filtering of an image stack
 
@@ -80,10 +41,13 @@ class ElementWiseMult(FilterAlgorithmBase):
             Stack to be filtered.
         in_place : bool
             if True, process ImageStack in-place, otherwise return a new stack
-        verbose : bool
-            If True, report on the percentage completed (default = False) during processing
-        n_processes : Optional[int]
-            Number of parallel processes to devote to calculating the filter
+        verbose : None
+            Not used. Elementwise multiply carries out a single vectorized multiplication that
+            cannot provide a status bar. Included for consistency with Filter API.
+        n_processes : None
+            Not used. Elementwise multiplication scales slowly with additional processes due to the
+            efficiency of vectorization on a single process. Included for consistency with Filter
+            API. All computation happens on the main process.
 
         Returns
         -------
@@ -94,30 +58,18 @@ class ElementWiseMult(FilterAlgorithmBase):
         """
 
         # Align the axes of the multipliers with ImageStack
-        mult_mat_aligned = self.mult_mat.transpose(*stack.xarray.dims)
+        mult_array_aligned: np.ndarray = self.mult_array.transpose(*stack.xarray.dims).values
+        if not in_place:
+            stack = deepcopy(stack)
 
-        # Build the grouping set
-        group_by = set()
-
-        sizes = mult_mat_aligned.sizes
-
-        if sizes['r'] == 1:
-            group_by.add(Axes.ROUND)
-        if sizes['c'] == 1:
-            group_by.add(Axes.CH)
-        if sizes['z'] == 1:
-            group_by.add(Axes.ZPLANE)
-
-        clip = partial(self._mult, mult_mat=mult_mat_aligned.values)
-        result = stack.apply(
-            clip,
-            group_by=group_by, verbose=verbose, in_place=in_place, n_processes=n_processes
-        )
-        return result
+        # stack._data contains the xarray
+        stack._data *= mult_array_aligned
+        stack._data = preserve_float_range(stack._data)
+        return stack
 
     @staticmethod
-    @click.command("ElementWiseMult")
+    @click.command("ElementWiseMultiply")
     @click.option(
-        "--mult-mat", required=True, type=np.ndarray, help="matrix to multiply with the image")
-    def _cli(ctx, mult_mat):
-        ctx.obj["component"]._cli_run(ctx, ElementWiseMult(mult_mat))
+        "--mult-array", required=True, type=np.ndarray, help="matrix to multiply with the image")
+    def _cli(ctx, mult_array):
+        ctx.obj["component"]._cli_run(ctx, ElementWiseMultiply(mult_array))

--- a/starfish/image/_filter/element_wise_mult.py
+++ b/starfish/image/_filter/element_wise_mult.py
@@ -107,4 +107,4 @@ class ElementWiseMult(FilterAlgorithmBase):
     @click.option(
         "--mult-mat", required=True, type=np.ndarray, help="matrix to multiply with the image")
     def _cli(ctx, mult_mat):
-        ctx.obj["component"]._cli_run(ctx, ElementWiseMult(mult_mat, is_volume))
+        ctx.obj["component"]._cli_run(ctx, ElementWiseMult(mult_mat))

--- a/starfish/image/_filter/element_wise_mult.py
+++ b/starfish/image/_filter/element_wise_mult.py
@@ -1,0 +1,108 @@
+from functools import partial
+from typing import Optional
+
+import numpy as np
+
+from starfish.imagestack.imagestack import ImageStack
+from starfish.types import Axes
+from starfish.util import click
+from ._base import FilterAlgorithmBase
+from .util import preserve_float_range
+
+
+class ElementWiseMult(FilterAlgorithmBase):
+
+    def __init__(self, mult_mat: np.ndarray) -> None:
+        """Image scaling filter
+
+        Parameters
+        ----------
+        corr_mat : np.ndarray
+            each image in the stack is scaled by this percentile.
+        
+        """
+        self.mult_mat = mult_mat
+
+    #TODO add default testing param
+    #_DEFAULT_TESTING_PARAMETERS = {"corr_mat": 0}
+
+    @staticmethod
+    def _mult(image: np.ndarray, mult_mat: np.ndarray) -> np.ndarray:
+        """Perform elementwise multiplication on the image tensor. This is useful for 
+        performing operations such as image normalization or field flatness correction
+
+        Parameters
+        ----------
+        image : np.ndarray
+            image to be scaled
+
+        mult_mat : np.ndarray
+            each image in the stack is element-wise multiplied by this matrix.
+
+
+        Returns
+        -------
+        np.ndarray :
+          Numpy array of same shape as img
+
+        """
+
+        # Element-wise mult
+
+        image = np.multiply(image, np.squeeze(mult_mat))
+
+
+        image = preserve_float_range(image)
+
+        return image
+
+    def run(
+            self, stack: ImageStack, in_place: bool=False, verbose: bool=False,
+            n_processes: Optional[int]=None
+    ) -> ImageStack:
+        """Perform filtering of an image stack
+
+        Parameters
+        ----------
+        stack : ImageStack
+            Stack to be filtered.
+        in_place : bool
+            if True, process ImageStack in-place, otherwise return a new stack
+        verbose : bool
+            If True, report on the percentage completed (default = False) during processing
+        n_processes : Optional[int]
+            Number of parallel processes to devote to calculating the filter
+
+        Returns
+        -------
+        ImageStack :
+            If in-place is False, return the results of filter as a new stack.  Otherwise return the
+            original stack.
+
+        """
+        # Build the grouping set
+        group_by = set()
+
+        if self.mult_mat.shape[0] == 1:
+            group_by.add(Axes.ROUND)
+        if self.mult_mat.shape[1] == 1:
+            group_by.add(Axes.CH)
+        if self.mult_mat.shape[2] == 1:
+            group_by.add(Axes.ZPLANE)
+
+        clip = partial(self._mult, mult_mat=self.mult_mat)
+        result = stack.apply(
+            clip,
+            group_by=group_by, verbose=verbose, in_place=in_place, n_processes=n_processes
+        )
+        return result
+
+    @staticmethod
+    @click.command("ElementWiseMult")
+    @click.option(
+        "--mult-mat", default=100, type=int, help="scale images by this percentile")
+    @click.option(  # FIXME: was this intentionally missed?
+        "--is-volume", is_flag=True, help="filter 3D volumes")
+    @click.pass_context
+    def _cli(ctx, p, is_volume):
+        ctx.obj["component"]._cli_run(ctx, ElementWiseMult(mult_mat, is_volume))

--- a/starfish/image/_filter/element_wise_mult.py
+++ b/starfish/image/_filter/element_wise_mult.py
@@ -23,8 +23,7 @@ class ElementWiseMult(FilterAlgorithmBase):
         """
         self.mult_mat = mult_mat
 
-    #TODO add default testing param
-    #_DEFAULT_TESTING_PARAMETERS = {"mult_mat": 0}
+    _DEFAULT_TESTING_PARAMETERS = {"mult_mat": np.array([[[[[1]]], [[[0.5]]]]])}
 
     @staticmethod
     def _mult(image: np.ndarray, mult_mat: np.ndarray) -> np.ndarray:
@@ -57,7 +56,6 @@ class ElementWiseMult(FilterAlgorithmBase):
 
         # Element-wise mult
         image = np.multiply(image, squeezed_mult_mat)
-
 
         image = preserve_float_range(image)
 
@@ -97,7 +95,6 @@ class ElementWiseMult(FilterAlgorithmBase):
         if self.mult_mat.shape[2] == 1:
             group_by.add(Axes.ZPLANE)
 
-
         clip = partial(self._mult, mult_mat=self.mult_mat)
         result = stack.apply(
             clip,
@@ -108,9 +105,6 @@ class ElementWiseMult(FilterAlgorithmBase):
     @staticmethod
     @click.command("ElementWiseMult")
     @click.option(
-        "--mult-mat", default=100, type=int, help="scale images by this percentile")
-    @click.option(  # FIXME: was this intentionally missed?
-        "--is-volume", is_flag=True, help="filter 3D volumes")
-    @click.pass_context
-    def _cli(ctx, p, is_volume):
+        "--mult-mat", required=True, type=np.ndarray, help="matrix to multiply with the image")
+    def _cli(ctx, mult_mat):
         ctx.obj["component"]._cli_run(ctx, ElementWiseMult(mult_mat, is_volume))

--- a/starfish/image/_filter/element_wise_mult.py
+++ b/starfish/image/_filter/element_wise_mult.py
@@ -27,7 +27,7 @@ class ElementWiseMult(FilterAlgorithmBase):
 
     _DEFAULT_TESTING_PARAMETERS = {
         "mult_mat": xr.DataArray(np.array([[[[[1]]], [[[0.5]]]]]),
-        dims=('r','c', 'z', 'y', 'x'))
+            dims=('r', 'c', 'z', 'y', 'x'))
     }
 
     @staticmethod
@@ -90,7 +90,7 @@ class ElementWiseMult(FilterAlgorithmBase):
             original stack.
 
         """
-        
+
         # Align the axes of the multipliers with ImageStack
         mult_mat_aligned = self.mult_mat.transpose(*stack.xarray.dims)
 

--- a/starfish/image/_filter/element_wise_mult.py
+++ b/starfish/image/_filter/element_wise_mult.py
@@ -19,7 +19,7 @@ class ElementWiseMult(FilterAlgorithmBase):
         ----------
         mult_mat : np.ndarray
             each image in the stack is scaled by this percentile.
-        
+
         """
         self.mult_mat = mult_mat
 
@@ -28,7 +28,7 @@ class ElementWiseMult(FilterAlgorithmBase):
 
     @staticmethod
     def _mult(image: np.ndarray, mult_mat: np.ndarray) -> np.ndarray:
-        """Perform elementwise multiplication on the image tensor. This is useful for 
+        """Perform elementwise multiplication on the image tensor. This is useful for
         performing operations such as image normalization or field flatness correction
 
         Parameters


### PR DESCRIPTION
# Objective
This PR introduces a pipeline component for field flatness correction and image normalization via a user supplied correction image. 

# Overview
Per our discussion in #945, I did the following:

> For illumination correction, the user would supply the full matrix. This method uses the Filter PipelineComponent. The user supplied matrix is a 5-d tensor with any singleton dimension being broadcast. For example, to correct illumination uniformly across (x, y) user would pass (1, 1, 1, x, y). To uniformly scale channels, user would pass (1, c, 1, 1, 1) where c- is a vector of length equal to the number of channels

# Usage
```python
import numpy as np

from starfish.imagestack.imagestack import ImageStack
import starfish

# Make the ImageStack
im = np.ones((1, 3, 5, 2, 2))
stack = ImageStack.from_numpy_array(im)

# Make the correction matrix
corr_mat = np.ones((1, 1, 1, 1, 3))
corr_mat[0, 0, 0, 0, 1] = 0.5
corr_mat_xr = xr.DataArray(corr_mat, dims=('r', 'x', 'z', 'y', 'c'))

# Correct...
filter_mult = starfish.image.Filter.ElementWiseMult(mult_mat=corr_mat_xr)
stack2 = filter_mult.run(stack, in_place=False, verbose=True)
```

# To do
- [x] Add tests (we can probably use variants of the usage example above)

# Questions
* I am not familiar with click. Can I supply an ndarray as a default parameter?
* For the `_DEFAULT_TESTING_PARAMETERS = {"corr_mat": 0}`: I assume these are passed as kwargs into some test. Where are those tests?
* Currently, I use `group_by` to chunk by ROUND, CH, Z (where appropriate) and numpy broadcasting for X, Y. I think this is preferred, as it is compatible with the multiprocessing. We can also just directly multiply the `mult_mat` with the `image` thanks to the magic of numpy, but I don't think this will use the multiprocessing, as implemented. Thoughts?
* Is there a better way to get the `group_by` axes (see the `run()` method)?
