### PR TITLE
Unpin matplotlib and squelch scary warning from napari

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,6 +1,6 @@
 click
 jsonschema
-matplotlib==2.1.2
+matplotlib
 numpy != 1.13.0
 pandas >= 0.23.4
 regional

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=install_requires,
     extras_require={
-        'napari': ['napari-gui==0.0.5.1', 'matplotlib==2.1.2'],
+        'napari': ['napari-gui==0.0.5.1'],
     },
     entry_points={
         'console_scripts': [

--- a/starfish/display/stack.py
+++ b/starfish/display/stack.py
@@ -189,8 +189,10 @@ def stack(
         Axes.ZPLANE.value
     ).values
 
-    # display the imagestack using napari
-    viewer = napari_gui.imshow(reordered_array, multichannel=False)
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', module='vispy.visuals.isocurve', lineno=22)
+        # display the imagestack using napari
+        viewer = napari_gui.imshow(reordered_array, multichannel=False)
     viewer._index = [0, 0, 0, 0, 0]  # initialize napari status bar
 
     if spots is not None:


### PR DESCRIPTION
@kne42 says that we don't need to keep matplotlib pinned any more.  We just might want to kill the potentially scary warning from napari.

Depends on #997

Test plan:
```
In [1]: import starfish.data

In [2]: exp = starfish.data.ISS(use_test_data=True)

In [3]: img = exp['fov_001']['primary']
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 16/16 [00:00<00:00, 256.35it/s]

In [4]: import starfish.display.stack

In [5]: starfish.display.stack(img)
Out[5]: <napari_gui.elements._viewer.Viewer at 0x13634fda0>
```