### PR TITLE
Fix exit code of `starfish validate xarray`

### DIFF
--- a/sptx_format/cli.py
+++ b/sptx_format/cli.py
@@ -77,9 +77,10 @@ def xarray(ctx, file):
         else:
             print("Unknown xarray output format!")
             ctx.exit(1)
-        ctx.exit(0)
     except KeyboardInterrupt:
         ctx.exit(3)
     except Exception as e:
         print(f"Invalid xarray: {e}")
         ctx.exit(1)
+    else:
+        ctx.exit(0)


### PR DESCRIPTION
ctx.exit(0) works by raising an exception, which is caught and reraised as a ctx.exit(1).

This moves the ctx.exit(0) into an else clause.