### PR TITLE
[easy] return python integer labels

### DIFF
--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -696,7 +696,7 @@ class ImageStack:
         Yields
         ------
         Dict[str, int]
-            Mapping of dimension name to index
+            Mapping of axis name to index
 
         """
         if axes is None:
@@ -980,7 +980,7 @@ class ImageStack:
         instance, imagestack.unique_index_values(Axes.ROUND) returns all the round ids in this
         imagestack."""
 
-        return [val for val in self.xarray.coords[axis.value].values]
+        return [int(val) for val in self.xarray.coords[axis.value].values]
 
     @property
     def tile_shape(self):


### PR DESCRIPTION
Since the labels are sourced from the xarray coordinates now, they come back as numpy int64 values.  Most of the time, we just want plain old python integers (e.g., json serialization doesn't work with numpy ints), so cast it.

Also ninja'ed in a small doc fix.

Depends on #1032 