### PR TITLE
[WIP] decoding filter and label transform

### DIFF
--- a/starfish/image/_filter/decode.py
+++ b/starfish/image/_filter/decode.py
@@ -1,0 +1,116 @@
+import numpy as np
+import xarray as xr
+from scipy.spatial.distance import cdist
+
+from starfish.codebook.codebook import Codebook
+from starfish.imagestack.imagestack import ImageStack
+from starfish.types import Axes, Features
+from starfish.util import click
+from ._base import FilterAlgorithmBase
+
+# TODO ambrosejcarr replace this with constitutive channel fluorescence mask when that PR is merged
+def _generate_test_codebook():
+    n_channel = 2
+    n_round = 2
+    data = np.zeros((n_channel, n_channel, n_round))
+    for c in range(n_channel):
+        data[c, c] = 1
+        code_names = [str(c) for c in range(n_channel)]
+    return Codebook._create_codebook(code_names, n_channel, n_round, data)
+
+
+class Decode(FilterAlgorithmBase):
+
+    def __init__(self, codebook: Codebook, metric: str="euclidean", norm_order: int=2) -> None:
+        """Decode an image in round/channel space to target space
+
+        The resulting ImageStack will be of shape (1, n_targets, z, y, x) where n_targets are the
+        number of targets in the codebook. The values of the decoded images are the distance of
+        each pixel from the given target, calculated using the provided distance.
+
+        Parameters
+        ----------
+        codebook : Codebook
+            codebook that will be used to decode image
+        metric : str
+            the metric used to calculate pixel intensity distance from codes in codebook
+
+        """
+        self.codebook = codebook
+        self.metric = metric
+        self.norm_order = norm_order
+
+    _DEFAULT_TESTING_PARAMETERS: dict = {
+        "codebook": _generate_test_codebook()
+    }
+
+    @staticmethod
+    def _decode(
+        image: xr.DataArray,
+        codebook: Codebook,
+        metric: str="euclidean",
+        norm_order: int=2
+    ) -> np.ndarray:
+        """
+        """
+        traces = image.xarray.stack(
+            features=(Axes.ZPLANE.value, Axes.Y.value, Axes.X.value)
+        )
+        traces = traces.transpose(Features.AXIS, Axes.CH.value, Axes.ROUND.value)
+
+        # normalize codes and traces
+        norm_intensities, norms = codebook._normalize_features(traces, norm_order=norm_order)
+        norm_codes, _ = codebook._normalize_features(codebook, norm_order=norm_order)
+
+        intensity_traces = norm_intensities.stack(traces=(Axes.CH.value, Axes.ROUND.value))
+        intensity_codes = norm_codes.stack(traces=(Axes.CH.value, Axes.ROUND.value))
+        distances = cdist(intensity_traces, intensity_codes)
+
+        # reshape into an ImageStack
+        distances = xr.DataArray(distances, coords=(norm_intensities.features, norm_codes.target))
+        distances = distances.unstack(Features.AXIS)
+        distances = distances.rename(target=Axes.CH.value)
+        distance_image = distances.expand_dims(Axes.ROUND.value)
+
+        # normalize distances into (0, 1) to keep ImageStack requirements
+        normalized_image = distance_image / distance_image.max()
+
+        # TODO return a label image
+        return ImageStack.from_numpy_array(normalized_image.values)
+
+    def run(self, stack, in_place=False, verbose=False, n_processes=None) -> ImageStack:
+        """Perform filtering of an image stack
+
+        Parameters
+        ----------
+        stack : ImageStack
+            Stack to be filtered.
+        in_place : bool
+            Not used. Decode changes the shape of the input image.
+        verbose : bool
+            If True, report on the percentage completed (default = False) during processing
+        n_processes : Optional[int]
+            Number of parallel processes to devote to calculating the filter
+
+        Returns
+        -------
+        ImageStack :
+            If in-place is False, return the results of filter as a new stack.  Otherwise return the
+            original stack.
+
+        """
+        # TODO support multiprocessing
+        return self._decode(stack, self.codebook, self.metric)
+
+    @staticmethod
+    @click.command("Decode")
+    @click.option(
+        "--codebook", type=str, required=True, help="Codebook used to decode images")
+    @click.option(
+        "--metric", default="euclidean", type=str, help="distance metric")
+    @click.option(
+        "--n_codes", type=int, default=1, help="if True, return only closest target for each pixel")
+    @click.pass_context
+    def _cli(ctx, codebook, metric, n_codes):
+        codebook_obj = Codebook.from_json(codebook)
+        ctx.obj["component"]._cli_run(ctx, Decode(codebook_obj, metric, n_codes))

