### PR TITLE
Imagestack.transform executes applied function on xarray objects instead of numpy arrays

### DIFF
--- a/starfish/image/_filter/bandpass.py
+++ b/starfish/image/_filter/bandpass.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 import xarray as xr
@@ -47,13 +47,14 @@ class Bandpass(FilterAlgorithmBase):
 
     @staticmethod
     def _bandpass(
-            image: xr.DataArray, lshort: Number, llong: int, threshold: Number, truncate: Number
+            image: Union[xr.DataArray, np.ndarray],
+            lshort: Number, llong: int, threshold: Number, truncate: Number
     ) -> np.ndarray:
         """Apply a bandpass filter to remove noise and background variation
 
         Parameters
         ----------
-        image : np.ndarray
+        image : Union[xr.DataArray, np.ndarray]
         lshort : float
             filter frequencies below this value
         llong : int

--- a/starfish/image/_filter/bandpass.py
+++ b/starfish/image/_filter/bandpass.py
@@ -2,6 +2,7 @@ from functools import partial
 from typing import Optional
 
 import numpy as np
+import xarray as xr
 from trackpy import bandpass
 
 from starfish.imagestack.imagestack import ImageStack
@@ -46,7 +47,7 @@ class Bandpass(FilterAlgorithmBase):
 
     @staticmethod
     def _bandpass(
-            image: np.ndarray, lshort: Number, llong: int, threshold: Number, truncate: Number
+            image: xr.DataArray, lshort: Number, llong: int, threshold: Number, truncate: Number
     ) -> np.ndarray:
         """Apply a bandpass filter to remove noise and background variation
 
@@ -69,7 +70,7 @@ class Bandpass(FilterAlgorithmBase):
             bandpassed image
 
         """
-        bandpassed: np.ndarray = bandpass(
+        bandpassed = bandpass(
             image, lshort=lshort, llong=llong, threshold=threshold,
             truncate=truncate
         )

--- a/starfish/image/_filter/clip.py
+++ b/starfish/image/_filter/clip.py
@@ -1,7 +1,8 @@
 from functools import partial
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
+import xarray as xr
 
 from starfish.imagestack.imagestack import ImageStack
 from starfish.util import click
@@ -30,12 +31,12 @@ class Clip(FilterAlgorithmBase):
     _DEFAULT_TESTING_PARAMETERS = {"p_min": 0, "p_max": 100}
 
     @staticmethod
-    def _clip(image: np.ndarray, p_min: int, p_max: int) -> np.ndarray:
+    def _clip(image: Union[xr.DataArray, np.ndarray], p_min: int, p_max: int) -> np.ndarray:
         """Clip values of img below and above percentiles p_min and p_max
 
         Parameters
         ----------
-        image : np.ndarray
+        image : Union[xr.DataArray, np.ndarray]
             image to be clipped
         p_min : int
           values below this percentile are set to the value of this percentile

--- a/starfish/image/_filter/gaussian_high_pass.py
+++ b/starfish/image/_filter/gaussian_high_pass.py
@@ -48,7 +48,7 @@ class GaussianHighPass(FilterAlgorithmBase):
 
         Parameters
         ----------
-        image : numpy.ndarray[np.float32]
+        image : Union[xr.DataArray, np.ndarray]
             2-d or 3-d image data
         sigma : Union[Number, Tuple[Number]]
             Standard deviation of gaussian kernel

--- a/starfish/image/_filter/gaussian_low_pass.py
+++ b/starfish/image/_filter/gaussian_low_pass.py
@@ -2,6 +2,7 @@ from functools import partial
 from typing import Callable, Optional, Tuple, Union
 
 import numpy as np
+import xarray as xr
 from skimage.filters import gaussian
 
 from starfish.imagestack.imagestack import ImageStack
@@ -37,7 +38,7 @@ class GaussianLowPass(FilterAlgorithmBase):
 
     @staticmethod
     def _low_pass(
-            image: np.ndarray,
+            image: Union[xr.DataArray, np.ndarray],
             sigma: Union[Number, Tuple[Number]],
             rescale: bool=False
     ) -> np.ndarray:
@@ -46,7 +47,7 @@ class GaussianLowPass(FilterAlgorithmBase):
 
         Parameters
         ----------
-        image : np.ndarray[np.float32]
+        image : Union[xr.DataArray, np.ndarray]
             2-d or 3-d image data
         sigma : Union[Number, Tuple[Number]]
             Standard deviation of the Gaussian kernel that will be applied. If a float, an

