### PR TITLE
Move preserve_float_range

### DIFF
--- a/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
+++ b/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
@@ -161,7 +161,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dpsf = Filter.DeconvolvePSF(num_iter=15, sigma=2, clip=True)\n",
+    "dpsf = Filter.DeconvolvePSF(num_iter=15, sigma=2)\n",
     "deconvolved = dpsf.run(high_passed, verbose=True, in_place=False)"
    ]
   },

--- a/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
+++ b/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
@@ -161,7 +161,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dpsf = Filter.DeconvolvePSF(num_iter=15, sigma=2)\n",
+    "dpsf = Filter.DeconvolvePSF(num_iter=15, sigma=2, clip_method=2)\n",
     "deconvolved = dpsf.run(high_passed, verbose=True, in_place=False)"
    ]
   },

--- a/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
+++ b/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
@@ -161,7 +161,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dpsf = Filter.DeconvolvePSF(num_iter=15, sigma=2, clip_method=2)\n",
+    "from starfish.types import Clip\n",
+    "dpsf = Filter.DeconvolvePSF(num_iter=15, sigma=2, clip_method=Clip.SCALE_BY_CHUNK)\n",
     "deconvolved = dpsf.run(high_passed, verbose=True, in_place=False)"
    ]
   },

--- a/notebooks/py/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
+++ b/notebooks/py/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
@@ -95,7 +95,8 @@ high_passed = ghp.run(primary_image, verbose=True, in_place=False)
 # EPY: END markdown
 
 # EPY: START code
-dpsf = Filter.DeconvolvePSF(num_iter=15, sigma=2, clip_method=2)
+from starfish.types import Clip
+dpsf = Filter.DeconvolvePSF(num_iter=15, sigma=2, clip_method=Clip.SCALE_BY_CHUNK)
 deconvolved = dpsf.run(high_passed, verbose=True, in_place=False)
 # EPY: END code
 

--- a/notebooks/py/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
+++ b/notebooks/py/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
@@ -95,7 +95,7 @@ high_passed = ghp.run(primary_image, verbose=True, in_place=False)
 # EPY: END markdown
 
 # EPY: START code
-dpsf = Filter.DeconvolvePSF(num_iter=15, sigma=2, clip=True)
+dpsf = Filter.DeconvolvePSF(num_iter=15, sigma=2)
 deconvolved = dpsf.run(high_passed, verbose=True, in_place=False)
 # EPY: END code
 

--- a/notebooks/py/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
+++ b/notebooks/py/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
@@ -95,7 +95,7 @@ high_passed = ghp.run(primary_image, verbose=True, in_place=False)
 # EPY: END markdown
 
 # EPY: START code
-dpsf = Filter.DeconvolvePSF(num_iter=15, sigma=2)
+dpsf = Filter.DeconvolvePSF(num_iter=15, sigma=2, clip_method=2)
 deconvolved = dpsf.run(high_passed, verbose=True, in_place=False)
 # EPY: END code
 

--- a/starfish/image/_filter/bandpass.py
+++ b/starfish/image/_filter/bandpass.py
@@ -9,7 +9,7 @@ from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Number
 from starfish.util import click
 from ._base import FilterAlgorithmBase
-from .util import determine_axes_to_group_by, preserve_float_range
+from .util import determine_axes_to_group_by
 
 
 class Bandpass(FilterAlgorithmBase):
@@ -75,7 +75,7 @@ class Bandpass(FilterAlgorithmBase):
             image, lshort=lshort, llong=llong, threshold=threshold,
             truncate=truncate
         )
-        return preserve_float_range(bandpassed)
+        return bandpassed
 
     def run(
             self, stack: ImageStack, in_place: bool = False, verbose: bool = False,

--- a/starfish/image/_filter/bandpass.py
+++ b/starfish/image/_filter/bandpass.py
@@ -140,7 +140,7 @@ class Bandpass(FilterAlgorithmBase):
         "--truncate", default=4, type=float,
         help="truncate the filter at this many standard deviations")
     @click.option(
-        "--clip-method", default=0, type=int,
+        "--clip-method", default=Clip.CLIP, type=Clip,
         help="method to constrain data to [0,1]. options: 'clip', 'scale_by_image', "
              "'scale_by_chunk'")
     @click.pass_context

--- a/starfish/image/_filter/bandpass.py
+++ b/starfish/image/_filter/bandpass.py
@@ -140,8 +140,8 @@ class Bandpass(FilterAlgorithmBase):
         help="truncate the filter at this many standard deviations")
     @click.option(
         "--clip-method", default=0, type=int,
-        help="method to constrain data to [0,1]. 0: clip, 1: scale by max per chunk, 2: scale "
-             "by max over whole ImageStack")
+        help="method to constrain data to [0,1]. 0: clip, 1: scale by max over whole image, "
+             "2: scale by max per chunk")
     @click.pass_context
     def _cli(ctx, lshort, llong, threshold, truncate, clip_method):
         ctx.obj["component"]._cli_run(

--- a/starfish/image/_filter/gaussian_high_pass.py
+++ b/starfish/image/_filter/gaussian_high_pass.py
@@ -6,7 +6,7 @@ import xarray as xr
 
 from starfish.image._filter.gaussian_low_pass import GaussianLowPass
 from starfish.imagestack.imagestack import ImageStack
-from starfish.types import Number
+from starfish.types import Clip, Number
 from starfish.util import click
 from starfish.util.dtype import preserve_float_range
 from ._base import FilterAlgorithmBase
@@ -19,7 +19,8 @@ from .util import (
 class GaussianHighPass(FilterAlgorithmBase):
 
     def __init__(
-            self, sigma: Union[Number, Tuple[Number]], is_volume: bool=False, clip_method: int=0
+        self, sigma: Union[Number, Tuple[Number]], is_volume: bool=False,
+        clip_method: Union[str, Clip]=Clip.CLIP
     ) -> None:
         """Gaussian high pass filter
 
@@ -30,15 +31,15 @@ class GaussianHighPass(FilterAlgorithmBase):
         is_volume : bool
             If True, 3d (z, y, x) volumes will be filtered, otherwise, filter 2d tiles
             independently.
-        clip_method : int
-            (Default 0) Controls the way that data are scaled to retain skimage dtype
+        clip_method : Union[str, Clip]
+            (Default Clip.CLIP) Controls the way that data are scaled to retain skimage dtype
             requirements that float data fall in [0, 1].
-            0: data above 1 are set to 1, and below 0 are set to 0
-            1: data above 1 are scaled by the maximum value, with the maximum value calculated
-               over the entire ImageStack
-            2: data above 1 are scaled by the maximum value, with the maximum value calculated
-               over each slice, where slice shapes are determined by the group_by parameters
-
+            Clip.CLIP: data above 1 are set to 1, and below 0 are set to 0
+            Clip.SCALE_BY_IMAGE: data above 1 are scaled by the maximum value, with the maximum
+                value calculated over the entire ImageStack
+            Clip.SCALE_BY_CHUNK: data above 1 are scaled by the maximum value, with the maximum
+                value calculated over each slice, where slice shapes are determined by the group_by
+                parameters
         """
         self.sigma = validate_and_broadcast_kernel_size(sigma, is_volume)
         self.is_volume = is_volume
@@ -116,8 +117,8 @@ class GaussianHighPass(FilterAlgorithmBase):
                   help="indicates that the image stack should be filtered in 3d")
     @click.option(
         "--clip-method", default=0, type=int,
-        help="method to constrain data to [0,1]. 0: clip, 1: scale by max over whole image, "
-             "2: scale by max per chunk")
+        help="method to constrain data to [0,1]. options: 'clip', 'scale_by_image', "
+             "'scale_by_chunk'")
     @click.pass_context
     def _cli(ctx, sigma, is_volume, clip_method):
         ctx.obj["component"]._cli_run(ctx, GaussianHighPass(sigma, is_volume, clip_method))

