### PR TITLE
[RFC] Add linear unmixing

### DIFF
--- a/starfish/image/_filter/linear_unmixing.py
+++ b/starfish/image/_filter/linear_unmixing.py
@@ -29,7 +29,7 @@ class LinearUnmixing(FilterAlgorithmBase):
 
     @staticmethod
     def _unmix(image: np.ndarray, coeff_mat: np.ndarray) -> np.ndarray:
-        """Clip values of img below and above percentiles p_min and p_max
+        """Perform linear unmixing of channels
 
         Parameters
         ----------

--- a/starfish/image/_filter/linear_unmixing.py
+++ b/starfish/image/_filter/linear_unmixing.py
@@ -39,18 +39,18 @@ class LinearUnmixing(FilterAlgorithmBase):
         coeff_mat : np.ndarray
             matrix of the linear unmixing coefficients. Should take the form:
             B = AX, where B are the unmixed values, A is coeff_mat and X are
-            the observed values.
+            the observed values. coeff_mat has shape (n_ch, n_ch).
 
         Returns
         -------
         np.ndarray :
-          Numpy array of same shape as img
+          Numpy array of same shape as image
 
         """
         # Preallocate the new image in the same shape
         unmixed_image = np.zeros(image.shape)
 
-        # Due to the grouping, assumes image is shape [chan, x, y]
+        # Due to the grouping in run(), image is shape [chan, x, y]
         n_channels = image.shape[0]
 
         for c in range(n_channels):

--- a/starfish/image/_filter/linear_unmixing.py
+++ b/starfish/image/_filter/linear_unmixing.py
@@ -1,0 +1,109 @@
+from functools import partial
+from typing import Optional
+
+import numpy as np
+
+from starfish.imagestack.imagestack import ImageStack
+from starfish.util import click
+from starfish.types import Axes
+from ._base import FilterAlgorithmBase
+from .util import preserve_float_range
+
+
+class LinearUnmixing(FilterAlgorithmBase):
+
+    def __init__(self, coeff_mat: np.ndarray) -> None:
+        """Image scaling filter
+
+        Parameters
+        ----------
+        coeff_mat : np.ndarray
+            matrix of the linear unmixing coefficients. Should take the form:
+            B = AX, where B are the unmixed values, A is coeff_mat and X are
+            the observed values.
+
+        """
+        self.coeff_mat = coeff_mat
+
+    _DEFAULT_TESTING_PARAMETERS = {"coeff_mat": np.array([[1, -0.25], [-0.25, 1]])}
+
+    @staticmethod
+    def _unmix(image: np.ndarray, coeff_mat: np.ndarray) -> np.ndarray:
+        """Clip values of img below and above percentiles p_min and p_max
+
+        Parameters
+        ----------
+        image : np.ndarray
+            image to be scaled
+
+        coeff_mat : np.ndarray
+            matrix of the linear unmixing coefficients. Should take the form:
+            B = AX, where B are the unmixed values, A is coeff_mat and X are
+            the observed values.
+
+        Returns
+        -------
+        np.ndarray :
+          Numpy array of same shape as img
+
+        """
+        # Preallocate the new image in the same shape
+        unmixed_image = np.zeros(image.shape)
+
+        # Due to the grouping, assumes image is shape [chan, x, y]
+        n_channels = image.shape[0]
+
+        for c in range(n_channels):
+            # Get the coefficients
+            coeffs = np.zeros((n_channels, 1, 1))
+            coeffs[:, 0, 0] = coeff_mat[c]
+
+            coeff_im = np.multiply(image, coeffs)
+
+            unmixed_image[c, ...] = np.sum(coeff_im, axis=0)
+
+        unmixed_image = preserve_float_range(unmixed_image)
+
+        return unmixed_image
+
+    def run(
+            self, stack: ImageStack, in_place: bool=False, verbose: bool=False,
+            n_processes: Optional[int]=None
+    ) -> ImageStack:
+        """Perform filtering of an image stack
+
+        Parameters
+        ----------
+        stack : ImageStack
+            Stack to be filtered.
+        in_place : bool
+            if True, process ImageStack in-place, otherwise return a new stack
+        verbose : bool
+            If True, report on the percentage completed (default = False) during processing
+        n_processes : Optional[int]
+            Number of parallel processes to devote to calculating the filter
+
+        Returns
+        -------
+        ImageStack :
+            If in-place is False, return the results of filter as a new stack.  Otherwise return the
+            original stack.
+
+        """
+        assert self.coeff_mat.shape == (stack.num_chs, stack.num_chs) 
+
+        group_by = {Axes.ROUND, Axes.ZPLANE}
+        unmix = partial(self._unmix, coeff_mat=self.coeff_mat)
+        result = stack.apply(
+            unmix,
+            group_by=group_by, verbose=verbose, in_place=in_place, n_processes=n_processes
+        )
+        return result
+
+    @staticmethod
+    @click.command("LinearUnmixing")
+    @click.option(
+        "--coeff_mat", required=True, type=np.ndarray, help="linear unmixing coefficients")
+    @click.pass_context
+    def _cli(ctx, coeff_mat):
+        ctx.obj["component"]._cli_run(ctx, LinearUnmixing(coeff_mat))

--- a/starfish/image/_filter/linear_unmixing.py
+++ b/starfish/image/_filter/linear_unmixing.py
@@ -4,8 +4,8 @@ from typing import Optional
 import numpy as np
 
 from starfish.imagestack.imagestack import ImageStack
-from starfish.util import click
 from starfish.types import Axes
+from starfish.util import click
 from ._base import FilterAlgorithmBase
 from .util import preserve_float_range
 
@@ -90,8 +90,6 @@ class LinearUnmixing(FilterAlgorithmBase):
             original stack.
 
         """
