### PR TITLE
iss: add validation command

### DIFF
--- a/starfish/config/__init__.py
+++ b/starfish/config/__init__.py
@@ -171,9 +171,14 @@ class StarfishConfig(object):
             v = v[k]
         v[lookup[-1]] = value
 
-    @staticmethod
-    def flag(name, default_value=""):
-        value = os.environ.get(name, default_value)
+    def flag(self, name, default_value=""):
+
+        if name in os.environ:
+            value = os.environ[name]
+            self._env_keys.remove(name)
+        else:
+            value = default_value
+
         if isinstance(value, str):
             value = value.lower()
             return value in ("true", "1", "yes", "y", "on", "active", "enabled")

--- a/starfish/test/full_pipelines/cli/get_cli_test_data.py
+++ b/starfish/test/full_pipelines/cli/get_cli_test_data.py
@@ -33,8 +33,9 @@ if __name__ == "__main__":
     with open(pathlib.Path(args.output_dir, 'codebook.json'), 'w') as f:
         json.dump(data, f)
 
-    # get experiment.json from url and save locally to tmp dir
-    experiment = requests.get(posixpath.join(args.experiment_url, "experiment.json"))
-    data = experiment.json()
-    with open(pathlib.Path(args.output_dir, 'experiment.json'), 'w') as f:
-        json.dump(data, f)
+    # get json files from url and save locally to tmp dir
+    for filename in ("experiment.json", "hybridization.json", "nuclei.json", "dots.json"):
+        obj = requests.get(posixpath.join(args.experiment_url, filename))
+        data = obj.json()
+        with open(pathlib.Path(args.output_dir, filename), 'w') as f:
+            json.dump(data, f)

--- a/starfish/test/full_pipelines/cli/get_cli_test_data.py
+++ b/starfish/test/full_pipelines/cli/get_cli_test_data.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
     for fov in exp.fovs():
         fov_dir = pathlib.Path(args.output_dir, fov.name)
         fov_dir.mkdir()
-        fov[FieldOfView.PRIMARY_IMAGES].export(str(fov_dir / "primary_images.json"))
+        fov[FieldOfView.PRIMARY_IMAGES].export(str(fov_dir / "hybridization.json"))
         for image_type in fov.image_types:
             if image_type == FieldOfView.PRIMARY_IMAGES:
                 continue

--- a/starfish/test/full_pipelines/cli/get_cli_test_data.py
+++ b/starfish/test/full_pipelines/cli/get_cli_test_data.py
@@ -11,6 +11,7 @@ from starfish.util.argparse import FsExistsType
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+    parser.add_argument("--primary-name", default="primary_images.json")
     parser.add_argument("experiment_url")
     parser.add_argument("output_dir", type=FsExistsType())
     args = parser.parse_args()
@@ -21,7 +22,7 @@ if __name__ == "__main__":
     for fov in exp.fovs():
         fov_dir = pathlib.Path(args.output_dir, fov.name)
         fov_dir.mkdir()
-        fov[FieldOfView.PRIMARY_IMAGES].export(str(fov_dir / "hybridization.json"))
+        fov[FieldOfView.PRIMARY_IMAGES].export(str(fov_dir / args.primary_name))
         for image_type in fov.image_types:
             if image_type == FieldOfView.PRIMARY_IMAGES:
                 continue
@@ -34,8 +35,10 @@ if __name__ == "__main__":
         json.dump(data, f)
 
     # get json files from url and save locally to tmp dir
-    for filename in ("experiment.json", "hybridization.json", "nuclei.json", "dots.json"):
+    for filename in ("experiment.json", args.primary_name, "nuclei.json", "dots.json"):
         obj = requests.get(posixpath.join(args.experiment_url, filename))
-        data = obj.json()
-        with open(pathlib.Path(args.output_dir, filename), 'w') as f:
-            json.dump(data, f)
+        # download file if it exists
+        if obj.status_code == 200:
+            data = obj.json()
+            with open(pathlib.Path(args.output_dir, filename), 'w') as f:
+                json.dump(data, f)

