### PR TITLE
[RFC] Add affine transform

### DIFF
--- a/starfish/image/_registration/affine_transform.py
+++ b/starfish/image/_registration/affine_transform.py
@@ -1,0 +1,123 @@
+from copy import deepcopy
+from typing import Optional, Tuple, Union
+
+from itertools import product
+import numpy as np
+from skimage.transform import AffineTransform, warp
+
+from starfish.image._filter.util import preserve_float_range
+from starfish.imagestack.imagestack import ImageStack
+from starfish.types import Axes
+from starfish.util import click
+from ._base import RegistrationAlgorithmBase
+
+
+class AffineTransform(RegistrationAlgorithmBase):
+    """
+    Performs an affine transform on the specified indices of an ImageStack
+
+    """
+    def __init__(
+        self, scale: Union[list, tuple]=None, rotation: float=None,
+        shear: float=None, translation: Union[list, tuple]=None,
+        rounds=None, channels=None, zplanes=None
+            ) -> None:
+
+        """Performs an affine transform on the specified indices of an ImageStack
+        Wraps skimage's AffineTransform
+        http://scikit-image.org/docs/dev/api/skimage.transform.html
+
+        Parameters
+        ----------
+        scale : list, tuple
+            images are registered to within 1 / upsample_factor of a pixel
+        rotation : float
+            Rotation angle in radians, counter-clockwise direction is positive
+        shear : float
+            Shear angle in radians, counter-clockwise direction is positive
+        translation : list, tuple
+            Number of pixels to translate the image (t_x, t_y)
+        rounds : np.ndarray
+            list of rounds to apply the transformation to. If omitted, transform
+            will be applied to all rounds.
+        channels : np.ndarray
+            list of channels to apply the transformation to. If omitted, transform
+            will be applied to all channels.
+        zplanes : np.ndarray
+            list of zplanes to apply the transformation to. If omitted, transform
+            will be applied to all zplanes.
+        """
+        self.scale = scale
+        self.rotation = rotation
+        self.shear = shear
+        self.translation = translation
+        self.rounds = rounds
+        self.channels = channels
+        self.zplanes = zplanes
+
+    def run(self, image: ImageStack, in_place: bool=False) -> Optional[ImageStack]:
+        """Register an ImageStack against a reference image.
+
+        Parameters
+        ----------
+        image : ImageStack
+            The stack to be registered
+        in_place : bool
+            If false, return a new registered stack. Else, register in-place (default False)
+
+        Returns
+        -------
+
+
+        """
+
+        if not in_place:
+            image = deepcopy(image)
+
+        # Get a list of all indices for an axes without provided indices
+        if self.rounds is None:
+            self.rounds = np.arange(image.num_rounds)
+        if self.channels is None:
+            self.channels = np.arange(image.num_chs)
+        if self.zplanes is None:
+            self.zplanes = np.arange(image.num_zplanes)
+
+        # Make the list of indices to iterate over
+        slice_indices = product(self.rounds, self.channels, self.zplanes)
+
+        # Get the transform
+        transform = AffineTransform(scale=self.scale, rotation=self.rotation,
+                                    shear=self.shear, translation=self.translation)
+
+        # Iterate through the selected tiles and perform the transform
+        for r, c, z in slice_indices:
+            selector = {Axes.ROUND: r, Axes.CH: c, Axes.ZPLANES: z}
+
+            tile = image.get_slice(selector)[0]
+            transformed = warp(tile, transform)
+            image.set_slice(selector, transformed.astype(np.float32))
+
+        if not in_place:
+            return image
+        return None
+
+    @staticmethod
+    @click.command("AffineTransform")
+    @click.option("--scale", default=None, type=list, help="Scale factor, (Sx, Sy)")
+    @click.option("--rotation", default=None, type=float,
+                  help="Rotation angle in radians, counter-clockwise direction is positive.")
+    @click.option("--shear", default=None, type=float,
+                  help="Shear angle in radians, counter-clockwise direction is positive.")
+    @click.option("--translation", default=None, type=list,
+                  help="Number of pixels to translate the image (t_x, t_y).")
+    @click.option("--rounds", default=None, type=list,
+                  help="list of rounds to apply the transformation to.")
+    @click.option("--channels", default=None, type=list,
+                  help="list of channels to apply the transformation to.")
+    @click.option("--zplanes", default=None, type=list,
+                  help="list of zplanes to apply the transformation to..")
+    @click.pass_context
+    def _cli(ctx, scale, rotation, shear, translation, rounds, channels, zplanes):
+        ctx.obj["component"]._cli_run(
+            ctx, AffineTransform(scale, rotation, shear, translation, rounds, channels, zplanes)
+                )

