### PR TITLE
[EASY] docs: fix automodule for expression_matrix

### DIFF
--- a/docs/source/api/core_objects/expression_matrix.rst
+++ b/docs/source/api/core_objects/expression_matrix.rst
@@ -7,5 +7,5 @@ Expression Matrix is a wrapper for xarray.DataArray that provides serialization 
 loom, and AnnData to enable it to be used with single-cell analysis software packages such as
 scanpy (python) and seurat (R).
 
-.. automodule:: starfish.expression_matrix.expression_matrix.ExpressionMatrix
+.. automodule:: starfish.expression_matrix.expression_matrix
    :members:


### PR DESCRIPTION
Don't _think_ this was leading to the wider RTD errors, but locally it failed `make docs-html` for me.