--- a/starfish/image/_filter/gaussian_high_pass.py
+++ b/starfish/image/_filter/gaussian_high_pass.py
@@ -116,8 +116,8 @@ class GaussianHighPass(FilterAlgorithmBase):
                   help="indicates that the image stack should be filtered in 3d")
     @click.option(
         "--clip-method", default=0, type=int,
-        help="method to constrain data to [0,1]. 0: clip, 1: scale by max per chunk, 2: scale "
-             "by max over whole ImageStack")
+        help="method to constrain data to [0,1]. 0: clip, 1: scale by max over whole image, "
+             "2: scale by max per chunk")
     @click.pass_context
     def _cli(ctx, sigma, is_volume, clip_method):
         ctx.obj["component"]._cli_run(ctx, GaussianHighPass(sigma, is_volume, clip_method))

--- a/starfish/image/_filter/gaussian_high_pass.py
+++ b/starfish/image/_filter/gaussian_high_pass.py
@@ -19,7 +19,7 @@ from .util import (
 class GaussianHighPass(FilterAlgorithmBase):
 
     def __init__(
-            self, sigma: Union[Number, Tuple[Number]], is_volume: bool=False,
+            self, sigma: Union[Number, Tuple[Number]], is_volume: bool=False, clip_method: int=0
     ) -> None:
         """Gaussian high pass filter
 
@@ -30,10 +30,19 @@ class GaussianHighPass(FilterAlgorithmBase):
         is_volume : bool
             If True, 3d (z, y, x) volumes will be filtered, otherwise, filter 2d tiles
             independently.
+        clip_method : int
+            (Default 0) Controls the way that data are scaled to retain skimage dtype
+            requirements that float data fall in [0, 1].
+            0: data above 1 are set to 1, and below 0 are set to 0
+            1: data above 1 are scaled by the maximum value, with the maximum value calculated
+               over the entire ImageStack
+            2: data above 1 are scaled by the maximum value, with the maximum value calculated
+               over each slice, where slice shapes are determined by the group_by parameters
 
         """
         self.sigma = validate_and_broadcast_kernel_size(sigma, is_volume)
         self.is_volume = is_volume
+        self.clip_method = clip_method
 
     _DEFAULT_TESTING_PARAMETERS = {"sigma": 3}
 
@@ -95,7 +104,8 @@ class GaussianHighPass(FilterAlgorithmBase):
         high_pass: Callable = partial(self._high_pass, sigma=self.sigma)
         result = stack.apply(
             high_pass,
-            group_by=group_by, verbose=verbose, in_place=in_place, n_processes=n_processes
+            group_by=group_by, verbose=verbose, in_place=in_place, n_processes=n_processes,
+            clip_method=self.clip_method
         )
         return result
 
@@ -104,6 +114,10 @@ class GaussianHighPass(FilterAlgorithmBase):
     @click.option("--sigma", type=float, help="standard deviation of gaussian kernel")
     @click.option("--is-volume", is_flag=True,
                   help="indicates that the image stack should be filtered in 3d")
+    @click.option(
+        "--clip-method", default=0, type=int,
+        help="method to constrain data to [0,1]. 0: clip, 1: scale by max per chunk, 2: scale "
+             "by max over whole ImageStack")
     @click.pass_context
-    def _cli(ctx, sigma, is_volume):
-        ctx.obj["component"]._cli_run(ctx, GaussianHighPass(sigma, is_volume))
+    def _cli(ctx, sigma, is_volume, clip_method):
+        ctx.obj["component"]._cli_run(ctx, GaussianHighPass(sigma, is_volume, clip_method))

--- a/starfish/image/_filter/gaussian_high_pass.py
+++ b/starfish/image/_filter/gaussian_high_pass.py
@@ -116,7 +116,7 @@ class GaussianHighPass(FilterAlgorithmBase):
     @click.option("--is-volume", is_flag=True,
                   help="indicates that the image stack should be filtered in 3d")
     @click.option(
-        "--clip-method", default=0, type=int,
+        "--clip-method", default=Clip.CLIP, type=Clip,
         help="method to constrain data to [0,1]. options: 'clip', 'scale_by_image', "
              "'scale_by_chunk'")
     @click.pass_context

--- a/starfish/image/_filter/gaussian_high_pass.py
+++ b/starfish/image/_filter/gaussian_high_pass.py
@@ -8,10 +8,10 @@ from starfish.image._filter.gaussian_low_pass import GaussianLowPass
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Number
 from starfish.util import click
+from starfish.util.dtype import preserve_float_range
 from ._base import FilterAlgorithmBase
 from .util import (
     determine_axes_to_group_by,
-    preserve_float_range,
     validate_and_broadcast_kernel_size,
 )
 

--- a/starfish/image/_filter/gaussian_low_pass.py
+++ b/starfish/image/_filter/gaussian_low_pass.py
@@ -8,10 +8,10 @@ from skimage.filters import gaussian
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Number
 from starfish.util import click
+from starfish.util.dtype import preserve_float_range
 from ._base import FilterAlgorithmBase
 from .util import (
     determine_axes_to_group_by,
-    preserve_float_range,
     validate_and_broadcast_kernel_size,
 )
 

--- a/starfish/image/_filter/gaussian_low_pass.py
+++ b/starfish/image/_filter/gaussian_low_pass.py
@@ -121,7 +121,7 @@ class GaussianLowPass(FilterAlgorithmBase):
     @click.option("--is-volume", is_flag=True,
                   help="indicates that the image stack should be filtered in 3d")
     @click.option(
-        "--clip-method", default=0, type=int,
+        "--clip-method", default=Clip.CLIP, type=Clip,
         help="method to constrain data to [0,1]. options: 'clip', 'scale_by_image', "
              "'scale_by_chunk'")
     @click.pass_context

--- a/starfish/image/_filter/gaussian_low_pass.py
+++ b/starfish/image/_filter/gaussian_low_pass.py
@@ -6,7 +6,7 @@ import xarray as xr
 from skimage.filters import gaussian
 
 from starfish.imagestack.imagestack import ImageStack
-from starfish.types import Number
+from starfish.types import Clip, Number
 from starfish.util import click
 from starfish.util.dtype import preserve_float_range
 from ._base import FilterAlgorithmBase
@@ -19,7 +19,8 @@ from .util import (
 class GaussianLowPass(FilterAlgorithmBase):
 
     def __init__(
-            self, sigma: Union[Number, Tuple[Number]], is_volume: bool=False, clip_method: int=0
+        self, sigma: Union[Number, Tuple[Number]], is_volume: bool=False,
+        clip_method: Union[str, Clip]=Clip.CLIP
     ) -> None:
         """Multi-dimensional low-pass gaussian filter.
 
@@ -30,15 +31,15 @@ class GaussianLowPass(FilterAlgorithmBase):
         is_volume : bool
             If True, 3d (z, y, x) volumes will be filtered, otherwise, filter 2d tiles
             independently.
-        clip_method : int
-            (Default 0) Controls the way that data are scaled to retain skimage dtype
+        clip_method : Union[str, Clip]
+            (Default Clip.CLIP) Controls the way that data are scaled to retain skimage dtype
             requirements that float data fall in [0, 1].
-            0: data above 1 are set to 1, and below 0 are set to 0
-            1: data above 1 are scaled by the maximum value, with the maximum value calculated
-               over the entire ImageStack
-            2: data above 1 are scaled by the maximum value, with the maximum value calculated
-               over each slice, where slice shapes are determined by the group_by parameters
-
+            Clip.CLIP: data above 1 are set to 1, and below 0 are set to 0
+            Clip.SCALE_BY_IMAGE: data above 1 are scaled by the maximum value, with the maximum
+                value calculated over the entire ImageStack
+            Clip.SCALE_BY_CHUNK: data above 1 are scaled by the maximum value, with the maximum
+                value calculated over each slice, where slice shapes are determined by the group_by
+                parameters
         """
         self.sigma = validate_and_broadcast_kernel_size(sigma, is_volume)
         self.is_volume = is_volume
@@ -121,8 +122,8 @@ class GaussianLowPass(FilterAlgorithmBase):
                   help="indicates that the image stack should be filtered in 3d")
     @click.option(
         "--clip-method", default=0, type=int,
-        help="method to constrain data to [0,1]. 0: clip, 1: scale by max over whole image, "
-             "2: scale by max per chunk")
+        help="method to constrain data to [0,1]. options: 'clip', 'scale_by_image', "
+             "'scale_by_chunk'")
     @click.pass_context
     def _cli(ctx, sigma, is_volume, clip_method):
         ctx.obj["component"]._cli_run(ctx, GaussianLowPass(sigma, is_volume, clip_method))

