### PR TITLE
RTD: use new requirements files

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,8 +1,9 @@
+version: 2
 build:
     image: latest
 
 python:
     version: 3.6
-
-requirements_file: 
-    null
+    install:
+        - requirements: REQUIREMENTS-CI.txt
+        - requirements: REQUIREMENTS-STRICT.txt


### PR DESCRIPTION
The sphinx_bootstrap_theme requirement is now in a second file.
RTD v1 only supports a single requirements file (which was
previously auto-detected). With v2 both `CI` and `STRICT` can
be referenced.

see:
 - https://github.com/spacetx/starfish/pull/997
 - https://readthedocs.org/projects/spacetx-starfish/builds/8570377/
 - https://docs.readthedocs.io/en/stable/config-file/v2.html#migrating-from-v1