--- a/starfish/image/transform/label.py
+++ b/starfish/image/transform/label.py
@@ -1,0 +1,112 @@
+from typing import Mapping, NamedTuple
+
+import numpy as np
+import xarray as xr
+from sklearn.neighbors import NearestNeighbors
+
+from starfish.codebook.codebook import Codebook
+from starfish.types import Axes, Features
+
+class LabelResult(NamedTuple):
+    metric_result: np.ndarray
+    gene_indices: np.ndarray
+    index_to_gene_map: Mapping[int, str]
+
+
+class Label:
+
+    # TODO add docstring
+    def __init__(self, codebook: Codebook, metric: str="euclidean", k_targets: int=1) -> None:
+        """
+
+        Parameters
+        ----------
+        codebook : Codebook
+            codebook that will be used to decode image
+        metric : str
+            the metric used to calculate pixel intensity distance from codes in codebook
+        k_targets : int
+            number of labeled arrays to emit for each pixel
+
+        """
+        self.codebook = codebook
+        self.metric = metric
+        self.k_targets = k_targets
+
+    @staticmethod
+    def _decode(
+        image: xr.DataArray,
+        codebook: Codebook,
+        k_targets: int,
+        metric: str="euclidean",
+        norm_order: int=2
+    ) -> LabelResult:
+        """
+        """
+        # TODO make this respect physical coordinates
+        traces = image.xarray.stack(
+            features=(Axes.ZPLANE.value, Axes.Y.value, Axes.X.value)
+        )
+        traces = traces.transpose(Features.AXIS, Axes.CH.value, Axes.ROUND.value)
+
+        # normalize codes and traces
+        norm_intensities, norms = codebook._normalize_features(traces, norm_order=norm_order)
+        norm_codes, _ = codebook._normalize_features(codebook, norm_order=norm_order)
+        expected = norm_codes.stack(codes=(Axes.CH.value, Axes.ROUND.value))
+        observed = norm_intensities.stack(codes=(Axes.CH.value, Axes.ROUND.value))
+
+        # calculate distances and labels
+        nn = NearestNeighbors(n_neighbors=k_targets, algorithm='ball_tree', metric=metric)
+        nn.fit(expected)
+        ranked_metric_output, ranked_indices = nn.kneighbors(observed)
+
+        # reshape back into image
+        def _create_xarray(data):
+            z = observed.features[Axes.ZPLANE.value].values
+            y = observed.features[Axes.Y.value].values
+            x = observed.features[Axes.X.value].values
+            xrdata = xr.DataArray(
+                data, dims=("pixels", "ranked_labels"),
+                coords={
+                    Axes.ZPLANE.value: ("pixels", z),
+                    Axes.Y.value: ("pixels", y),
+                    Axes.X.value: ("pixels", x)
+                }
+            )
+            xrdata = xrdata.set_index(pixels=(Axes.ZPLANE.value, Axes.Y.value, Axes.X.value))
+            unstacked = xrdata.unstack("pixels")
+            return unstacked
+
+        ranked_metric_output = _create_xarray(ranked_metric_output)
+        ranked_indices = _create_xarray(ranked_indices)
+
+        index_to_gene_map = dict(zip(
+            norm_codes.indexes[Features.TARGET].values,
+            np.arange(len(norm_codes.indexes[Features.TARGET].values))
+        ))
+
+        return LabelResult(ranked_metric_output, ranked_indices, index_to_gene_map)
+
+    def run(self, stack, in_place=False, verbose=False, n_processes=None) -> LabelResult:
+        """Perform filtering of an image stack
+
+        Parameters
+        ----------
+        stack : ImageStack
+            Stack to be filtered.
+        in_place : bool
+            if True, process ImageStack in-place, otherwise return a new stack
+        verbose : bool
+            If True, report on the percentage completed (default = False) during processing
+        n_processes : Optional[int]
+            Number of parallel processes to devote to calculating the filter
+
+        Returns
+        -------
+        ImageStack :
+            If in-place is False, return the results of filter as a new stack.  Otherwise return the
+            original stack.
+
+        """
+        # TODO support multiprocessing
+        return self._decode(stack, self.codebook, self.k_targets, self.metric)