--- a/starfish/image/_filter/laplace.py
+++ b/starfish/image/_filter/laplace.py
@@ -3,6 +3,7 @@ from functools import partial
 from typing import Callable, Optional, Tuple, Union
 
 import numpy as np
+import xarray as xr
 from scipy.ndimage import gaussian_laplace
 
 from starfish.image._filter._base import FilterAlgorithmBase
@@ -81,8 +82,10 @@ class Laplace(FilterAlgorithmBase):
     _DEFAULT_TESTING_PARAMETERS = {"sigma": 0.5}
 
     @staticmethod
-    def _gaussian_laplace(image: np.ndarray, sigma: Union[Number, Tuple[Number]],
-                          mode: str = 'reflect', cval: float = 0.0) -> np.ndarray:
+    def _gaussian_laplace(
+        image: Union[xr.DataArray, np.ndarray], sigma: Union[Number, Tuple[Number]],
+        mode: str = 'reflect', cval: float = 0.0
+    ) -> np.ndarray:
         filtered = gaussian_laplace(
             image, sigma=sigma, mode=mode, cval=cval)
 

--- a/starfish/image/_filter/mean_high_pass.py
+++ b/starfish/image/_filter/mean_high_pass.py
@@ -2,6 +2,7 @@ from functools import partial
 from typing import Callable, Optional, Tuple, Union
 
 import numpy as np
+import xarray as xr
 from scipy.ndimage.filters import uniform_filter
 
 from starfish.imagestack.imagestack import ImageStack
@@ -44,13 +45,15 @@ class MeanHighPass(FilterAlgorithmBase):
     _DEFAULT_TESTING_PARAMETERS = {"size": 1}
 
     @staticmethod
-    def _high_pass(image: np.ndarray, size: Number, rescale: bool=False) -> np.ndarray:
+    def _high_pass(
+        image: Union[xr.DataArray, np.ndarray], size: Number, rescale: bool=False
+    ) -> np.ndarray:
         """
         Applies a mean high pass filter to an image
 
         Parameters
         ----------
-        image : numpy.ndarray[np.float32]
+        image : Union[xr.DataArray, numpy.ndarray]
             2-d or 3-d image data
         size : Union[Number, Tuple[Number]]
             width of the kernel
@@ -59,7 +62,7 @@ class MeanHighPass(FilterAlgorithmBase):
 
         Returns
         -------
-        np.ndarray [np.float32]:
+        np.ndarray[np.float32]:
             Filtered image, same shape as input
         """
 

--- a/starfish/image/_filter/richardson_lucy_deconvolution.py
+++ b/starfish/image/_filter/richardson_lucy_deconvolution.py
@@ -1,7 +1,8 @@
 from functools import partial
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
+import xarray as xr
 from scipy.signal import convolve, fftconvolve
 
 from starfish.imagestack.imagestack import ImageStack
@@ -52,13 +53,14 @@ class DeconvolvePSF(FilterAlgorithmBase):
     # and the results look bad. #548 addresses this problem.
     @staticmethod
     def _richardson_lucy_deconv(
-            image: np.ndarray, iterations: int, psf: np.ndarray, clip: bool) -> np.ndarray:
+            image: Union[xr.DataArray, np.ndarray], iterations: int, psf: np.ndarray, clip: bool
+    ) -> np.ndarray:
         """
         Deconvolves input image with a specified point spread function.
 
         Parameters
         ----------
-        image : ndarray
+        image : Union[xr.DataArray, np.ndarray]
            Input degraded image (can be N dimensional).
         psf : ndarray
            The point spread function.

--- a/starfish/image/_filter/scale_by_percentile.py
+++ b/starfish/image/_filter/scale_by_percentile.py
@@ -1,7 +1,8 @@
 from functools import partial
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
+import xarray as xr
 
 from starfish.imagestack.imagestack import ImageStack
 from starfish.util import click
@@ -27,12 +28,12 @@ class ScaleByPercentile(FilterAlgorithmBase):
     _DEFAULT_TESTING_PARAMETERS = {"p": 0}
 
     @staticmethod
-    def _scale(image: np.ndarray, p: int) -> np.ndarray:
+    def _scale(image: Union[xr.DataArray, np.ndarray], p: int) -> np.ndarray:
         """Clip values of img below and above percentiles p_min and p_max
 
         Parameters
         ----------
