### PR TITLE
cli: add `validate xarray` command

### DIFF
--- a/sptx_format/cli.py
+++ b/sptx_format/cli.py
@@ -1,13 +1,44 @@
+from time import time
+
+import xarray as xr
+
 from sptx_format import validate_sptx
 from starfish.util import click
 
 
-@click.command()
-@click.option("--experiment-json", required=True, metavar="JSON_FILE_OR_URL")
+class DefaultGroup(click.Group):
+    """
+    Handle the old style invocation by changing --experiment to the subcommand
+    """
+
+    def parse_args(self, ctx, args):
+        copy = list()
+        for arg in args:
+            if arg.startswith("--experiment-json"):
+                parts = arg.split("=")
+                parts[0] = "experiment"
+                copy.extend(parts)
+            else:
+                copy.append(arg)
+        print(copy)
+        super(DefaultGroup, self).parse_args(ctx, copy)
+
+
+@click.group(cls=DefaultGroup)
+@click.option("--experiment-json", required=False, metavar="JSON_FILE_OR_URL")
 @click.option("--fuzz", is_flag=True)
 @click.pass_context
 def validate(ctx, experiment_json, fuzz):
+    assert not experiment_json
+
+
+@validate.command()
+@click.argument("experiment_json", metavar="JSON_FILE_OR_URL")
+@click.option("--fuzz", is_flag=True)
+@click.pass_context
+def experiment(ctx, experiment_json, fuzz):
     """validate experiment against the jsonschemas"""
+
     try:
         valid = validate_sptx.validate(experiment_json, fuzz)
         if valid:
@@ -16,3 +47,40 @@ def validate(ctx, experiment_json, fuzz):
             ctx.exit(1)
     except KeyboardInterrupt:
         ctx.exit(3)
+
+
+@validate.command()
+@click.argument("file")
+@click.pass_context
+def xarray(ctx, file):
+    try:
+        d = xr.open_dataset(file)
+        print("=" * 60)
+        start = time()
+        print(d)
+        stop = time()
+        print("=" * 60)
+        print(f"Opened {file} in {stop-start}s.")
+        names = set(d.coords._names)
+        spots = "z y x radius z_min z_max y_min y_max x_min x_max "
+        spots += "intensity spot_id features c r xc yc zc"
+        spots = set(spots.split(" "))
+        target_spots = set(["cell_id"])
+        decoded_spots = set(["target", "distance", "passes_thresholds"])
+        if spots.issubset(names):
+            if target_spots.issubset(names):
+                if decoded_spots.issubset(names):
+                    print("Likely decoded spots")
+                else:
+                    print("Likely target spots")
+            else:
+                print("Likely just spots")
+        else:
+            print("Unknown xarray output format!")
+            ctx.exit(1)
+        ctx.exit(0)
+    except KeyboardInterrupt:
+        ctx.exit(3)
+    except Exception as e:
+        print(f"Invalid xarray: {e}")
+        ctx.exit(1)

--- a/sptx_format/cli.py
+++ b/sptx_format/cli.py
@@ -20,7 +20,6 @@ class DefaultGroup(click.Group):
                 copy.extend(parts)
             else:
                 copy.append(arg)
-        print(copy)
         super(DefaultGroup, self).parse_args(ctx, copy)
 
 

--- a/starfish/test/full_pipelines/cli/test_build.py
+++ b/starfish/test/full_pipelines/cli/test_build.py
@@ -12,8 +12,14 @@ class TestWithBuildData(unittest.TestCase):
             "--fov-count=2", '--primary-image-dimensions={"z": 3}',
             lambda tempdir: tempdir
         ],
+        # Old-style
         [
             "starfish", "validate", "--experiment-json",
+            lambda tempdir: os.sep.join([tempdir, "experiment.json"])
+        ],
+        # New-style
+        [
+            "starfish", "validate", "experiment",
             lambda tempdir: os.sep.join([tempdir, "experiment.json"])
         ],
     )

