### PR TITLE
Change tile shape to a dict by default

### DIFF
--- a/REQUIREMENTS-STRICT.txt
+++ b/REQUIREMENTS-STRICT.txt
@@ -57,7 +57,7 @@ semantic-version==2.6.0
 Send2Trash==1.5.0
 showit==1.1.4
 six==1.12.0
-slicedimage==1.0.4
+slicedimage==2.0.0
 sympy==1.3
 terminado==0.8.1
 testpath==0.4.2

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -9,7 +9,7 @@ scikit-image>=0.14.0
 scikit-learn
 scipy
 showit >= 1.1.4
-slicedimage == 1.0.4
+slicedimage == 2.0.0
 scikit-learn
 sympy
 tqdm

--- a/data_formatting_examples/format_baristaseq.py
+++ b/data_formatting_examples/format_baristaseq.py
@@ -17,7 +17,7 @@ from starfish.experiment.builder import (FetchedTile, TileFetcher,
                                          write_experiment_json)
 from starfish.types import Axes, Coordinates, Number
 
-DEFAULT_TILE_SHAPE = 1000, 800
+DEFAULT_TILE_SHAPE = {Axes.Y: 1000, Axes.X: 800}
 
 
 class BaristaSeqTile(FetchedTile):
@@ -25,7 +25,7 @@ class BaristaSeqTile(FetchedTile):
         self.file_path = file_path
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> Mapping[Axes, int]:
         return DEFAULT_TILE_SHAPE
 
     @property

--- a/data_formatting_examples/format_imc_data.py
+++ b/data_formatting_examples/format_imc_data.py
@@ -19,8 +19,8 @@ class ImagingMassCytometryTile(FetchedTile):
         self._tile_data = imread(self.file_path)
 
     @property
-    def shape(self) -> Tuple[int, ...]:
-        return self._tile_data.shape
+    def shape(self) -> Mapping[Axes, int]:
+        return {Axes.Y: self._tile_data.shape[0], Axes.X: self._tile_data.shape[1]}
 
     @property
     def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:

--- a/data_formatting_examples/format_iss_breast_data.py
+++ b/data_formatting_examples/format_iss_breast_data.py
@@ -16,8 +16,8 @@ class IssCroppedBreastTile(FetchedTile):
         self.file_path = file_path
 
     @property
-    def shape(self) -> Tuple[int, ...]:
-        return 1044, 1390
+    def shape(self) -> Mapping[Axes, int]:
+        return {Axes.Y: 1044, Axes.X: 1390}
 
     @property
     def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:

--- a/data_formatting_examples/format_iss_data.py
+++ b/data_formatting_examples/format_iss_data.py
@@ -16,7 +16,7 @@ from starfish.experiment.builder import write_experiment_json
 from starfish.types import Axes, Coordinates, Features, Number
 from starfish.util.argparse import FsExistsType
 
-SHAPE = 980, 1330
+SHAPE = {Axes.Y: 980, Axes.X: 1330}
 
 
 class ISSTile(FetchedTile):
@@ -24,7 +24,7 @@ class ISSTile(FetchedTile):
         self.file_path = file_path
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> Mapping[Axes, int]:
         return SHAPE
 
     @property

--- a/data_formatting_examples/format_merfish_U2OS_data.py
+++ b/data_formatting_examples/format_merfish_U2OS_data.py
@@ -11,7 +11,7 @@ from starfish.experiment.builder import FetchedTile, TileFetcher, write_experime
 from starfish.types import Axes, Coordinates, Number
 from starfish.util.argparse import FsExistsType
 
-SHAPE = 2048, 2048
+SHAPE = {Axes.Y: 2048, Axes.X: 2048}
 
 
 # We use this to cache images across tiles.  In the case of the merfish data set, FOVs are saved
@@ -47,7 +47,7 @@ class MERFISHTile(FetchedTile):
         self.ch = ch
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> Mapping[Axes, int]:
         return SHAPE
 
     @property