--- a/starfish/test/image/filter/test_api_contract.py
+++ b/starfish/test/image/filter/test_api_contract.py
@@ -24,6 +24,7 @@ import pytest
 
 from starfish import ImageStack
 from starfish.image import Filter
+from starfish.image._filter.decode import Decode
 from starfish.image._filter.max_proj import MaxProj
 
 methods: Dict = Filter._algorithm_to_class_map()
@@ -60,7 +61,7 @@ def test_all_methods_adhere_to_contract(filter_class):
     except TypeError:
         raise AssertionError(f'{filter_class} must accept in_place parameter')
     assert isinstance(filtered, ImageStack)
-    if filter_class is not MaxProj:
+    if filter_class not in (MaxProj, Decode):
         # Max Proj does not have an in place option, so we need to skip this assertion
         assert data is filtered, \
             f'{filter_class} should return a reference to the input ImageStack when run in_place'


### PR DESCRIPTION
## Decoding filter 

This filter calculates the distance of each gene target in the codebook to the tiles across `(round, channel)`. The resulting ImageStack is of shape `(1, n_codes, z, y, x)` where `n_codes` is the number of gene targets in the codebook

[This link](http://www.giphy.com/gifs/jICSOgY01aaqSMV9MJ) contains an example output from the filter. The clim is first set manually, then the similarity of each code is iterated through. You can see that there is highly uneven expression of different genes. These results match what was observed by the original study authors (r^2 ~ 0.98)

This code projects across channels to identify the maximum similarity score with a gene, which can then be visualized. 
```
# filter image
dfilt = starfish.image.Filter.Decode(experiment.codebook)
decoded = dfilt.run(quantile_normalized)

# transform distance to similarity
similarity = starfish.ImageStack.from_numpy_array(1 - decoded.xarray)

# find maximum similarity across codebook
label = similarity.max_proj(Axes.CH)

# look at the max-similarity projection
starfish.display.stack(label)
```

[This link](http://www.giphy.com/gifs/1X7hdHewl6txITF3N7) contains an example of visualizing the output of the above code in napari, and using the clim slider to walk through the range of similarity thresholds. This can be used to visually inspect and select the right similarity for the pixel spot detector on these data. The final frame is a similarity of about 0.45, or a max distance of 0.55. 

Note that this filter calculates the full cross-distance matrix between each code and pixel. This can get very, very large in cases where there are a lot of pixels or a large codebook (e.g. SeqFISH, which has a 10,000 code codebook). 

## Label transform

To enable similar functionality to above on a large experiment or large codebook, this PR also adds a label transform, which carries out an approximate nearest-code matching of a user-specified number `k_targets`. This transform emits: 

1. A `4-d (k_targets, z, y, x)` image whose values are the ranked distances to the k-closest codes. 
2. A `4-d (k_targets, z, y, x)` image whose values are the ranked indices that map each distance in (1) to an integer representing the code. 
3. an `index_to_code` dict that allows the integer code IDs to be mapped to their gene targets. 

This enables similar functionality to the above decode function for cases where the data cannot all fit in memory, or for which a dense `cdist` calculation is not practically computationally feasible.

cc @kevinyamauchi @berl I'd love any comments you might have on this. Next step is to fix pixel spot decoding to work cumulatively on the results of this filter, and to enable both (1) connected-component based roi-finding and (2) spot-finding on the distance maps. 