### PR TITLE
Bump PyYAML to 4.2b4

### DIFF
--- a/REQUIREMENTS-STRICT.txt
+++ b/REQUIREMENTS-STRICT.txt
@@ -46,7 +46,7 @@ pyparsing==2.3.1
 python-dateutil==2.8.0
 pytz==2018.9
 PyWavelets==1.0.1
-PyYAML==4.2b1
+PyYAML==4.2b4
 pyzmq==17.1.2
 regional==1.1.2
 requests==2.21.0


### PR DESCRIPTION
Other dependencies in the graph (like tornado) pull in a newer
version of PyYAML which then gets deleted leading to:

```
FoundError: [Errno 2] No such file or directory:
'/home/docs/checkouts/readthedocs.org/user_builds/
  spacetx-starfish/envs/latest/lib/python3.6/site-packages/
  PyYAML-4.2b4-py3.6-linux-x86_64.egg'
```

in https://readthedocs.org/projects/spacetx-starfish/builds/8578793/