@@ -69,7 +69,7 @@ class MERFISHAuxTile(FetchedTile):
         self.dapi_index = 17
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> Mapping[Axes, int]:
         return SHAPE
 
     @property

--- a/data_formatting_examples/format_osmfish.py
+++ b/data_formatting_examples/format_osmfish.py
@@ -45,8 +45,16 @@ class osmFISHTile(FetchedTile):
         self._coordinates = coordinates
 
     @property
-    def shape(self) -> Tuple[int, ...]:
-        return self.tile_data().shape
+    def shape(self) -> Mapping[Axes, int]:
+        """
+        Gets image shape directly from the data. Note that this will result in the data being
+        read twice, since the shape is retrieved from all tiles before the data is read, and thus
+        single-file caching does not resolve the duplicated reads.
+
+        Because the data here isn't tremendously large, this is acceptable in this instance.
+        """
+        raw_shape = self.tile_data().shape
+        return {Axes.Y: raw_shape[0], Axes.X: raw_shape[1]}
 
     @property
     def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:

--- a/data_formatting_examples/format_seqFISH.py
+++ b/data_formatting_examples/format_seqFISH.py
@@ -35,7 +35,7 @@ class SeqFISHTile(FetchedTile):
         self._coordinates = coordinates
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> Mapping[Axes, int]:
         """
         Gets image shape directly from the data. Note that this will result in the data being
         read twice, since the shape is retrieved from all tiles before the data is read, and thus
@@ -43,7 +43,8 @@ class SeqFISHTile(FetchedTile):
 
         Because the data here isn't tremendously large, this is acceptable in this instance.
         """
-        return self.tile_data().shape
+        raw_shape = self.tile_data().shape
+        return {Axes.Y: raw_shape[0], Axes.X: raw_shape[1]}
 
     @property
     def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:

--- a/data_formatting_examples/format_starmap.py
+++ b/data_formatting_examples/format_starmap.py
@@ -55,8 +55,8 @@ class StarMapTile(FetchedTile):
         }
 
     @property
-    def shape(self) -> Tuple[int, ...]:
-        return (3738, 17247)  # hard coded for these datasets.
+    def shape(self) -> Mapping[Axes, int]:
+        return {Axes.Y: 3738, Axes.X: 17247}  # hard coded for these datasets.
 
     @property
     def coordinates(self):

--- a/starfish/experiment/builder/__init__.py
+++ b/starfish/experiment/builder/__init__.py
@@ -62,7 +62,7 @@ def build_image(
         chs: Sequence[int],
         zplanes: Sequence[int],
         image_fetcher: TileFetcher,
-        default_shape: Optional[Tuple[int, int]]=None,
+        default_shape: Optional[Mapping[Axes, int]]=None,
         axes_order: Sequence[Axes]=DEFAULT_DIMENSION_ORDER,
 ) -> Collection:
     """
@@ -153,7 +153,7 @@ def write_experiment_json(
         primary_tile_fetcher: Optional[TileFetcher]=None,
         aux_tile_fetcher: Optional[Mapping[str, TileFetcher]]=None,
         postprocess_func: Optional[Callable[[dict], dict]]=None,
-        default_shape: Optional[Tuple[int, int]]=None,
+        default_shape: Optional[Mapping[Axes, int]]=None,
         dimension_order: Sequence[Axes]=(Axes.ZPLANE, Axes.ROUND, Axes.CH),
 ) -> None:
     """

--- a/starfish/experiment/builder/defaultproviders.py
+++ b/starfish/experiment/builder/defaultproviders.py
@@ -9,7 +9,7 @@ from slicedimage import (
     ImageFormat,
 )
 
-from starfish.types import Coordinates, Number
+from starfish.types import Axes, Coordinates, Number
 from .providers import FetchedTile, TileFetcher
 
 
