### PR TITLE
Optimize dockerfile to reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,8 @@ USER starfish
 # Set up the initial conda environment
 COPY --chown=starfish:starfish environment.yml /src/environment.yml
 WORKDIR /src
-RUN conda env create -f environment.yml
+RUN conda env create -f environment.yml \
+    && conda clean -tipsy
 
 # Prepare for build
 COPY --chown=starfish:starfish . /src
@@ -51,7 +52,7 @@ RUN echo "source activate starfish" >> ~/.bashrc
 ENV PATH /home/starfish/.conda/envs/starfish/bin:$PATH
 
 # Build and configure for running
-RUN pip install -e . --ignore-installed
+RUN pip install -e . --ignore-installed --no-cache-dir
 
 env MPLBACKEND Agg
 ENTRYPOINT ["starfish"]


### PR DESCRIPTION
Performing cleanup with conda environment setup
and preventing pip package caching reduces docker
image size from ~3.6 GB down to 2.76 GB