### PR TITLE
Fix regionprops call to skimage

### DIFF
--- a/starfish/spots/_detector/local_max_peak_finder.py
+++ b/starfish/spots/_detector/local_max_peak_finder.py
@@ -225,7 +225,7 @@ class LocalMaxPeakFinder(SpotFinderAlgorithmBase):
         # identify each spot's size by binarizing and calculating regionprops
         masked_image = data_image[:, :] > self.threshold
         labels = label(masked_image)[0]
-        spot_props = regionprops(labels)
+        spot_props = regionprops(np.squeeze(labels))
 
         # mask spots whose areas are too small or too large
         for spot_prop in spot_props:
@@ -234,7 +234,7 @@ class LocalMaxPeakFinder(SpotFinderAlgorithmBase):
 
         # store re-calculated regionprops and labels based on the area-masked image
         self._labels = label(masked_image)[0]
-        self._spot_props = regionprops(self._labels)
+        self._spot_props = regionprops(np.squeeze(self._labels))
 
         if self.verbose:
             print('computing final spots ...')

--- a/starfish/test/spots/detector/pixel_spot_detector/combine_adjacent_features/test_create_spot_attributes.py
+++ b/starfish/test/spots/detector/pixel_spot_detector/combine_adjacent_features/test_create_spot_attributes.py
@@ -20,7 +20,7 @@ def test_create_spot_attributes():
     """
     # make some fixtures
     intensity_table, label_image, decoded_image = labeled_intensities_factory()
-    region_properties = regionprops(label_image)
+    region_properties = regionprops(np.squeeze(label_image))
     target_map = TargetsMap(np.array(list('abcdef')))
     caf = CombineAdjacentFeatures(min_area=1, max_area=3, connectivity=2)
     spot_attributes, passes_filters = caf._create_spot_attributes(


### PR DESCRIPTION
scikit-image in 0.14.2 no longer removes singleton dimensions.  This broke starfish when used with that version of scikit-image.  See http://scikit-image.org/docs/0.14.x/release_notes_and_installation.html#api-changes and https://github.com/scikit-image/scikit-image/pull/3284

Test plan: `pip install -r REQUIREMENTS-STRICT.txt && python notebooks/py/osmFISH.py`