--- a/starfish/image/_filter/gaussian_low_pass.py
+++ b/starfish/image/_filter/gaussian_low_pass.py
@@ -121,8 +121,8 @@ class GaussianLowPass(FilterAlgorithmBase):
                   help="indicates that the image stack should be filtered in 3d")
     @click.option(
         "--clip-method", default=0, type=int,
-        help="method to constrain data to [0,1]. 0: clip, 1: scale by max per chunk, 2: scale "
-             "by max over whole ImageStack")
+        help="method to constrain data to [0,1]. 0: clip, 1: scale by max over whole image, "
+             "2: scale by max per chunk")
     @click.pass_context
     def _cli(ctx, sigma, is_volume, clip_method):
         ctx.obj["component"]._cli_run(ctx, GaussianLowPass(sigma, is_volume, clip_method))

--- a/starfish/image/_filter/laplace.py
+++ b/starfish/image/_filter/laplace.py
@@ -130,7 +130,7 @@ class Laplace(FilterAlgorithmBase):
         "--is-volume", is_flag=True,
         help="indicates that the image stack should be filtered in 3d")
     @click.option(
-        "--clip-method", default=0, type=int,
+        "--clip-method", default=Clip.CLIP, type=Clip,
         help="method to constrain data to [0,1]. options: 'clip', 'scale_by_image', "
              "'scale_by_chunk'")
     @click.pass_context

--- a/starfish/image/_filter/laplace.py
+++ b/starfish/image/_filter/laplace.py
@@ -9,7 +9,6 @@ from scipy.ndimage import gaussian_laplace
 from starfish.image._filter._base import FilterAlgorithmBase
 from starfish.image._filter.util import (
     determine_axes_to_group_by,
-    preserve_float_range,
     validate_and_broadcast_kernel_size,
 )
 from starfish.imagestack.imagestack import ImageStack
@@ -90,7 +89,6 @@ class Laplace(FilterAlgorithmBase):
             image, sigma=sigma, mode=mode, cval=cval)
 
         filtered = -filtered  # the peaks are negative so invert the signal
-        filtered = preserve_float_range(filtered)
 
         return filtered
 

--- a/starfish/image/_filter/laplace.py
+++ b/starfish/image/_filter/laplace.py
@@ -130,8 +130,8 @@ class Laplace(FilterAlgorithmBase):
         help="indicates that the image stack should be filtered in 3d")
     @click.option(
         "--clip-method", default=0, type=int,
-        help="method to constrain data to [0,1]. 0: clip, 1: scale by max per chunk, 2: scale "
-             "by max over whole ImageStack")
+        help="method to constrain data to [0,1]. 0: clip, 1: scale by max over whole image, "
+             "2: scale by max per chunk")
     @click.pass_context
     def _cli(ctx, sigma, mode, cval, is_volume, clip_method):
         ctx.obj["component"]._cli_run(ctx, Laplace(sigma, mode, cval, is_volume, clip_method))