--- a/starfish/test/full_pipelines/cli/test_iss.py
+++ b/starfish/test/full_pipelines/cli/test_iss.py
@@ -43,6 +43,11 @@ class TestWithIssData(CLITest, unittest.TestCase):
                 lambda tempdir, *args, **kwargs: os.path.join(tempdir, "formatted")
             ],
             [
+                "starfish", "validate", "experiment",
+                lambda tempdir, *args, **kwargs: os.path.join(
+                    tempdir, "formatted", "experiment.json")
+            ],
+            [
                 "starfish", "registration",
                 "--input", lambda tempdir, *args, **kwargs: os.path.join(
                     tempdir, "formatted/fov_001", "primary_images.json"),

--- a/starfish/test/full_pipelines/cli/test_iss.py
+++ b/starfish/test/full_pipelines/cli/test_iss.py
@@ -39,6 +39,7 @@ class TestWithIssData(CLITest, unittest.TestCase):
             [
                 sys.executable,
                 "starfish/test/full_pipelines/cli/get_cli_test_data.py",
+                "--primary-name=hybridization.json",
                 "https://d2nhj9g34unfro.cloudfront.net/20181005/ISS-TEST/",
                 lambda tempdir, *args, **kwargs: os.path.join(tempdir, "formatted")
             ],

--- a/starfish/test/full_pipelines/cli/test_iss.py
+++ b/starfish/test/full_pipelines/cli/test_iss.py
@@ -50,9 +50,9 @@ class TestWithIssData(CLITest, unittest.TestCase):
             [
                 "starfish", "registration",
                 "--input", lambda tempdir, *args, **kwargs: os.path.join(
-                    tempdir, "formatted/fov_001", "primary_images.json"),
+                    tempdir, "formatted/fov_001", "hybridization.json"),
                 "--output", lambda tempdir, *args, **kwargs: os.path.join(
-                    tempdir, "registered", "primary_images.json"),
+                    tempdir, "registered", "hybridization.json"),
                 "FourierShiftRegistration",
                 "--reference-stack", lambda tempdir, *args, **kwargs: os.path.join(
                     tempdir, "formatted/fov_001", "dots.json"),
@@ -61,9 +61,9 @@ class TestWithIssData(CLITest, unittest.TestCase):
             [
                 "starfish", "filter",
                 "--input", lambda tempdir, *args, **kwargs: os.path.join(
-                    tempdir, "registered", "primary_images.json"),
+                    tempdir, "registered", "hybridization.json"),
                 "--output", lambda tempdir, *args, **kwargs: os.path.join(
-                    tempdir, "filtered", "primary_images.json"),
+                    tempdir, "filtered", "hybridization.json"),
                 "WhiteTophat",
                 "--masking-radius", "15",
             ],
@@ -88,7 +88,7 @@ class TestWithIssData(CLITest, unittest.TestCase):
             [
                 "starfish", "detect_spots",
                 "--input", lambda tempdir, *args, **kwargs: os.path.join(
-                    tempdir, "filtered", "primary_images.json"),
+                    tempdir, "filtered", "hybridization.json"),
                 "--output", lambda tempdir, *args, **kwargs: os.path.join(
                     tempdir, "results", "spots.nc"),
                 "--blobs-stack", lambda tempdir, *args, **kwargs: os.path.join(
@@ -102,7 +102,7 @@ class TestWithIssData(CLITest, unittest.TestCase):
             [
                 "starfish", "segment",
                 "--primary-images", lambda tempdir, *args, **kwargs: os.path.join(
-                    tempdir, "filtered", "primary_images.json"),
+                    tempdir, "filtered", "hybridization.json"),
                 "--nuclei", lambda tempdir, *args, **kwargs: os.path.join(
                     tempdir, "filtered", "nuclei.json"),
                 "-o", lambda tempdir, *args, **kwargs: os.path.join(


### PR DESCRIPTION
On adding a validation command, `test_iss.py` begins to fail due to a confusion between the older "hybridization.json" and the newer "primary_images.json". This PR:

 * [x] adds validation
 * [x] makes `get_cli_test_data.py` configurable
 * [x] updates `test_iss.py` to pass `--primary-name=hybridization.json`

(`test_iss.py` should have failed _previously_ which needs tracking down.)