@@ -19,8 +19,8 @@ class RandomNoiseTile(FetchedTile):
     for the image.
     """
     @property
-    def shape(self) -> Tuple[int, ...]:
-        return 1536, 1024
+    def shape(self) -> Mapping[Axes, int]:
+        return {Axes.Y: 1536, Axes.X: 1024}
 
     @property
     def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
@@ -35,7 +35,8 @@ class RandomNoiseTile(FetchedTile):
         return ImageFormat.TIFF
 
     def tile_data(self) -> np.ndarray:
-        return np.random.randint(0, 256, size=self.shape, dtype=np.uint8)
+        return np.random.randint(
+            0, 256, size=(self.shape[Axes.Y], self.shape[Axes.X]), dtype=np.uint8)
 
 
 class OnesTile(FetchedTile):
@@ -43,12 +44,12 @@ class OnesTile(FetchedTile):
     This is a simple implementation of :class:`.FetchedImage` that simply is entirely all pixels at
     maximum intensity.
     """
-    def __init__(self, shape: Tuple[int, int]) -> None:
+    def __init__(self, shape: Mapping[Axes, int]) -> None:
         super().__init__()
         self._shape = shape
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> Mapping[Axes, int]:
         return self._shape
 
     @property
@@ -64,7 +65,10 @@ class OnesTile(FetchedTile):
         return ImageFormat.TIFF
 
     def tile_data(self) -> np.ndarray:
-        return np.full(shape=self.shape, fill_value=1.0, dtype=np.float32)
+        return np.full(
+            shape=(self.shape[Axes.Y], self.shape[Axes.X]),
+            fill_value=1.0,
+            dtype=np.float32)
 
 
 def tile_fetcher_factory(

--- a/starfish/experiment/builder/providers.py
+++ b/starfish/experiment/builder/providers.py
@@ -6,7 +6,7 @@ from typing import Mapping, Tuple, Union
 
 import numpy as np
 
-from starfish.types import Coordinates, Number
+from starfish.types import Axes, Coordinates, Number
 
 
 class FetchedTile:
@@ -17,13 +17,13 @@ class FetchedTile:
         pass
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> Mapping[Axes, int]:
         """Return Tile shape.
 
         Returns
         -------
-        Tuple[int, ...]
-            The tile shape in (y, x)
+        Mapping[Axis, int]
+            The shape of the tile, mapping from Axes to its size.
         """
         raise NotImplementedError()
 
@@ -50,7 +50,7 @@ class FetchedTile:
         return {}
 
     def tile_data(self) -> np.ndarray:
-        """Return the image data representing the tile.
+        """Return the image data representing the tile.  The tile must be row-major.
 
         Returns
         -------

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -146,7 +146,7 @@ class ImageStack:
             data_tick_marks[dim_for_axis.value] = list(
                 sorted(set(tilekey[dim_for_axis] for tilekey in self._tile_data.keys())))
 
-        data_shape.extend(tile_data.tile_shape)
+        data_shape.extend([tile_data.tile_shape[Axes.Y], tile_data.tile_shape[Axes.X]])
         data_dimensions.extend([Axes.Y.value, Axes.X.value])
 
         # now that we know the tile data type (kind and size), we can allocate the data array.
@@ -993,7 +993,7 @@ class ImageStack:
                 Axes.CH: self.num_chs,
                 Axes.ZPLANE: self.num_zplanes,
             },
-            default_tile_shape=self.tile_shape,
+            default_tile_shape={Axes.Y: self.tile_shape[0], Axes.X: self.tile_shape[1]},
             extras=self._tile_data.extras,
         )
         for tilekey in self._tile_data.keys():