--- a/starfish/image/_filter/mean_high_pass.py
+++ b/starfish/image/_filter/mean_high_pass.py
@@ -118,8 +118,8 @@ class MeanHighPass(FilterAlgorithmBase):
         help="indicates that the image stack should be filtered in 3d")
     @click.option(
         "--clip-method", default=0, type=int,
-        help="method to constrain data to [0,1]. 0: clip, 1: scale by max per chunk, 2: scale "
-             "by max over whole ImageStack")
+        help="method to constrain data to [0,1]. 0: clip, 1: scale by max over whole image, "
+             "2: scale by max per chunk")
     @click.pass_context
     def _cli(ctx, size, is_volume, clip_method):
         ctx.obj["component"]._cli_run(ctx, MeanHighPass(size, is_volume, clip_method))

--- a/starfish/image/_filter/mean_high_pass.py
+++ b/starfish/image/_filter/mean_high_pass.py
@@ -8,9 +8,10 @@ from scipy.ndimage.filters import uniform_filter
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Number
 from starfish.util import click
+from starfish.util.dtype import preserve_float_range
 from ._base import FilterAlgorithmBase
 from .util import (
-    determine_axes_to_group_by, preserve_float_range, validate_and_broadcast_kernel_size
+    determine_axes_to_group_by, validate_and_broadcast_kernel_size
 )
 
 

--- a/starfish/image/_filter/mean_high_pass.py
+++ b/starfish/image/_filter/mean_high_pass.py
@@ -126,7 +126,7 @@ class MeanHighPass(FilterAlgorithmBase):
         "--is-volume", is_flag=True,
         help="indicates that the image stack should be filtered in 3d")
     @click.option(
-        "--clip-method", default=0, type=int,
+        "--clip-method", default=Clip.CLIP, type=Clip,
         help="method to constrain data to [0,1]. options: 'clip', 'scale_by_image', "
              "'scale_by_chunk'")
     @click.pass_context

--- a/starfish/image/_filter/richardson_lucy_deconvolution.py
+++ b/starfish/image/_filter/richardson_lucy_deconvolution.py
@@ -8,7 +8,6 @@ from scipy.signal import convolve, fftconvolve
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Number
 from starfish.util import click