-        assert self.coeff_mat.shape == (stack.num_chs, stack.num_chs) 
-
         group_by = {Axes.ROUND, Axes.ZPLANE}
         unmix = partial(self._unmix, coeff_mat=self.coeff_mat)
         result = stack.apply(

--- a/starfish/test/image/filter/test_linear_unmixing.py
+++ b/starfish/test/image/filter/test_linear_unmixing.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+from starfish import ImageStack
+from starfish.image._filter.linear_unmixing import LinearUnmixing
+
+def setup_linear_unmixing_test():
+	""" 
+
+		Create the image stack, coeff matrix, and reference result
+		for the linear unmixing test
+
+	"""
+	# Create image
+	im = np.ones((2, 3, 5, 2, 2), dtype=np.float32)
+	stack = ImageStack.from_numpy_array(im)
+
+	# Create coefficients matrix
+	coeff_mat = np.array([[1, 0, 0], [-0.25, 1, -0.25], [0, 0, 1]])
+
+	# Create reference result
+	ref_result = np.ones((2, 3, 5, 2, 2))
+	ref_result[:, 1, ...] = 0.5 * np.ones((5, 2, 2))
+
+	return stack, coeff_mat, ref_result
+
+def test_linear_unmixing():
+	""" Test the linear unmixing filter """
+	stack, coeff_mat, ref_result = setup_linear_unmixing_test()
+
+	filter_unmix = LinearUnmixing(coeff_mat=coeff_mat)
+	stack2 = filter_unmix.run(stack, in_place=False, verbose=False)
+
+	assert np.all(ref_result == stack2.xarray.values)

--- a/starfish/test/image/filter/test_linear_unmixing.py
+++ b/starfish/test/image/filter/test_linear_unmixing.py
@@ -4,30 +4,30 @@ from starfish import ImageStack
 from starfish.image._filter.linear_unmixing import LinearUnmixing
 
 def setup_linear_unmixing_test():
-	""" 
+    """
+        Create the image stack, coeff matrix, and reference result
+        for the linear unmixing test
 
-		Create the image stack, coeff matrix, and reference result
-		for the linear unmixing test
+    """
+    # Create image
+    im = np.ones((2, 3, 5, 2, 2), dtype=np.float32)
+    stack = ImageStack.from_numpy_array(im)
 
-	"""
-	# Create image
-	im = np.ones((2, 3, 5, 2, 2), dtype=np.float32)
-	stack = ImageStack.from_numpy_array(im)
+    # Create coefficients matrix
+    coeff_mat = np.array([[1, 0, 0], [-0.25, 1, -0.25], [0, 0, 1]])
 
-	# Create coefficients matrix
-	coeff_mat = np.array([[1, 0, 0], [-0.25, 1, -0.25], [0, 0, 1]])
+    # Create reference result
+    ref_result = np.ones((2, 3, 5, 2, 2))
+    ref_result[:, 1, ...] = 0.5 * np.ones((5, 2, 2))
 
-	# Create reference result
-	ref_result = np.ones((2, 3, 5, 2, 2))
-	ref_result[:, 1, ...] = 0.5 * np.ones((5, 2, 2))
-
-	return stack, coeff_mat, ref_result
+    return stack, coeff_mat, ref_result
 
 def test_linear_unmixing():
-	""" Test the linear unmixing filter """
-	stack, coeff_mat, ref_result = setup_linear_unmixing_test()
+    """ Test the linear unmixing filter """
+    
+    stack, coeff_mat, ref_result = setup_linear_unmixing_test()
 
-	filter_unmix = LinearUnmixing(coeff_mat=coeff_mat)
-	stack2 = filter_unmix.run(stack, in_place=False, verbose=False)
+    filter_unmix = LinearUnmixing(coeff_mat=coeff_mat)
+    stack2 = filter_unmix.run(stack, in_place=False, verbose=False)
 
-	assert np.all(ref_result == stack2.xarray.values)
+    assert np.all(ref_result == stack2.xarray.values)

--- a/starfish/test/image/filter/test_linear_unmixing.py
+++ b/starfish/test/image/filter/test_linear_unmixing.py
@@ -24,7 +24,7 @@ def setup_linear_unmixing_test():
 
 def test_linear_unmixing():
     """ Test the linear unmixing filter """
-    
+
     stack, coeff_mat, ref_result = setup_linear_unmixing_test()
 
     filter_unmix = LinearUnmixing(coeff_mat=coeff_mat)


### PR DESCRIPTION
# Objective
This PR introduces a component to perform linear unmixing across channels to compensate for crosstalk between filters.

# Overview
Per our discussion in #945, I implemented the following:

> 2\. Channel cross-talk: takes a square channel x channel coefficient matrix. This uses the Filter PipelineComponent.

# Usage
```python
import numpy as np
from starfish.imagestack.imagestack import ImageStack

import starfish

# Create the ImageStack
im = np.ones((1, 3, 5, 2, 2))
stack = ImageStack.from_numpy_array(im)

# Create the coefficient matrix
coeff_mat = np.array([[1, 0, 0], [-0.25, 1, -0.25], [0, 0, 1]])

# Unmix
filter_unmix = starfish.image.Filter.LinearUnmixing(coeff_mat=coeff_mat)
stack2 = filter_unmix.run(stack, in_place=False, verbose=True)
```

# Questions
* I think it would be nice to expose a couple of rescaling options. Perhaps normalizing to the max and/or mean?
* This assumes the unmixing will be performed across channels. Is there value in making it general? At the moment, I can't think of any use cases, so I'm leaning towards keeping it specific to channels.