### PR TITLE
Fix how we cast from xarray to numpy

### DIFF
--- a/starfish/image/_filter/util.py
+++ b/starfish/image/_filter/util.py
@@ -134,10 +134,7 @@ def preserve_float_range(
     """
     array = array.copy()
 
-    if isinstance(array, xr.DataArray):
-        data = array.values
-    else:
-        data = array
+    data = np.asarray(array)
 
     if np.any(data < 0):
         data[data < 0] = 0

--- a/starfish/spots/_detector/local_max_peak_finder.py
+++ b/starfish/spots/_detector/local_max_peak_finder.py
@@ -201,11 +201,12 @@ class LocalMaxPeakFinder(SpotFinderAlgorithmBase):
         Number :  #TODO ambrosejcarr this should probably be a float
             The intensity threshold
         """
+        img = np.asarray(img)
         thresholds, spot_counts = self._compute_num_spots_per_threshold(img)
         threshold = self._select_optimal_threshold(thresholds, spot_counts)
         return threshold
 
-    def image_to_spots(self, data_image: xr.DataArray) -> SpotAttributes:
+    def image_to_spots(self, data_image: Union[np.ndarray, xr.DataArray]) -> SpotAttributes:
         """measure attributes of spots detected by binarizing the image using the selected threshold
 
         Parameters
@@ -222,8 +223,7 @@ class LocalMaxPeakFinder(SpotFinderAlgorithmBase):
         if self.threshold is None:
             self.threshold = self._compute_threshold(data_image)
 
-        if isinstance(data_image, xr.DataArray):
-            data_image = data_image.values
+        data_image = np.asarray(data_image)
 
         # identify each spot's size by binarizing and calculating regionprops
         masked_image = data_image[:, :] > self.threshold

--- a/starfish/spots/_detector/trackpy_local_max_peak_finder.py
+++ b/starfish/spots/_detector/trackpy_local_max_peak_finder.py
@@ -85,7 +85,7 @@ class TrackpyLocalMaxPeakFinder(SpotFinderAlgorithmBase):
         self.is_volume = is_volume
         self.verbose = verbose
 
-    def image_to_spots(self, image: np.ndarray) -> SpotAttributes:
+    def image_to_spots(self, image: Union[np.ndarray, xr.DataArray]) -> SpotAttributes:
         """
 
         Parameters
@@ -99,10 +99,7 @@ class TrackpyLocalMaxPeakFinder(SpotFinderAlgorithmBase):
             spot attributes table for all detected spots
 
         """
-
-        if isinstance(image, xr.DataArray):
-            image = image.values
-
+        image = np.asarray(image)
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', FutureWarning)  # trackpy numpy indexing warning
             warnings.simplefilter('ignore', UserWarning)  # yielded if black images


### PR DESCRIPTION
There are some places in the codebase where we need a numpy array instead of an xarray.  Switch all instances where we do this to `np.asarray(...)`.  Also, fixed type hints where appropriate.

This should fix the master-breaking bug in #1035, but does not resolve the issue of (xarray) coordinates not being transferred to the constituent xarrays.