-from starfish.util.dtype import preserve_float_range
 from ._base import FilterAlgorithmBase
 from .util import (
     determine_axes_to_group_by,
@@ -19,7 +18,7 @@ from .util import (
 class DeconvolvePSF(FilterAlgorithmBase):
 
     def __init__(
-        self, num_iter: int, sigma: Number, is_volume: bool = False, clip_method: int=1
+        self, num_iter: int, sigma: Number, is_volume: bool = False, clip_method: int=0
     ) -> None:
         """Deconvolve a point spread function
 
@@ -182,9 +181,9 @@ class DeconvolvePSF(FilterAlgorithmBase):
     @click.option("--is-volume", is_flag=True,
                   help="indicates that the image stack should be filtered in 3d")
     @click.option(
-        "--clip-method", default=1, type=int,
-        help="method to constrain data to [0,1]. 0: clip, 1: scale by max per chunk, 2: scale "
-             "by max over whole ImageStack")
+        "--clip-method", default=0, type=int,
+        help="method to constrain data to [0,1]. 0: clip, 1: scale by max over whole image, "
+             "2: scale by max per chunk")
     @click.pass_context
     def _cli(ctx, num_iter, sigma, is_volume, clip_method):
         ctx.obj["component"]._cli_run(ctx, DeconvolvePSF(num_iter, sigma, is_volume, clip_method))

--- a/starfish/image/_filter/richardson_lucy_deconvolution.py
+++ b/starfish/image/_filter/richardson_lucy_deconvolution.py
@@ -183,7 +183,7 @@ class DeconvolvePSF(FilterAlgorithmBase):
     @click.option("--is-volume", is_flag=True,
                   help="indicates that the image stack should be filtered in 3d")
     @click.option(
-        "--clip-method", default=0, type=int,
+        "--clip-method", default=Clip.CLIP, type=Clip,
         help="method to constrain data to [0,1]. options: 'clip', 'scale_by_image', "
              "'scale_by_chunk'")
     @click.pass_context

--- a/starfish/image/_filter/scale_by_percentile.py
+++ b/starfish/image/_filter/scale_by_percentile.py
@@ -109,7 +109,7 @@ class ScaleByPercentile(FilterAlgorithmBase):
     @click.option(  # FIXME: was this intentionally missed?
         "--is-volume", is_flag=True, help="filter 3D volumes")
     @click.option(
-        "--clip-method", default=0, type=int,
+        "--clip-method", default=Clip.CLIP, type=Clip,
         help="method to constrain data to [0,1]. options: 'clip', 'scale_by_image', "
              "'scale_by_chunk'")
     @click.pass_context

--- a/starfish/image/_filter/scale_by_percentile.py
+++ b/starfish/image/_filter/scale_by_percentile.py
@@ -44,7 +44,6 @@ class ScaleByPercentile(FilterAlgorithmBase):
         ----------
         image : Union[xr.DataArray, np.ndarray
             image to be scaled
-
         p : int
             each image in the stack is scaled by this percentile. must be in [0, 100]
 
@@ -106,8 +105,8 @@ class ScaleByPercentile(FilterAlgorithmBase):
         "--is-volume", is_flag=True, help="filter 3D volumes")
     @click.option(
         "--clip-method", default=0, type=int,
-        help="method to constrain data to [0,1]. 0: clip, 1: scale by max per chunk, 2: scale "
-             "by max over whole ImageStack")
+        help="method to constrain data to [0,1]. 0: clip, 1: scale by max over whole image, "
+             "2: scale by max per chunk")
     @click.pass_context
     def _cli(ctx, p, is_volume, clip_method):
         ctx.obj["component"]._cli_run(ctx, ScaleByPercentile(p, is_volume, clip_method))

--- a/starfish/image/_filter/scale_by_percentile.py
+++ b/starfish/image/_filter/scale_by_percentile.py
@@ -7,7 +7,7 @@ import xarray as xr
 from starfish.imagestack.imagestack import ImageStack
 from starfish.util import click
 from ._base import FilterAlgorithmBase
-from .util import determine_axes_to_group_by, preserve_float_range
+from .util import determine_axes_to_group_by
 
 
 class ScaleByPercentile(FilterAlgorithmBase):
@@ -53,7 +53,6 @@ class ScaleByPercentile(FilterAlgorithmBase):
         v = np.percentile(image, p)
 
         image = image / v
-        image = preserve_float_range(image)
 
         return image
 

--- a/starfish/image/_filter/util.py
+++ b/starfish/image/_filter/util.py
@@ -1,7 +1,6 @@
 from typing import Set, Tuple, Union
 
 import numpy as np
-import xarray as xr
 from skimage.morphology import binary_opening, disk
 
 from starfish.types import Axes, Number
@@ -109,41 +108,6 @@ def validate_and_broadcast_kernel_size(
             valid_sigma = (sigma,) * 2
 
     return valid_sigma
-
-
-def preserve_float_range(
-        array: Union[xr.DataArray, np.ndarray],
-        rescale: bool=False) -> Union[xr.DataArray, np.ndarray]:
-    """
-    Clips values below zero to zero. If values above one are detected, clips them
-    to 1 unless `rescale` is True, in which case the input is scaled by
-    the max value and the dynamic range is preserved.
-
-    Parameters
-    ----------
-    array : Union[xr.DataArray, np.ndarray]
-        Array whose values should be in the interval [0, 1] but may not be.
-    rescale: bool
-        If true, scale values by the max.
-
-    Returns
-    -------
-    array : Union[xr.DataArray, np.ndarray]
-        Array whose values are in the interval [0, 1].
-
-    """
-    array = array.copy()
-
-    data = np.asarray(array)
-
-    if np.any(data < 0):
-        data[data < 0] = 0
-    if np.any(data > 1):
-        if rescale:
-            data /= data.max()
-        else:
-            data[data > 1] = 1
-    return array.astype(np.float32)
 
 
 def determine_axes_to_group_by(is_volume: bool) -> Set[Axes]:

--- a/starfish/image/_filter/white_tophat.py
+++ b/starfish/image/_filter/white_tophat.py
@@ -98,7 +98,7 @@ class WhiteTophat(FilterAlgorithmBase):
     @click.option(  # FIXME: was this intentionally missed?
         "--is-volume", is_flag=True, help="filter 3D volumes")
     @click.option(
-        "--clip-method", default=0, type=int,
+        "--clip-method", default=Clip.CLIP, type=Clip,
         help="method to constrain data to [0,1]. options: 'clip', 'scale_by_image', "
              "'scale_by_chunk'")
     @click.pass_context

--- a/starfish/image/_filter/white_tophat.py
+++ b/starfish/image/_filter/white_tophat.py
@@ -20,7 +20,7 @@ class WhiteTophat(FilterAlgorithmBase):
     https://en.wikipedia.org/wiki/Top-hat_transform
     """
 
-    def __init__(self, masking_radius: int, is_volume: bool=False, clip_method: bool=0) -> None:
+    def __init__(self, masking_radius: int, is_volume: bool=False, clip_method: int=0) -> None:
         """
         Instance of a white top hat morphological masking filter which masks objects larger
         than `masking_radius`
@@ -96,8 +96,8 @@ class WhiteTophat(FilterAlgorithmBase):
         "--is-volume", is_flag=True, help="filter 3D volumes")
     @click.option(
         "--clip-method", default=0, type=int,
-        help="method to constrain data to [0,1]. 0: clip, 1: scale by max per chunk, 2: scale "
-             "by max over whole ImageStack")
+        help="method to constrain data to [0,1]. 0: clip, 1: scale by max over whole image, "
+             "2: scale by max per chunk")
     @click.pass_context
     def _cli(ctx, masking_radius, is_volume, clip_method):
         ctx.obj["component"]._cli_run(ctx, WhiteTophat(masking_radius, is_volume, clip_method))

--- a/starfish/image/_filter/zero_by_channel_magnitude.py
+++ b/starfish/image/_filter/zero_by_channel_magnitude.py
@@ -23,7 +23,6 @@ class ZeroByChannelMagnitude(FilterAlgorithmBase):
         thresh : int
             pixels in each round that have a L2 norm across channels below this threshold
             are set to 0
-
         normalize : bool
             if True, this scales all rounds to have unit L2 norm across channels
         """

--- a/starfish/image/_registration/fourier_shift.py
+++ b/starfish/image/_registration/fourier_shift.py
@@ -5,10 +5,10 @@ import numpy as np
 from scipy.ndimage import fourier_shift
 from skimage.feature import register_translation
 
-from starfish.util.dtype import preserve_float_range
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Axes
 from starfish.util import click
+from starfish.util.dtype import preserve_float_range
 from ._base import RegistrationAlgorithmBase
 
 

--- a/starfish/image/_registration/fourier_shift.py
+++ b/starfish/image/_registration/fourier_shift.py
@@ -5,7 +5,7 @@ import numpy as np
 from scipy.ndimage import fourier_shift
 from skimage.feature import register_translation
 
-from starfish.image._filter.util import preserve_float_range
+from starfish.util.dtype import preserve_float_range
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Axes
 from starfish.util import click

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -744,9 +744,10 @@ class ImageStack:
         kwargs : dict
             Additional arguments to pass to func
         clip_method : int
-            (Default 0) Controls the way that data are scaled to retain skimage dtype
-            requirements that float data fall in [0, 1].
-            0: data above 1 are set to 1, and below 0 are set to 0
+            (Default 0) Controls the way that data that exceed 1 are scaled to retain skimage dtype
+            requirements (float data fall in [0, 1]). Regardless of the method, data below 0 are
+            set to 0.
+            0: data above 1 are set to 1.
             1: data above 1 are scaled by the maximum value, with the maximum value calculated
                over the entire ImageStack
             2: data above 1 are scaled by the maximum value, with the maximum value calculated
@@ -767,7 +768,9 @@ class ImageStack:
             image_stack = deepcopy(self)
             return image_stack.apply(
                 func=func,
-                group_by=group_by, in_place=True, verbose=verbose, n_processes=n_processes, **kwargs
+                group_by=group_by, in_place=True, verbose=verbose, n_processes=n_processes,
+                clip_method=clip_method,
+                **kwargs
             )
 
         # wrapper adds a target `data` parameter where the results from func will be stored
@@ -794,9 +797,9 @@ class ImageStack:
     ) -> None:
         result = apply_func(data, **kwargs)
         if clip_method == 0:
-            data[:] = preserve_float_range(result, False)
+            data[:] = preserve_float_range(result, rescale=False)
         elif clip_method == 2:
-            data[:] = preserve_float_range(result, True)
+            data[:] = preserve_float_range(result, rescale=True)
         else:
             data[:] = result
 

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -59,6 +59,7 @@ from starfish.types import (
     STARFISH_EXTRAS_KEY
 )
 from starfish.util import logging
+from starfish.util.dtype import preserve_float_range
 from ._mp_dataarray import MPDataArray
 from .dataorder import AXES_DATA, N_AXES
 
@@ -771,7 +772,7 @@ class ImageStack:
     @staticmethod
     def _in_place_apply(apply_func: Callable[..., np.ndarray], data: np.ndarray, **kwargs) -> None:
         result = apply_func(data, **kwargs)
-        data[:] = result
+        data[:] = preserve_float_range(result)
 
     def transform(
             self,

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -749,9 +749,9 @@ class ImageStack:
             set to 0.
             0: data above 1 are set to 1.
             1: data above 1 are scaled by the maximum value, with the maximum value calculated
-               over the entire ImageStack
+            over the entire ImageStack
             2: data above 1 are scaled by the maximum value, with the maximum value calculated
-               over each slice, where slice shapes are determined by the group_by parameters
+            over each slice, where slice shapes are determined by the group_by parameters
 
         Returns
         -------

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -749,10 +749,10 @@ class ImageStack:
             requirements that float data fall in [0, 1].
             Clip.CLIP: data above 1 are set to 1, and below 0 are set to 0
             Clip.SCALE_BY_IMAGE: data above 1 are scaled by the maximum value, with the maximum
-                value calculated over the entire ImageStack
+            value calculated over the entire ImageStack
             Clip.SCALE_BY_CHUNK: data above 1 are scaled by the maximum value, with the maximum
-                value calculated over each slice, where slice shapes are determined by the group_by
-                parameters
+            value calculated over each slice, where slice shapes are determined by the group_by
+            parameters
 
         Returns
         -------

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -716,6 +716,7 @@ class ImageStack:
             in_place=False,
             verbose: bool=False,
             n_processes: Optional[int]=None,
+            clip_method: int=0,
             **kwargs
     ) -> "ImageStack":
         """Split the image along a set of axes and apply a function across all the components.  This
@@ -725,14 +726,14 @@ class ImageStack:
         Parameters
         ----------
         func : Callable
-            Function to apply. must expect a first argument which is a numpy array (see group_by)
-            but may return any object type.
+            Function to apply. must expect a first argument which is a 2d or 3d numpy array and
+            return an array of the same shape.
         group_by : Set[Axes]
             Axes to split the data along.  For instance, splitting a 2D array (axes: X, Y; size:
             3, 4) by X results in 3 arrays of size 4.  (default {Axes.ROUND, Axes.CH,
             Axes.ZPLANE})
         in_place : bool
-            (default True) If True, function is executed in place. If n_proc is not 1, the tile or
+            (Default False) If True, function is executed in place. If n_proc is not 1, the tile or
             volume will be copied once during execution. If false, a new ImageStack object will be
             produced.
         verbose : bool
@@ -742,6 +743,14 @@ class ImageStack:
             (default = None).
         kwargs : dict
             Additional arguments to pass to func
+        clip_method : int
+            (Default 0) Controls the way that data are scaled to retain skimage dtype
+            requirements that float data fall in [0, 1].
+            0: data above 1 are set to 1, and below 0 are set to 0
+            1: data above 1 are scaled by the maximum value, with the maximum value calculated
+               over the entire ImageStack
+            2: data above 1 are scaled by the maximum value, with the maximum value calculated
+               over each slice, where slice shapes are determined by the group_by parameters
 
         Returns
         -------
@@ -749,30 +758,47 @@ class ImageStack:
             If inplace is False, return a new ImageStack, otherwise return a reference to the
             original stack with data modified by application of func
         """
+        # default grouping is by (x, y) tile
         if group_by is None:
             group_by = {Axes.ROUND, Axes.CH, Axes.ZPLANE}
 
         if not in_place:
+            # create a copy of the ImageStack, call apply on that stack with in_place=True
             image_stack = deepcopy(self)
             return image_stack.apply(
-                func,
+                func=func,
                 group_by=group_by, in_place=True, verbose=verbose, n_processes=n_processes, **kwargs
             )
-        bound_func = partial(ImageStack._in_place_apply, func)
 
+        # wrapper adds a target `data` parameter where the results from func will be stored
+        # data are clipped or scaled by chunk using preserve_float_range if clip_method != 2
+        bound_func = partial(ImageStack._in_place_apply, func, clip_method=clip_method)
+
+        # execute the processing workflow
         self.transform(
-            bound_func,
+            func=bound_func,
             group_by=group_by,
             verbose=verbose,
             n_processes=n_processes,
             **kwargs)
 
+        # scale based on values of whole image
+        if clip_method == 1:
+            self._data = preserve_float_range(self._data, rescale=True)
+
         return self
 
     @staticmethod
-    def _in_place_apply(apply_func: Callable[..., np.ndarray], data: np.ndarray, **kwargs) -> None:
+    def _in_place_apply(
+        apply_func: Callable[..., np.ndarray], data: np.ndarray, clip_method: int, **kwargs
+    ) -> None:
         result = apply_func(data, **kwargs)
-        data[:] = preserve_float_range(result)
+        if clip_method == 0:
+            data[:] = preserve_float_range(result, False)
+        elif clip_method == 2:
+            data[:] = preserve_float_range(result, True)
+        else:
+            data[:] = result
 
     def transform(
             self,
@@ -806,8 +832,9 @@ class ImageStack:
         List[Any] :
             The results of applying func to stored image data
         """
+        # default grouping is by (x, y) tile
         if group_by is None:
-            group_by = {Axes.X, Axes.Y}
+            group_by = {Axes.ROUND, Axes.CH, Axes.ZPLANE}
 
         selectors = list(self._iter_axes(group_by))
         slice_lists = [self._build_slice_list(index)[0]
@@ -817,15 +844,19 @@ class ImageStack:
         if verbose and StarfishConfig().verbose:
             selectors_and_slice_lists = tqdm(selectors_and_slice_lists)
 
+        mp_applyfunc: Callable = partial(
+            self._processing_workflow, partial(func, **kwargs))
+
         with Pool(
                 processes=n_processes,
                 initializer=SharedMemory.initializer,
                 initargs=((self._data._backing_mp_array,
                            self._data._data.shape,
                            self._data._data.dtype),)) as pool:
-            mp_applyfunc: Callable = partial(
-                self._processing_workflow, partial(func, **kwargs))
             results = pool.imap(mp_applyfunc, selectors_and_slice_lists)
+
+            # Note: results is [None, ...] if executing an in-place workflow
+            # Note: this return must be inside the context manager or the Pool will deadlock
             return list(zip(results, selectors))
 
     @staticmethod
@@ -851,8 +882,8 @@ class ImageStack:
         )
         sliced = data_array.sel(selector_and_slice_list[0])
 
-        # return the result of the function called on the slice
-        return worker_callable(sliced)
+        # pass worker_callable a view into the backing array, which will be overwritten
+        return worker_callable(sliced)  # type: ignore
 
     @property
     def tile_metadata(self) -> pd.DataFrame:

--- a/starfish/intensity_table/intensity_table.py
+++ b/starfish/intensity_table/intensity_table.py
@@ -8,7 +8,7 @@ import regional
 import xarray as xr
 
 from starfish.expression_matrix.expression_matrix import ExpressionMatrix
-from starfish.image._filter.util import preserve_float_range
+from starfish.util.dtype import preserve_float_range
 from starfish.types import Axes, Features, LOG, SpotAttributes, STARFISH_EXTRAS_KEY
 
 

--- a/starfish/intensity_table/intensity_table.py
+++ b/starfish/intensity_table/intensity_table.py
@@ -8,8 +8,8 @@ import regional
 import xarray as xr
 
 from starfish.expression_matrix.expression_matrix import ExpressionMatrix
-from starfish.util.dtype import preserve_float_range
 from starfish.types import Axes, Features, LOG, SpotAttributes, STARFISH_EXTRAS_KEY
+from starfish.util.dtype import preserve_float_range
 
 
 class IntensityTable(xr.DataArray):

--- a/starfish/spots/_detector/detect.py
+++ b/starfish/spots/_detector/detect.py
@@ -227,7 +227,6 @@ def detect_spots(data_stack: ImageStack,
 
     if reference_image_from_max_projection:
         reference_image = data_stack.max_proj(Axes.CH, Axes.ROUND).xarray.squeeze()
-        # reference_image = reference_image._squeezed_numpy(Axes.CH, Axes.ROUND)
 
     group_by = {Axes.ROUND, Axes.CH}
 

--- a/starfish/test/full_pipelines/api/test_merfish.py
+++ b/starfish/test/full_pipelines/api/test_merfish.py
@@ -217,7 +217,7 @@ def test_merfish_pipeline_cropped_data():
 
     # verify that the number of spots are correct
     spots_passing_filters = spot_intensities[Features.PASSES_THRESHOLDS].sum()
-    assert spots_passing_filters == 1410
+    assert spots_passing_filters == 1417
 
     # compare to paper results
     bench = pd.read_csv('https://d2nhj9g34unfro.cloudfront.net/MERFISH/benchmark_results.csv',
@@ -232,8 +232,8 @@ def test_merfish_pipeline_cropped_data():
 
     # assert that number of high-expression detected genes are correct
     expected_counts = pd.Series(
-        [113, 105, 57, 44, 30],
-        index=('nan', 'MALAT1', 'SRRM2', 'FASN', 'LRP1')
+        [120, 101, 54, 43, 30],
+        index=('nan', 'MALAT1', 'SRRM2', 'FASN', 'PRKDC')
     )
     assert np.array_equal(
         expected_counts.values,
@@ -248,4 +248,4 @@ def test_merfish_pipeline_cropped_data():
 
     corrcoef = np.corrcoef(tmp[:, 1], tmp[:, 0])[0, 1]
 
-    assert np.round(corrcoef, 4) == 0.9144
+    assert np.round(corrcoef, 4) == 0.9647

--- a/starfish/test/image/test_apply.py
+++ b/starfish/test/image/test_apply.py
@@ -54,3 +54,45 @@ def test_apply_single_process():
     assert (stack.xarray == 1).all()
     output = stack.apply(divide, value=2, n_processes=1)
     assert (output.xarray == 0.5).all()
+
+def test_apply_clipping_methods():
+    """test that apply properly clips the imagestack"""
+
+    # create a half-valued float array
+    data = np.full((2, 2, 2, 5, 5), fill_value=0.5, dtype=np.float32)
+    # set one value to max
+    data[1, 1, 1, 1, 1] = 1
+
+    imagestack = ImageStack.from_numpy_array(data)
+
+    # max value after multiplication == 2, all other values == 1
+    def apply_function(x):
+        return x * 2
+
+    # clip_method 0
+    # all data are clipped to 1, setting all values to 1 (np.unique(pre_scaled) == [1, 2])
+    res = imagestack.apply(apply_function, clip_method=0, in_place=False, n_processes=1)
+    assert np.allclose(res.xarray.values, 1)
+
+    # clip_method 1
+    # all data are scaled, resulting in values being multiplied by 0.5, replicating the original
+    # data
+    res = imagestack.apply(apply_function, clip_method=1, in_place=False, n_processes=1)
+    assert np.allclose(imagestack.xarray, res.xarray)
+
+    # clip_method 2
+    res = imagestack.apply(
+        apply_function, clip_method=2, in_place=False, n_processes=1,
+        group_by={Axes.CH, Axes.ROUND},
+    )
+    # any (round, ch) combination that was all 0.5 should now be all 1.
+    assert np.allclose(res.sel({Axes.ROUND: 0, Axes.CH: 0}).xarray, 1)
+    assert np.allclose(res.sel({Axes.ROUND: 1, Axes.CH: 0}).xarray, 1)
+    assert np.allclose(res.sel({Axes.ROUND: 0, Axes.CH: 1}).xarray, 1)
+
+    # the specific (round, ch) combination with the single "1" value should be scaled, and due to
+    # construction, look like the original data.
+    assert np.allclose(
+        res.sel({Axes.ROUND: 1, Axes.CH: 1}).xarray,
+        imagestack.sel({Axes.ROUND: 1, Axes.CH: 1}).xarray
+    )

--- a/starfish/test/image/test_apply.py
+++ b/starfish/test/image/test_apply.py
@@ -3,7 +3,7 @@ import copy
 import numpy as np
 
 from starfish.imagestack.imagestack import ImageStack
-from starfish.types import Axes
+from starfish.types import Axes, Clip
 from starfish.util.synthesize import SyntheticData
 
 
@@ -71,18 +71,20 @@ def test_apply_clipping_methods():
 
     # clip_method 0
     # all data are clipped to 1, setting all values to 1 (np.unique(pre_scaled) == [1, 2])
-    res = imagestack.apply(apply_function, clip_method=0, in_place=False, n_processes=1)
+    res = imagestack.apply(apply_function, clip_method=Clip.CLIP, in_place=False, n_processes=1)
     assert np.allclose(res.xarray.values, 1)
 
     # clip_method 1
     # all data are scaled, resulting in values being multiplied by 0.5, replicating the original
     # data
-    res = imagestack.apply(apply_function, clip_method=1, in_place=False, n_processes=1)
+    res = imagestack.apply(
+        apply_function, clip_method=Clip.SCALE_BY_IMAGE, in_place=False, n_processes=1
+    )
     assert np.allclose(imagestack.xarray, res.xarray)
 
     # clip_method 2
     res = imagestack.apply(
-        apply_function, clip_method=2, in_place=False, n_processes=1,
+        apply_function, clip_method=Clip.SCALE_BY_CHUNK, in_place=False, n_processes=1,
         group_by={Axes.CH, Axes.ROUND},
     )
     # any (round, ch) combination that was all 0.5 should now be all 1.

--- a/starfish/test/pipeline/test_filter.py
+++ b/starfish/test/pipeline/test_filter.py
@@ -5,7 +5,7 @@ import pytest
 
 from starfish.image._filter import gaussian_high_pass, mean_high_pass
 from starfish.imagestack.imagestack import ImageStack
-from starfish.types import Number
+from starfish.types import Clip, Number
 
 
 def random_data_image_stack_factory():
@@ -22,7 +22,9 @@ def test_gaussian_high_pass(sigma: Union[Number, Tuple[Number]], is_volume: bool
     """high pass is subtractive, sum of array should be less after running."""
     image_stack = random_data_image_stack_factory()
     sum_before = np.sum(image_stack.xarray)
-    ghp = gaussian_high_pass.GaussianHighPass(sigma=sigma, is_volume=is_volume)
+    ghp = gaussian_high_pass.GaussianHighPass(
+        sigma=sigma, is_volume=is_volume, clip_method=Clip.CLIP
+    )
     result = ghp.run(image_stack, n_processes=1)
     assert np.sum(result.xarray) < sum_before
 
@@ -35,6 +37,6 @@ def test_mean_high_pass(size: Union[Number, Tuple[Number]], is_volume: bool) -> 
     """high pass is subtractive, sum of array should be less after running."""
     image_stack = random_data_image_stack_factory()
     sum_before = np.sum(image_stack.xarray)
-    mhp = mean_high_pass.MeanHighPass(size=size, is_volume=is_volume)
+    mhp = mean_high_pass.MeanHighPass(size=size, is_volume=is_volume, clip_method=Clip.CLIP)
     result = mhp.run(image_stack)
     assert np.sum(result.xarray) < sum_before

--- a/starfish/types/__init__.py
+++ b/starfish/types/__init__.py
@@ -2,6 +2,7 @@ from typing import Union
 
 from ._constants import (
     Axes,
+    Clip,
     Coordinates,
     CORE_DEPENDENCIES,
     Features,

--- a/starfish/types/_constants.py
+++ b/starfish/types/_constants.py
@@ -76,3 +76,13 @@ class Features:
     CELL_ID = 'cell_id'
     SPOT_ID = 'spot_id'
     INTENSITY = 'intensity'
+
+
+class Clip(AugmentedEnum):
+    """
+    contains clipping options that determine how out-of-bounds values produced by filters are
+    treated to keep the image contained within [0, 1]
+    """
+    CLIP = 'clip'
+    SCALE_BY_IMAGE = 'scale_by_image'
+    SCALE_BY_CHUNK = 'scale_by_chunk'

--- a/starfish/util/dtype.py
+++ b/starfish/util/dtype.py
@@ -31,8 +31,9 @@ def preserve_float_range(
     else:
         data = array
 
-    if np.any(data < 0):
-        data[data < 0] = 0
+    negative = data < 0
+    if np.any(negative):
+        data[negative] = 0
     if np.any(data > 1):
         if rescale:
             data /= data.max()

--- a/starfish/util/dtype.py
+++ b/starfish/util/dtype.py
@@ -1,7 +1,7 @@
 from typing import Union
 
-import xarray as xr
 import numpy as np
+import xarray as xr
 
 def preserve_float_range(
         array: Union[xr.DataArray, np.ndarray],

--- a/starfish/util/dtype.py
+++ b/starfish/util/dtype.py
@@ -1,0 +1,41 @@
+from typing import Union
+
+import xarray as xr
+import numpy as np
+
+def preserve_float_range(
+        array: Union[xr.DataArray, np.ndarray],
+        rescale: bool=False) -> Union[xr.DataArray, np.ndarray]:
+    """
+    Clips values below zero to zero. If values above one are detected, clips them
+    to 1 unless `rescale` is True, in which case the input is scaled by
+    the max value and the dynamic range is preserved.
+
+    Parameters
+    ----------
+    array : Union[xr.DataArray, np.ndarray]
+        Array whose values should be in the interval [0, 1] but may not be.
+    rescale: bool
+        If true, scale values by the max.
+
+    Returns
+    -------
+    array : Union[xr.DataArray, np.ndarray]
+        Array whose values are in the interval [0, 1].
+
+    """
+    array = array.copy()
+
+    if isinstance(array, xr.DataArray):
+        data = array.values
+    else:
+        data = array
+
+    if np.any(data < 0):
+        data[data < 0] = 0
+    if np.any(data > 1):
+        if rescale:
+            data /= data.max()
+        else:
+            data[data > 1] = 1
+    return array.astype(np.float32)


### PR DESCRIPTION
## Purpose

Clipping and scaling was not happening properly in our filters, leading to some bugs. Specifically, `preserve_float_range` with `rescale=True` scales by the max value of the provided image. This was being called on _each chunk independently_, when some filters need to call it on the _whole imagestack_. This PR adds that flexibility. 

## Changes

- Move `preserve_float_range` calls into `ImageStack.apply` and enable 3 modes of clipping (see below).
- Move `preserve_float_range` from `filter` to `starfish.util.dtype`.
- Each filter that can create values outside [0, 1] now receives a `clip_method` parameter. 
- Add comments to `apply`, `transform` and related methods to clarify process flow. 
- Add tests for clipping types
- Improve correlation for MERFISH notebook by adjusting deconvolution clipping
- Fix miscellaneous documentation errors in the Filters

New `clip_method` parameter:
```
        clip_method : int
            (Default 0) Controls the way that data are scaled to retain skimage dtype
            requirements that float data fall in [0, 1].
            0: data above 1 are set to 1, and below 0 are set to 0
            1: data above 1 are scaled by the maximum value, with the maximum value calculated
               over the entire ImageStack
            2: data above 1 are scaled by the maximum value, with the maximum value calculated
               over each slice, where slice shapes are determined by the group_by parameters
```

## Review strategy

- review `starfish/imagestack/imagestack.py`
- review `starfish/test/image/test_apply.py`
- review `starfish/test/full_pipelines/api/test_merfish.py`
- glance at all the filters and the merfish notebook -- changes there are minimal. 