### PR TITLE
[easy] Reduce the reinstalling of packages on travis runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ help-integration:
 #
 install-dev:
 	pip install --force-reinstall --upgrade -r REQUIREMENTS-STRICT.txt
-	pip install --force-reinstall --upgrade -e .
+	pip install -e .
 	pip install -r REQUIREMENTS-CI.txt
 	pip freeze
 


### PR DESCRIPTION
We just ran `--force-reinstall --upgrade`.  We shouldn't need to again.