--- a/starfish/test/full_pipelines/cli/test_iss.py
+++ b/starfish/test/full_pipelines/cli/test_iss.py
@@ -128,6 +128,23 @@ class TestWithIssData(CLITest, unittest.TestCase):
                     tempdir, "results", "decoded-spots.nc"),
                 "PerRoundMaxChannelDecoder",
             ],
+
+            # Validate results/{spots,targeted-spots,decoded-spots}.nc
+            [
+                "starfish", "validate", "xarray",
+                lambda tempdir, *args, **kwargs: os.path.join(
+                    tempdir, "results", "spots.nc")
+            ],
+            [
+                "starfish", "validate", "xarray",
+                lambda tempdir, *args, **kwargs: os.path.join(
+                    tempdir, "results", "targeted-spots.nc")
+            ],
+            [
+                "starfish", "validate", "xarray",
+                lambda tempdir, *args, **kwargs: os.path.join(
+                    tempdir, "results", "decoded-spots.nc")
+            ],
         )
 
     def verify_results(self, intensities):

--- a/starfish/util/click.py
+++ b/starfish/util/click.py
@@ -5,6 +5,7 @@ from click import (
     command,
     Context,
     echo,
+    Group,
     group,
     Option,
     ParamType,
@@ -16,7 +17,7 @@ from click import option as _click_option
 
 # Workaround for F401
 __click_imports: Sequence[Any] = [
-    argument, command, Context, echo, group,
+    argument, command, Context, echo, group, Group,
     Option, _click_option, ParamType, pass_context, Path
 ]
 

--- a/starfish/util/exec.py
+++ b/starfish/util/exec.py
@@ -65,6 +65,9 @@ def stages(commands: Sequence[Sequence[Union[str, Callable]]],
     finally:
         if tempobj:
             tempobj.cleanup()
+        else:
+            print("Temporary files kept under:")
+            print(tempdir)
 
 
 def prepare_stage(stage: Sequence[Union[str, Callable]],


### PR DESCRIPTION
 - call xr.open_dataset and print repr
 - try to detect which type of output it is
 - return non-zero if unknown or invalid

Also:
   - add an `experiment` subcommand
   - rewrite `--experiment-json` to use subcommand
   - print temp directory for test output for easier testing

Example output:

```

         _              __ _     _
        | |            / _(_)   | |
     ___| |_ __ _ _ __| |_ _ ___| |__
    / __| __/ _` | '__|  _| / __| '_  `
    \__ \ || (_| | |  | | | \__ \ | | |
    |___/\__\__,_|_|  |_| |_|___/_| |_|


============================================================
<xarray.Dataset>
Dimensions:                        (c: 4, features: 51, r: 4)
Coordinates:
    z                              (features) int64 ...
    y                              (features) int64 ...
    x                              (features) int64 ...
    radius                         (features) int64 ...
    z_min                          (features) int64 ...
    z_max                          (features) int64 ...
    y_min                          (features) int64 ...
    y_max                          (features) int64 ...
    x_min                          (features) int64 ...
    x_max                          (features) int64 ...
    intensity                      (features) float64 ...
    spot_id                        (features) int64 ...
  * features                       (features) int64 0 1 2 3 4 5 6 7 8 9 10 ...
  * c                              (c) int64 0 1 2 3
  * r                              (r) int64 0 1 2 3
    xc                             (features) float32 ...
    yc                             (features) float32 ...
    zc                             (features) float32 ...
    cell_id                        (features) uint8 ...
    target                         (features) object ...
    distance                       (features) float64 ...
    passes_thresholds              (features) bool ...
Data variables:
    __xarray_dataarray_variable__  (features, c, r) float64 ...
============================================================
Opened /tmp/tmpjp8wl1mn/results/decoded-spots.nc in 0.003281116485595703s.
Likely decoded spots
starfish validate  ==> 2.16147780418396 seconds
Temporary files kept under:
/tmp/tmpjp8wl1mn

```

Test plan:
 * run `starfish validate xarray $FILENAME` on the contents of `results/`
