### PR TITLE
Inhibit multiprocessing.Pool on NT

### DIFF
--- a/starfish/multiprocessing/pool.py
+++ b/starfish/multiprocessing/pool.py
@@ -1,23 +1,43 @@
 import multiprocessing.pool as mp
-from typing import Optional
+import os
+from typing import Callable, Iterable, Optional
 
 
-class Pool(mp.Pool):
+class Pool:
     """Wrapper class for multiprocessing pool. If n_processes=1 just use map on main
     thread for debugging purposes """
 
-    def __init__(self, processes: Optional[int]=None, *args, **kwargs):
-        mp.Pool.__init__(self, processes, *args, **kwargs)
-        self.n_processes = processes
+    def __init__(
+            self,
+            processes: Optional[int]=None,
+            initializer: Optional[Callable]=None,
+            initargs: Optional[Iterable]=None,
+            *args, **kwargs):
+        self.initializer = initializer
+        self.initargs = initargs or []
+        if processes == 1 or os.name == "nt":
+            self.pool = None
+        else:
+            self.pool = mp.Pool(processes, self.initializer, self.initargs, *args, **kwargs)
 
     def map(self, func, iterable, chunksize=None):
-        if self.n_processes == 1:
-            self._initializer(*self._initargs)
+        if self.pool is None:
+            self.initializer(*self.initargs)
             return map(func, iterable)
-        return mp.Pool.map(self, func, iterable, chunksize)
+        return self.pool.map(func, iterable, chunksize)
 
     def imap(self, func, iterable, chunksize=1):
-        if self.n_processes == 1:
-            self._initializer(*self._initargs)
+        if self.pool is None:
+            self.initializer(*self.initargs)
             return map(func, iterable)
-        return mp.Pool.imap(self, func, iterable, chunksize)
+        return self.pool.imap(func, iterable, chunksize)
+
+    def __enter__(self, *args, **kwargs):
+        if self.pool is None:
+            return self
+        return self.pool.__enter__(*args, **kwargs)
+
+    def __exit__(self, *args, **kwargs):
+        if self.pool is None:
+            return None
+        return self.pool.__exit__(*args, **kwargs)


### PR DESCRIPTION
Windows does not have fork, so everything must be passed via the pickling interface.  Unfortunately, multiprocessing.Array cannot be sent across a non-fork boundary.  Therefore, we are temporarily disabling multiprocessing.Pool on Windows entirely.  This requires starfish.multiprocessing.pool.Pool to not inherit, and only start up a true multiprocessing.Pool object when it's safe to.

Test plan: `make fast` on Mac, `pytest starfish/test/image/test_apply.py` on Windows.