--- a/starfish/image/_registration/affine_transform.py
+++ b/starfish/image/_registration/affine_transform.py
@@ -1,12 +1,11 @@
 from copy import deepcopy
-from typing import Optional, Tuple, Union
-
 from itertools import product
+from typing import Optional, Union
+
 import numpy as np
 from skimage.transform import AffineTransform as AT
 from skimage.transform import warp
 
-from starfish.image._filter.util import preserve_float_range
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Axes
 from starfish.util import click
@@ -22,7 +21,7 @@ class AffineTransform(RegistrationAlgorithmBase):
         self, scale: Union[list, tuple]=None, rotation: float=None,
         shear: float=None, translation: Union[list, tuple]=None,
         rounds=None, channels=None, zplanes=None
-            ) -> None:
+    ) -> None:
 
         """Performs an affine transform on the specified indices of an ImageStack
         Wraps skimage's AffineTransform
@@ -88,7 +87,7 @@ class AffineTransform(RegistrationAlgorithmBase):
 
         # Get the transform
         transformation = AT(scale=self.scale, rotation=self.rotation,
-                                    shear=self.shear, translation=self.translation)
+                            shear=self.shear, translation=self.translation)
 
         # Iterate through the selected tiles and perform the transform
         for r, c, z in slice_indices:
@@ -121,4 +120,4 @@ class AffineTransform(RegistrationAlgorithmBase):
     def _cli(ctx, scale, rotation, shear, translation, rounds, channels, zplanes):
         ctx.obj["component"]._cli_run(
             ctx, AffineTransform(scale, rotation, shear, translation, rounds, channels, zplanes)
-                )
+        )

--- a/starfish/image/_registration/affine_transform.py
+++ b/starfish/image/_registration/affine_transform.py
@@ -3,7 +3,8 @@ from typing import Optional, Tuple, Union
 
 from itertools import product
 import numpy as np
-from skimage.transform import AffineTransform, warp
+from skimage.transform import AffineTransform as AT
+from skimage.transform import warp
 
 from starfish.image._filter.util import preserve_float_range
 from starfish.imagestack.imagestack import ImageStack
@@ -86,15 +87,15 @@ class AffineTransform(RegistrationAlgorithmBase):
         slice_indices = product(self.rounds, self.channels, self.zplanes)
 
         # Get the transform
-        transform = AffineTransform(scale=self.scale, rotation=self.rotation,
+        transformation = AT(scale=self.scale, rotation=self.rotation,
                                     shear=self.shear, translation=self.translation)
 
         # Iterate through the selected tiles and perform the transform
         for r, c, z in slice_indices:
-            selector = {Axes.ROUND: r, Axes.CH: c, Axes.ZPLANES: z}
+            selector = {Axes.ROUND: r, Axes.CH: c, Axes.ZPLANE: z}
 
             tile = image.get_slice(selector)[0]
-            transformed = warp(tile, transform)
+            transformed = warp(tile, transformation)
             image.set_slice(selector, transformed.astype(np.float32))
 
         if not in_place:


### PR DESCRIPTION
# Objective
This PR introduces a pipeline component to perform a precomputed affine transformation on an `ImageStack`

# Overview
Per our discussion in #945, I implemented the a registration component that wraps the `skimage.transform.AffineTransform`. The user can input a list of round, channel, zplane indices to select which tiles are transformed.

# Usage
```python

from skimage import data, io, img_as_float32
import numpy as np

import starfish

# Create an image
tile = img_as_float32(data.checkerboard())

im = np.zeros((2, 3, 5, 200, 200), dtype=np.float32)

for r in range(im.shape[0]):
    for c in range(im.shape[1]):
        for z in range(im.shape[2]):
            im[r, c, z, :, :] = tile
            
stack = starfish.imagestack.imagestack.ImageStack.from_numpy_array(im)

# Transform
translate = starfish.image.Registration.AffineTransform(channels=[0, 2], translation=(100, 100))
stack2 = translate.run(stack, in_place=False)
```

# Questions
* The skimage affine transform allows the user to either input the transformation matrix directly or input the individual parameters (e.g., translation, rotation) independently. I think this is a bit confusing because you can't input both the matrix and individual parameters because they may conflict. Thus, I think we should expose only one option. I opted for the individual parameters, because I thought that would be more intuitive for the general audience. What do you think?