@@ -1102,7 +1102,7 @@ class ImageStack:
             tile_fetcher = tile_fetcher_factory(
                 OnesTile,
                 False,
-                (tile_height, tile_width),
+                {Axes.Y: tile_height, Axes.X: tile_width},
             )
 
         collection = build_image(

--- a/starfish/imagestack/parser/_tiledata.py
+++ b/starfish/imagestack/parser/_tiledata.py
@@ -11,11 +11,18 @@ class TileData:
     Base class for a parser to implement that provides the data for a single tile.
     """
     @property
-    def tile_shape(self) -> Tuple[int, int]:
+    def tile_shape(self) -> Mapping[Axes, int]:
         raise NotImplementedError()
 
     @property
     def numpy_array(self) -> np.ndarray:
+        """Return the image data representing the tile.  The tile must be row-major.
+
+        Returns
+        -------
+        ndarray :
+            The image data
+        """
         raise NotImplementedError()
 
     @property
@@ -41,7 +48,7 @@ class TileCollectionData:
         raise NotImplementedError()
 
     @property
-    def tile_shape(self) -> Tuple[int, int]:
+    def tile_shape(self) -> Mapping[Axes, int]:
         """Returns the shape of a tile."""
         raise NotImplementedError()
 

--- a/starfish/imagestack/parser/crop.py
+++ b/starfish/imagestack/parser/crop.py
@@ -103,16 +103,16 @@ class CropParameters:
 
         return start, stop
 
-    def crop_shape(self, shape: Tuple[int, int]) -> Tuple[int, int]:
+    def crop_shape(self, shape: Mapping[Axes, int]) -> Mapping[Axes, int]:
         """
         Given the shape of the original tile, return the shape of the cropped tile.
         """
-        output_x_shape = CropParameters._crop_axis(shape[1], self._x_slice)
-        output_y_shape = CropParameters._crop_axis(shape[0], self._y_slice)
+        output_x_shape = CropParameters._crop_axis(shape[Axes.X], self._x_slice)
+        output_y_shape = CropParameters._crop_axis(shape[Axes.Y], self._y_slice)
         width = output_x_shape[1] - output_x_shape[0]
         height = output_y_shape[1] - output_y_shape[0]
 
-        return height, width
+        return {Axes.Y: height, Axes.X: width}
 
     def crop_image(self, image: np.ndarray) -> np.ndarray:
         """
@@ -126,7 +126,7 @@ class CropParameters:
     def crop_coordinates(
             self,
             coordinates: Mapping[Coordinates, Tuple[Number, Number]],
-            shape: Tuple[int, int],
+            shape: Mapping[Axes, int],
     ) -> Mapping[Coordinates, Tuple[Number, Number]]:
         """
         Given a mapping of coordinate to coordinate values, return a mapping of the coordinate to
@@ -137,12 +137,12 @@ class CropParameters:
         if self._x_slice is not None:
             xmin, xmax = recalculate_physical_coordinate_range(
                 xmin, xmax,
-                shape[1],
+                shape[Axes.X],
                 self._x_slice)
         if self._y_slice is not None:
             ymin, ymax = recalculate_physical_coordinate_range(
                 ymin, ymax,
-                shape[0],
+                shape[Axes.Y],
                 self._y_slice)
 
         return_coords = {
@@ -161,7 +161,7 @@ class CroppedTileData(TileData):
         self.cropping_parameters = cropping_parameters
 
     @property
-    def tile_shape(self) -> Tuple[int, int]:
+    def tile_shape(self) -> Mapping[Axes, int]:
         return self.cropping_parameters.crop_shape(self.backing_tile_data.tile_shape)
 
     @property
@@ -197,7 +197,7 @@ class CroppedTileCollectionData(TileCollectionData):
         return self.crop_parameters.filter_tilekeys(self.backing_tile_collection_data.keys())
 
     @property
-    def tile_shape(self) -> Tuple[int, int]:
+    def tile_shape(self) -> Mapping[Axes, int]:
         return self.crop_parameters.crop_shape(self.backing_tile_collection_data.tile_shape)
 
     @property

--- a/starfish/imagestack/parser/numpy/__init__.py
+++ b/starfish/imagestack/parser/numpy/__init__.py
@@ -42,8 +42,11 @@ class NumpyImageTile(TileData):
         self._selector = selector
 
     @property
-    def tile_shape(self) -> Tuple[int, int]:
-        return self._data.shape
+    def tile_shape(self) -> Mapping[Axes, int]:
+        raw_tile_shape = self._data.shape
+        assert len(raw_tile_shape) == 2
+        tile_shape = {Axes.Y: raw_tile_shape[0], Axes.X: raw_tile_shape[1]}
+        return tile_shape
 
     @property
     def numpy_array(self):
@@ -102,8 +105,8 @@ class NumpyData(TileCollectionData):
         return keys
 
     @property
-    def tile_shape(self) -> Tuple[int, int]:
-        return self.data.shape[-2:]
+    def tile_shape(self) -> Mapping[Axes, int]:
+        return {Axes.Y: self.data.shape[-2], Axes.X: self.data.shape[-1]}
 
     @property
     def extras(self) -> dict:

--- a/starfish/imagestack/parser/tileset/_parser.py
+++ b/starfish/imagestack/parser/tileset/_parser.py
@@ -22,11 +22,14 @@ class _TileSetConsistencyDetector:
     trigger a :py:class:`starfish.errors.DataFormatWarning`.
     """
     def __init__(self) -> None:
-        self.tile_shape: Optional[Tuple[int, ...]] = None
+        self.tile_shape: Optional[Mapping[Axes, int]] = None
         self.kind = None
         self.dtype_size = None
 
-    def report_tile_shape(self, r: int, ch: int, zplane: int, tile_shape: Tuple[int, ...]) -> None:
+    def report_tile_shape(
+            self,
+            r: int, ch: int, zplane: int,
+            tile_shape: Mapping[Axes, int]) -> None:
         """As each tile is parsed, the tile shape should be reported via this method.  If an
         inconsistency is detected, a ValueError exception will be raised.
 
@@ -34,8 +37,8 @@ class _TileSetConsistencyDetector:
         ----------
         r, ch, zplane : int
             The indices of the tile, which is used to generate the exception text.
-        tile_shape : Tuple[int, ...]
-            The shape of the tile.
+        tile_shape : Mapping[Axes, int]
+            The shape of the tile, mapping from Axes to its size.
         """
         if self.tile_shape is not None and self.tile_shape != tile_shape:
             raise ValueError(
@@ -99,9 +102,11 @@ class SlicedImageTile(TileData):
         self._expectations.report_dtype(self._r, self._ch, self._zplane, self._numpy_array.dtype)
 
     @property
-    def tile_shape(self) -> Tuple[int, int]:
+    def tile_shape(self) -> Mapping[Axes, int]:
         self._load()
-        tile_shape = self._numpy_array.shape
+        raw_tile_shape = self._numpy_array.shape
+        assert len(raw_tile_shape) == 2
+        tile_shape = {Axes.Y: raw_tile_shape[0], Axes.X: raw_tile_shape[1]}
         self._expectations.report_tile_shape(self._r, self._ch, self._zplane, tile_shape)
         return tile_shape
 
@@ -156,7 +161,7 @@ class TileSetData(TileCollectionData):
         return self.tiles.keys()
 
     @property
-    def tile_shape(self) -> Tuple[int, int]:
+    def tile_shape(self) -> Mapping[Axes, int]:
         return self._tile_shape
 
     @property
@@ -181,7 +186,7 @@ class TileSetData(TileCollectionData):
 
 def parse_tileset(
         tileset: TileSet
-) -> Tuple[Tuple[int, int], TileCollectionData]:
+) -> Tuple[Mapping[Axes, int], TileCollectionData]:
     """
     Parse a :py:class:`slicedimage.TileSet` for formatting into an
     :py:class:`starfish.imagestack.ImageStack`.

--- a/starfish/spacetx_format/schema/field_of_view/field_of_view.json
+++ b/starfish/spacetx_format/schema/field_of_view/field_of_view.json
@@ -74,16 +74,41 @@
       }
     },
     "default_tile_shape": {
-      "type": "array",
-      "minItems": 2,
-      "maxItems": 2,
-      "items": {
-        "type": "integer",
-        "description": "The default tile shape (x, y) of the tiles in this field of view.",
-        "example": 2048,
-        "minimum": 0,
-        "maximum": 3000
-      }
+      "oneOf": [
+        {
+          "type": "array",
+          "description": "The default tile shape (y, x) of the tiles in this field of view.",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "type": "integer",
+            "example": 2048,
+            "minimum": 0,
+            "maximum": 3000
+          }
+        },
+        {
+          "type": "object",
+          "description": "The default tile shape of the tiles in this field of view.",
+          "properties": {
+            "x": {
+              "type": "integer",
+              "description": "The width of the tile in pixels.",
+              "minimum": 1
+            },
+            "y": {
+              "type": "integer",
+              "description": "The height of the tile in pixels.",
+              "minimum": 1
+            }
+          },
+          "required": [
+            "x",
+            "y"
+          ],
+          "additionalProperties": false
+        }
+      ]
     },
     "default_tile_format": {
       "type": "string",

--- a/starfish/spacetx_format/schema/field_of_view/tiles/tiles.json
+++ b/starfish/spacetx_format/schema/field_of_view/tiles/tiles.json
@@ -37,15 +37,41 @@
       ]
     },
     "tile_shape": {
-      "type": "array",
-      "minItems": 2,
-      "maxItems": 2,
-      "items": {
-        "type": "integer",
-        "description": "The shape (x, y) of this tile.",
-        "minimum": 0,
-        "maximum": 3000
-      }
+      "oneOf": [
+        {
+          "type": "array",
+          "description": "The default tile shape (y, x) of the tiles in this field of view.",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "type": "integer",
+            "example": 2048,
+            "minimum": 0,
+            "maximum": 3000
+          }
+        },
+        {
+          "type": "object",
+          "description": "The default tile shape of the tiles in this field of view.",
+          "properties": {
+            "x": {
+              "type": "integer",
+              "description": "The width of the tile in pixels.",
+              "minimum": 1
+            },
+            "y": {
+              "type": "integer",
+              "description": "The height of the tile in pixels.",
+              "minimum": 1
+            }
+          },
+          "required": [
+            "x",
+            "y"
+          ],
+          "additionalProperties": false
+        }
+      ]
     },
     "extras": {
       "description": "Unstructured field used to contain additional data about this data manifest.",

--- a/starfish/test/experiment/test_experiment.py
+++ b/starfish/test/experiment/test_experiment.py
@@ -32,7 +32,7 @@ def get_aligned_tileset():
     alignedTileset = TileSet(
         [Axes.X, Axes.Y, Axes.CH, Axes.ZPLANE, Axes.ROUND],
         {Axes.CH: NUM_CH, Axes.ROUND: NUM_ROUND, Axes.ZPLANE: NUM_Z},
-        (HEIGHT, WIDTH))
+        {Axes.Y: HEIGHT, Axes.X: WIDTH})
 
     for r in range(NUM_ROUND):
         for ch in range(NUM_CH):
@@ -58,7 +58,7 @@ def get_un_aligned_tileset():
     unAlignedTileset = TileSet(
         [Axes.X, Axes.Y, Axes.CH, Axes.ZPLANE, Axes.ROUND],
         {Axes.CH: NUM_CH, Axes.ROUND: NUM_ROUND, Axes.ZPLANE: NUM_Z},
-        (HEIGHT, WIDTH))
+        {Axes.Y: HEIGHT, Axes.X: WIDTH})
 
     for r in range(NUM_ROUND):
         for ch in range(NUM_CH):

--- a/starfish/test/image/test_imagestack_coordinates.py
+++ b/starfish/test/image/test_imagestack_coordinates.py
@@ -41,8 +41,8 @@ class AlignedTiles(FetchedTile):
         self._zplane = z
 
     @property
-    def shape(self) -> Tuple[int, ...]:
-        return HEIGHT, WIDTH
+    def shape(self) -> Mapping[Axes, int]:
+        return {Axes.Y: HEIGHT, Axes.X: WIDTH}
 
     @property
     def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
@@ -87,8 +87,8 @@ class ScalarTiles(FetchedTile):
         self._zplane = z
 
     @property
-    def shape(self) -> Tuple[int, ...]:
-        return HEIGHT, WIDTH
+    def shape(self) -> Mapping[Axes, int]:
+        return {Axes.Y: HEIGHT, Axes.X: WIDTH}
 
     @property
     def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
@@ -113,8 +113,8 @@ class OffsettedTiles(FetchedTile):
         self._round = _round
 
     @property
-    def shape(self) -> Tuple[int, ...]:
-        return HEIGHT, WIDTH
+    def shape(self) -> Mapping[Axes, int]:
+        return {Axes.Y: HEIGHT, Axes.X: WIDTH}
 
     @property
     def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:

--- a/starfish/test/image/test_imagestack_cropped_load.py
+++ b/starfish/test/image/test_imagestack_cropped_load.py
@@ -52,8 +52,8 @@ class UniqueTiles(FetchedTile):
         self._zplane = zplane
 
     @property
-    def shape(self) -> Tuple[int, ...]:
-        return HEIGHT, WIDTH
+    def shape(self) -> Mapping[Axes, int]:
+        return {Axes.Y: HEIGHT, Axes.X: WIDTH}
 
     @property
     def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:

--- a/starfish/test/image/test_imagestack_labeled_indices.py
+++ b/starfish/test/image/test_imagestack_labeled_indices.py
@@ -44,8 +44,8 @@ class UniqueTiles(FetchedTile):
         self._zplane = zplane
 
     @property
-    def shape(self) -> Tuple[int, ...]:
-        return HEIGHT, WIDTH
+    def shape(self) -> Mapping[Axes, int]:
+        return {Axes.Y: HEIGHT, Axes.X: WIDTH}
 
     @property
     def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:

--- a/starfish/test/image/test_imagestack_metadata.py
+++ b/starfish/test/image/test_imagestack_metadata.py
@@ -11,7 +11,7 @@ NUM_ZPLANE = 12
 
 class OnesTilesWithExtras(OnesTile):
     def __init__(self, extras: dict, *args, **kwargs) -> None:
-        super().__init__((10, 10))
+        super().__init__({Axes.Y: 10, Axes.X: 10})
         self._extras = extras
 
     @property
@@ -46,7 +46,7 @@ def test_missing_extras():
     """
     class OnesTilesWithExtrasMostly(OnesTile):
         def __init__(self, fov, r, ch, z, extras: dict) -> None:
-            super().__init__((10, 10))
+            super().__init__({Axes.Y: 10, Axes.X: 10})
             self.fov = fov
             self._extras = extras
 

--- a/starfish/test/image/test_slicedimage_dtype.py
+++ b/starfish/test/image/test_slicedimage_dtype.py
@@ -9,7 +9,7 @@ from slicedimage import ImageFormat
 from starfish.errors import DataFormatWarning
 from starfish.experiment.builder import FetchedTile, TileFetcher
 from starfish.imagestack.imagestack import ImageStack
-from starfish.types import Coordinates, Number
+from starfish.types import Axes, Coordinates, Number
 
 NUM_ROUND = 2
 NUM_CH = 2
@@ -24,8 +24,8 @@ class OnesTilesByDtype(FetchedTile):
         self._dtype = dtype
 
     @property
-    def shape(self) -> Tuple[int, ...]:
-        return HEIGHT, WIDTH
+    def shape(self) -> Mapping[Axes, int]:
+        return {Axes.Y: HEIGHT, Axes.X: WIDTH}
 
     @property
     def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:


### PR DESCRIPTION
1. Where tile shape is being used, we use a dict between axis and the size of the tile along that axis.
2. Where there is a contract for tile data, we indicate that the data should be row-major.

Test plan: `make -j fast`  tests on travis will not complete until https://github.com/spacetx/slicedimage/pull/81 has landed and a new version is released.

Resolves #528