-        image : np.ndarray
+        image : Union[xr.DataArray, np.ndarray
             image to be scaled
 
         p : int

--- a/starfish/image/_filter/util.py
+++ b/starfish/image/_filter/util.py
@@ -133,17 +133,19 @@ def preserve_float_range(
 
     """
     array = array.copy()
+
     if isinstance(array, xr.DataArray):
         data = array.values
     else:
         data = array
+
     if np.any(data < 0):
-        data[array < 0] = 0
-    if np.any(array > 1):
+        data[data < 0] = 0
+    if np.any(data > 1):
         if rescale:
             data /= data.max()
         else:
-            data[array > 1] = 1
+            data[data > 1] = 1
     return array.astype(np.float32)
 
 

--- a/starfish/image/_filter/white_tophat.py
+++ b/starfish/image/_filter/white_tophat.py
@@ -1,6 +1,7 @@
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
+import xarray as xr
 from skimage.morphology import ball, disk, white_tophat
 
 from starfish.imagestack.imagestack import ImageStack
@@ -38,7 +39,7 @@ class WhiteTophat(FilterAlgorithmBase):
 
     _DEFAULT_TESTING_PARAMETERS = {"masking_radius": 3}
 
-    def _white_tophat(self, image: np.ndarray) -> np.ndarray:
+    def _white_tophat(self, image: Union[xr.DataArray, np.ndarray]) -> np.ndarray:
         if self.is_volume:
             structuring_element = ball(self.masking_radius)
         else:

--- a/starfish/spots/_detector/detect.py
+++ b/starfish/spots/_detector/detect.py
@@ -226,8 +226,8 @@ def detect_spots(data_stack: ImageStack,
         )
 
     if reference_image_from_max_projection:
-        reference_image = data_stack.max_proj(Axes.CH, Axes.ROUND)
-        reference_image = reference_image._squeezed_numpy(Axes.CH, Axes.ROUND)
+        reference_image = data_stack.max_proj(Axes.CH, Axes.ROUND).xarray.squeeze()
+        # reference_image = reference_image._squeezed_numpy(Axes.CH, Axes.ROUND)
 
     group_by = {Axes.ROUND, Axes.CH}
 

--- a/starfish/spots/_detector/local_max_peak_finder.py
+++ b/starfish/spots/_detector/local_max_peak_finder.py
@@ -205,7 +205,7 @@ class LocalMaxPeakFinder(SpotFinderAlgorithmBase):
         threshold = self._select_optimal_threshold(thresholds, spot_counts)
         return threshold
 
-    def image_to_spots(self, data_image: Union[np.ndarray, xr.DataArray]) -> SpotAttributes:
+    def image_to_spots(self, data_image: xr.DataArray) -> SpotAttributes:
         """measure attributes of spots detected by binarizing the image using the selected threshold
 
         Parameters
@@ -221,6 +221,9 @@ class LocalMaxPeakFinder(SpotFinderAlgorithmBase):
 
         if self.threshold is None:
             self.threshold = self._compute_threshold(data_image)
+
+        if isinstance(data_image, xr.DataArray):
+            data_image = data_image.values
 
         # identify each spot's size by binarizing and calculating regionprops
         masked_image = data_image[:, :] > self.threshold

--- a/starfish/spots/_detector/trackpy_local_max_peak_finder.py
+++ b/starfish/spots/_detector/trackpy_local_max_peak_finder.py
@@ -99,6 +99,10 @@ class TrackpyLocalMaxPeakFinder(SpotFinderAlgorithmBase):
             spot attributes table for all detected spots
 
         """
+
+        if isinstance(image, xr.DataArray):
+            image = image.values
+
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', FutureWarning)  # trackpy numpy indexing warning
             warnings.simplefilter('ignore', UserWarning)  # yielded if black images


### PR DESCRIPTION
@kevinyamauchi pointed out in #987 and #983 that our apply method hampers our ability to write expressive `PipelineComponent`s because it returns numpy arrays instead of xarray DataArray objects. 

This PR:

1. Modifies `ImageStack.transform` so that methods used by `apply` can take advantage of `xarray` named axes. Because we are rebuilding an array from the `sharedmemory` object, this does not give us access to data stored in the coordinates. Thus, the returned arrays only guarantee that the Axes are in the correct order. If `is_volume` is True, xarrays generated by `ImageStack.transform` have dims = `(z, y, x)` and no coordinates. If `is_volume` is False, xarrays generated by `ImageStack.transform` have dims = `(y, x)` and no coordinates. These are set based on the information in `starfish.imagestack.dataorder.AXES_DATA`

2. Fixes a bug in `preserve_float_range`. That function has obviously never seen an `xarray` before. 😆 

3. Minor updates to `SpotFinder` methods to support receiving `xr.DataArray` objects

4. Updates to docstrings to reflect flexibility to receive `Union[xr.DataArray, np.ndarray]` images. 