### PR TITLE
add 3d spot display and ability to visually mask failing spots

### DIFF
--- a/REQUIREMENTS-STRICT.txt
+++ b/REQUIREMENTS-STRICT.txt
@@ -26,6 +26,7 @@ MarkupSafe==1.1.0
 matplotlib==2.1.2
 mistune==0.8.4
 mpmath==1.1.0
+git+https://github.com/napari/napari-gui.git@master
 nbconvert==5.4.1
 nbformat==4.4.0
 networkx==2.2
@@ -50,7 +51,7 @@ PyYAML==4.2b4
 pyzmq==17.1.2
 regional==1.1.2
 requests==2.21.0
-scikit-image==0.14.2
+git+https://github.com/scikit-image/scikit-image.git@master
 scikit-learn==0.20.2
 scipy==1.2.1
 semantic-version==2.6.0

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,12 +1,13 @@
 click
 jsonschema
 matplotlib
+git+https://github.com/napari/napari-gui.git@master
 numpy != 1.13.0
 pandas >= 0.23.4
 regional
 semantic_version
 scikit-image>=0.14.0
-scikit-learn
+git+https://github.com/scikit-image/scikit-image.git@master
 scipy
 showit >= 1.1.4
 slicedimage == 1.0.4


### PR DESCRIPTION
Ignore installation strategy for now, which fails on Travis and is blocked by solution to #932 

- Moves napari to a core dependency
- Add n-dimensional markers which enables visualization of spots across Z. Dramatically improves the visual salience of spots, as before the spots would be visible across ~5 z-planes, but the marker would only appear at the point of highest intensity. 
- Refactor marker plotting into `_plot_markers` to support the below functionality
- Enable additional sets of spots to be passed beyond the first array. These spots can be contrast colored to enable A/B comparison of spots that successfully decode and spots that do not, or to identify autofluorescence that is decoded separately. If the zero-color for the image colormap is passed as the color for these markers, the spots will _mask_ the failing spots, making it very clear which spots have been decoded, and which are not explained under current spot-calling strategies, leading to fast iteration on choosing the correct spots. 