### PR TITLE
Add LocalSearchBlobDetector to support BaristaSeq, SeqFISH, STARmap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,9 @@ jobs:
     - name: SeqFISH Notebook
       if: type = push and branch =~ /^(master|merge)/
       script: make install-dev run__notebooks/py/SeqFISH.py
+    - name: STARmap Notebook
+      if: type = push and branch =~ /^(master|merge)/
+      script: make install-dev run__notebooks/py/STARmap.py
     - name: Released Notebooks
       if: type = cron and branch =~ /^(master|merge)/
       script: make check_notebooks install-released-notebooks-support run_notebooks

--- a/notebooks/STARmap.ipynb
+++ b/notebooks/STARmap.ipynb
@@ -1,0 +1,298 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from itertools import product\n",
+    "from functools import partial\n",
+    "from typing import Tuple\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "import starfish\n",
+    "import starfish.data\n",
+    "from starfish.types import Axes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%gui qt\n",
+    "import starfish.display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 672/672 [00:13<00:00, 49.38it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "experiment = starfish.data.STARmap(use_test_data=True)\n",
+    "stack = experiment['fov_000'].get_image('primary')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 28/28 [00:00<00:00, 206.46it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# look at the channel/round projection\n",
+    "ch_r_projection = stack.max_proj(Axes.CH, Axes.ROUND)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<napari_gui.elements._viewer.Viewer at 0x1f31ded68>"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "starfish.display.stack(ch_r_projection)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It actually looks like there is a small shift approximately the size of a spot in the `x = -y` direction for at least one (round, channel) pair (see top left corner for most obvious manifestation).\n",
+    "\n",
+    "Attempt a translation registration to fix. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 6/6 [00:00<00:00, 178.07it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Starmap only requires translation. Verify that things are registered with a quick \n",
+    "# similarity registration. \n",
+    "\n",
+    "from skimage.feature import register_translation\n",
+    "from skimage.transform import warp\n",
+    "from skimage.transform import SimilarityTransform\n",
+    "\n",
+    "def _register_imagestack(target_image, reference_image, upsample_factor=5):\n",
+    "    target_image = np.squeeze(target_image)\n",
+    "    reference_image = np.squeeze(reference_image)\n",
+    "    shift, error, phasediff = register_translation(target_image, reference_image, upsample_factor=1)\n",
+    "    return SimilarityTransform(translation=shift)\n",
+    "\n",
+    "# identify the locations of all the spots by max projecting over z\n",
+    "projection = stack.max_proj(Axes.CH, Axes.ZPLANE)\n",
+    "reference_image = projection.sel({Axes.ROUND: 1}).xarray\n",
+    "\n",
+    "# learn the transformations for each stack\n",
+    "register_imagestack = partial(\n",
+    "    _register_imagestack, reference_image=reference_image, upsample_factor=5\n",
+    ")\n",
+    "transforms = projection.transform(register_imagestack, group_by={Axes.ROUND}, n_processes=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[array([-2., -2.]),\n",
+       " array([0., 0.]),\n",
+       " array([0., 0.]),\n",
+       " array([0., 0.]),\n",
+       " array([-1.,  0.]),\n",
+       " array([0., 0.])]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[t.translation for (t, ind) in transforms]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Unfortunately, simple translation registration can't improve upon this problem significantly. To account for this, a small local search will be allowed in the spot finding step to match spots across (round, channel) volumes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The first stage of the STARmap pipeline is to align the intensity distributions across channels and rounds. Here we calculate a reference distribution by sorting each image's intensities in increasing order and averaging the ordered intensities across rounds and channels. All (z, y, x) volumes from each round and channel are quantile normalized against this reference. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Calculating reference distribution...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "24it [02:24,  6.59s/it]\n"
+     ]
+    }
+   ],
+   "source": [
+    "mh = starfish.image.Filter.MatchHistograms({Axes.CH, Axes.ROUND})\n",
+    "stack = mh.run(stack, in_place=True, verbose=True, n_processes=8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, a local blob detector that finds spots in each (z, y, x) volume separately is applied. The user selects an \"anchor round\" and spots found in all channels of that round are used to seed a local search across other rounds and channels. The closest spot is selected, and any spots outside the search radius (here 10 pixels) is discarded.\n",
+    "\n",
+    "The Spot finder returns an IntensityTable containing all spots from round zero. Note that many of the spots do _not_ identify spots in other rounds and channels and will therefore fail decoding. Because of the stringency built into the STARmap codebook, it is OK to be relatively permissive with the spot finding parameters for this assay."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "lsbd = starfish.spots._detector.local_search_blob_detector.LocalSearchBlobDetector(\n",
+    "    min_sigma=1,\n",
+    "    max_sigma=8,\n",
+    "    num_sigma=10,\n",
+    "    threshold=np.percentile(np.ravel(substack.xarray.values), 95),\n",
+    "    exclude_border=2,\n",
+    "    anchor_round=0,\n",
+    "    search_radius=10,\n",
+    ")\n",
+    "intensities = lsbd.run(stack, n_processes=8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This viewer call displays all detected spots, regardless of whether or not they decode. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viewer = starfish.display.stack(stack, intensities, radius_multiplier=0.1, mask_intensities=0.01)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, spots are decoded, and only spots that pass the decoding stage are displayed. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "decoded = experiment.codebook.decode_per_round_max(intensities.fillna(0))\n",
+    "decode_mask = decoded['target'] != 'nan'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viewer = starfish.display.stack(stack, decoded[decode_mask], radius_multiplier=0.1, mask_intensities=0.1)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/py/STARmap.py
+++ b/notebooks/py/STARmap.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+# coding: utf-8
+#
+# EPY: stripped_notebook: {"metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}, "language_info": {"codemirror_mode": {"name": "ipython", "version": 3}, "file_extension": ".py", "mimetype": "text/x-python", "name": "python", "nbconvert_exporter": "python", "pygments_lexer": "ipython3", "version": "3.6.5"}}, "nbformat": 4, "nbformat_minor": 2}
+
+# EPY: START markdown
+### Load Data
+# EPY: END markdown
+
+# EPY: START code
+import os
+from itertools import product
+from functools import partial
+from typing import Tuple
+
+import numpy as np
+
+import starfish
+import starfish.data
+from starfish.types import Axes
+# EPY: END code
+
+# EPY: START code
+# EPY: ESCAPE %gui qt
+import starfish.display
+# EPY: END code
+
+# EPY: START code
+experiment = starfish.data.STARmap(use_test_data=True)
+stack = experiment['fov_000'].get_image('primary')
+# EPY: END code
+
+# EPY: START code
+# look at the channel/round projection
+ch_r_projection = stack.max_proj(Axes.CH, Axes.ROUND)
+# EPY: END code
+
+# EPY: START code
+starfish.display.stack(ch_r_projection)
+# EPY: END code
+
+# EPY: START markdown
+#It actually looks like there is a small shift approximately the size of a spot in the `x = -y` direction for at least one (round, channel) pair (see top left corner for most obvious manifestation).
+#
+#Attempt a translation registration to fix. 
+# EPY: END markdown
+
+# EPY: START code
+# Starmap only requires translation. Verify that things are registered with a quick 
+# similarity registration. 
+
+from skimage.feature import register_translation
+from skimage.transform import warp
+from skimage.transform import SimilarityTransform
+
+def _register_imagestack(target_image, reference_image, upsample_factor=5):
+    target_image = np.squeeze(target_image)
+    reference_image = np.squeeze(reference_image)
+    shift, error, phasediff = register_translation(target_image, reference_image, upsample_factor=1)
+    return SimilarityTransform(translation=shift)
+
+# identify the locations of all the spots by max projecting over z
+projection = stack.max_proj(Axes.CH, Axes.ZPLANE)
+reference_image = projection.sel({Axes.ROUND: 1}).xarray
+
+# learn the transformations for each stack
+register_imagestack = partial(
+    _register_imagestack, reference_image=reference_image, upsample_factor=5
+)
+transforms = projection.transform(register_imagestack, group_by={Axes.ROUND}, n_processes=1)
+# EPY: END code
+
+# EPY: START code
+[t.translation for (t, ind) in transforms]
+# EPY: END code
+
+# EPY: START markdown
+#Unfortunately, simple translation registration can't improve upon this problem significantly. To account for this, a small local search will be allowed in the spot finding step to match spots across (round, channel) volumes.
+# EPY: END markdown
+
+# EPY: START markdown
+#The first stage of the STARmap pipeline is to align the intensity distributions across channels and rounds. Here we calculate a reference distribution by sorting each image's intensities in increasing order and averaging the ordered intensities across rounds and channels. All (z, y, x) volumes from each round and channel are quantile normalized against this reference. 
+# EPY: END markdown
+
+# EPY: START code
+mh = starfish.image.Filter.MatchHistograms({Axes.CH, Axes.ROUND})
+stack = mh.run(stack, in_place=True, verbose=True, n_processes=8)
+# EPY: END code
+
+# EPY: START markdown
+#Finally, a local blob detector that finds spots in each (z, y, x) volume separately is applied. The user selects an "anchor round" and spots found in all channels of that round are used to seed a local search across other rounds and channels. The closest spot is selected, and any spots outside the search radius (here 10 pixels) is discarded.
+#
+#The Spot finder returns an IntensityTable containing all spots from round zero. Note that many of the spots do _not_ identify spots in other rounds and channels and will therefore fail decoding. Because of the stringency built into the STARmap codebook, it is OK to be relatively permissive with the spot finding parameters for this assay.
+# EPY: END markdown
+
+# EPY: START code
+lsbd = starfish.spots._detector.local_search_blob_detector.LocalSearchBlobDetector(
+    min_sigma=1,
+    max_sigma=8,
+    num_sigma=10,
+    threshold=np.percentile(np.ravel(substack.xarray.values), 95),
+    exclude_border=2,
+    anchor_round=0,
+    search_radius=10,
+)
+intensities = lsbd.run(stack, n_processes=8)
+# EPY: END code
+
+# EPY: START markdown
+#This viewer call displays all detected spots, regardless of whether or not they decode. 
+# EPY: END markdown
+
+# EPY: START code
+viewer = starfish.display.stack(stack, intensities, radius_multiplier=0.1, mask_intensities=0.01)
+# EPY: END code
+
+# EPY: START markdown
+#Next, spots are decoded, and only spots that pass the decoding stage are displayed. 
+# EPY: END markdown
+
+# EPY: START code
+decoded = experiment.codebook.decode_per_round_max(intensities.fillna(0))
+decode_mask = decoded['target'] != 'nan'
+# EPY: END code
+
+# EPY: START code
+viewer = starfish.display.stack(stack, decoded[decode_mask], radius_multiplier=0.1, mask_intensities=0.1)
+# EPY: END code

--- a/starfish/compat.py
+++ b/starfish/compat.py
@@ -2,7 +2,8 @@ import skimage
 from packaging import version
 
 if version.parse(skimage.__version__) > version.parse("0.14.2"):
-    from skimage.transform import match_histograms
+    import skimage.transform
+    match_histograms = skimage.transform.match_histograms
 else:
 
     """
@@ -98,3 +99,292 @@ else:
             matched = _match_cumulative_cdf(image, reference)
 
         return matched
+
+if version.parse(skimage.__version__) > version.parse("0.14.2"):
+    import skimage.feature
+    blob_log = skimage.feature.blob_log
+    blob_dog = skimage.feature.blob_dog
+else:
+    from skimage.feature.blob import _prune_blobs
+    import numpy as np
+    from scipy.ndimage import gaussian_filter, gaussian_laplace
+    from skimage import img_as_float
+    from skimage.feature import peak_local_max
+
+    def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
+                 overlap=.5, *, exclude_border=False):
+        r"""Finds blobs in the given grayscale image.
+        Blobs are found using the Difference of Gaussian (DoG) method [1]_.
+        For each blob found, the method returns its coordinates and the standard
+        deviation of the Gaussian kernel that detected the blob.
+        Parameters
+        ----------
+        image : 2D or 3D ndarray
+            Input grayscale image, blobs are assumed to be light on dark
+            background (white on black).
+        min_sigma : scalar or sequence of scalars, optional
+            The minimum standard deviation for Gaussian kernel. Keep this low to
+            detect smaller blobs. The standard deviations of the Gaussian filter
+            are given for each axis as a sequence, or as a single number, in
+            which case it is equal for all axes.
+        max_sigma : scalar or sequence of scalars, optional
+            The maximum standard deviation for Gaussian kernel. Keep this high to
+            detect larger blobs. The standard deviations of the Gaussian filter
+            are given for each axis as a sequence, or as a single number, in
+            which case it is equal for all axes.
+        sigma_ratio : float, optional
+            The ratio between the standard deviation of Gaussian Kernels used for
+            computing the Difference of Gaussians
+        threshold : float, optional.
+            The absolute lower bound for scale space maxima. Local maxima smaller
+            than thresh are ignored. Reduce this to detect blobs with less
+            intensities.
+        overlap : float, optional
+            A value between 0 and 1. If the area of two blobs overlaps by a
+            fraction greater than `threshold`, the smaller blob is eliminated.
+        exclude_border : int or bool, optional
+            If nonzero int, `exclude_border` excludes blobs from
+            within `exclude_border`-pixels of the border of the image.
+        Returns
+        -------
+        A : (n, image.ndim + sigma) ndarray
+            A 2d array with each row representing 2 coordinate values for a 2D
+            image, and 3 coordinate values for a 3D image, plus the sigma(s) used.
+            When a single sigma is passed, outputs are:
+            ``(r, c, sigma)`` or ``(p, r, c, sigma)`` where ``(r, c)`` or
+            ``(p, r, c)`` are coordinates of the blob and ``sigma`` is the standard
+            deviation of the Gaussian kernel which detected the blob. When an
+            anisotropic gaussian is used (sigmas per dimension), the detected sigma
+            is returned for each dimension.
+        References
+        ----------
+        .. [1] https://en.wikipedia.org/wiki/Blob_detection#The_difference_of_Gaussians_approach
+        Examples
+        --------
+        >>> from skimage import data, feature
+        >>> feature.blob_dog(data.coins(), threshold=.5, max_sigma=40)
+        array([[ 267.      ,  359.      ,   16.777216],
+            [ 267.      ,  115.      ,   10.48576 ],
+            [ 263.      ,  302.      ,   16.777216],
+            [ 263.      ,  245.      ,   16.777216],
+            [ 261.      ,  173.      ,   16.777216],
+            [ 260.      ,   46.      ,   16.777216],
+            [ 198.      ,  155.      ,   10.48576 ],
+            [ 196.      ,   43.      ,   10.48576 ],
+            [ 195.      ,  102.      ,   16.777216],
+            [ 194.      ,  277.      ,   16.777216],
+            [ 193.      ,  213.      ,   16.777216],
+            [ 185.      ,  347.      ,   16.777216],
+            [ 128.      ,  154.      ,   10.48576 ],
+            [ 127.      ,  102.      ,   10.48576 ],
+            [ 125.      ,  208.      ,   10.48576 ],
+            [ 125.      ,   45.      ,   16.777216],
+            [ 124.      ,  337.      ,   10.48576 ],
+            [ 120.      ,  272.      ,   16.777216],
+            [  58.      ,  100.      ,   10.48576 ],
+            [  54.      ,  276.      ,   10.48576 ],
+            [  54.      ,   42.      ,   16.777216],
+            [  52.      ,  216.      ,   16.777216],
+            [  52.      ,  155.      ,   16.777216],
+            [  45.      ,  336.      ,   16.777216]])
+        Notes
+        -----
+        The radius of each blob is approximately :math:`\sqrt{2}\sigma` for
+        a 2-D image and :math:`\sqrt{3}\sigma` for a 3-D image.
+        """
+
+        image = img_as_float(image)
+
+        # if both min and max sigma are scalar, function returns only one sigma
+        scalar_sigma = np.isscalar(max_sigma) and np.isscalar(min_sigma)
+
+        # Gaussian filter requires that sequence-type sigmas have same
+        # dimensionality as image. This broadcasts scalar kernels
+        if np.isscalar(max_sigma):
+            max_sigma = np.full(image.ndim, max_sigma, dtype=float)
+        if np.isscalar(min_sigma):
+            min_sigma = np.full(image.ndim, min_sigma, dtype=float)
+
+        # Convert sequence types to array
+        min_sigma = np.asarray(min_sigma, dtype=float)
+        max_sigma = np.asarray(max_sigma, dtype=float)
+
+        # k such that min_sigma*(sigma_ratio**k) > max_sigma
+        k = int(np.mean(np.log(max_sigma / min_sigma) / np.log(sigma_ratio) + 1))
+
+        # a geometric progression of standard deviations for gaussian kernels
+        sigma_list = np.array([min_sigma * (sigma_ratio ** i)
+                              for i in range(k + 1)])
+
+        gaussian_images = [gaussian_filter(image, s) for s in sigma_list]
+
+        # computing difference between two successive Gaussian blurred images
+        # multiplying with average standard deviation provides scale invariance
+        dog_images = [(gaussian_images[i] - gaussian_images[i + 1])
+                      * np.mean(sigma_list[i]) for i in range(k)]
+
+        image_cube = np.stack(dog_images, axis=-1)
+
+        # local_maxima = get_local_maxima(image_cube, threshold)
+        local_maxima = peak_local_max(image_cube, threshold_abs=threshold,
+                                      footprint=np.ones((3,) * (image.ndim + 1)),
+                                      threshold_rel=0.0,
+                                      exclude_border=exclude_border)
+        # Catch no peaks
+        if local_maxima.size == 0:
+            return np.empty((0, 3))
+
+        # Convert local_maxima to float64
+        lm = local_maxima.astype(np.float64)
+
+        # translate final column of lm, which contains the index of the
+        # sigma that produced the maximum intensity value, into the sigma
+        sigmas_of_peaks = sigma_list[local_maxima[:, -1]]
+
+        if scalar_sigma:
+            # select one sigma column, keeping dimension
+            sigmas_of_peaks = sigmas_of_peaks[:, 0:1]
+
+        # Remove sigma index and replace with sigmas
+        lm = np.hstack([lm[:, :-1], sigmas_of_peaks])
+
+        return _prune_blobs(lm, overlap)
+
+    def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
+                 overlap=.5, log_scale=False, *, exclude_border=False):
+        r"""Finds blobs in the given grayscale image.
+        Blobs are found using the Laplacian of Gaussian (LoG) method [1]_.
+        For each blob found, the method returns its coordinates and the standard
+        deviation of the Gaussian kernel that detected the blob.
+        Parameters
+        ----------
+        image : 2D or 3D ndarray
+            Input grayscale image, blobs are assumed to be light on dark
+            background (white on black).
+        min_sigma : scalar or sequence of scalars, optional
+            the minimum standard deviation for Gaussian kernel. Keep this low to
+            detect smaller blobs. The standard deviations of the Gaussian filter
+            are given for each axis as a sequence, or as a single number, in
+            which case it is equal for all axes.
+        max_sigma : scalar or sequence of scalars, optional
+            The maximum standard deviation for Gaussian kernel. Keep this high to
+            detect larger blobs. The standard deviations of the Gaussian filter
+            are given for each axis as a sequence, or as a single number, in
+            which case it is equal for all axes.
+        num_sigma : int, optional
+            The number of intermediate values of standard deviations to consider
+            between `min_sigma` and `max_sigma`.
+        threshold : float, optional.
+            The absolute lower bound for scale space maxima. Local maxima smaller
+            than thresh are ignored. Reduce this to detect blobs with less
+            intensities.
+        overlap : float, optional
+            A value between 0 and 1. If the area of two blobs overlaps by a
+            fraction greater than `threshold`, the smaller blob is eliminated.
+        log_scale : bool, optional
+            If set intermediate values of standard deviations are interpolated
+            using a logarithmic scale to the base `10`. If not, linear
+            interpolation is used.
+        exclude_border : int or bool, optional
+            If nonzero int, `exclude_border` excludes blobs from
+            within `exclude_border`-pixels of the border of the image.
+        Returns
+        -------
+        A : (n, image.ndim + sigma) ndarray
+            A 2d array with each row representing 2 coordinate values for a 2D
+            image, and 3 coordinate values for a 3D image, plus the sigma(s) used.
+            When a single sigma is passed, outputs are:
+            ``(r, c, sigma)`` or ``(p, r, c, sigma)`` where ``(r, c)`` or
+            ``(p, r, c)`` are coordinates of the blob and ``sigma`` is the standard
+            deviation of the Gaussian kernel which detected the blob. When an
+            anisotropic gaussian is used (sigmas per dimension), the detected sigma
+            is returned for each dimension.
+        References
+        ----------
+        .. [1] https://en.wikipedia.org/wiki/Blob_detection#The_Laplacian_of_Gaussian
+        Examples
+        --------
+        >>> from skimage import data, feature, exposure
+        >>> img = data.coins()
+        >>> img = exposure.equalize_hist(img)  # improves detection
+        >>> feature.blob_log(img, threshold = .3)
+        array([[ 266.        ,  115.        ,   11.88888889],
+            [ 263.        ,  302.        ,   17.33333333],
+            [ 263.        ,  244.        ,   17.33333333],
+            [ 260.        ,  174.        ,   17.33333333],
+            [ 198.        ,  155.        ,   11.88888889],
+            [ 198.        ,  103.        ,   11.88888889],
+            [ 197.        ,   44.        ,   11.88888889],
+            [ 194.        ,  276.        ,   17.33333333],
+            [ 194.        ,  213.        ,   17.33333333],
+            [ 185.        ,  344.        ,   17.33333333],
+            [ 128.        ,  154.        ,   11.88888889],
+            [ 127.        ,  102.        ,   11.88888889],
+            [ 126.        ,  208.        ,   11.88888889],
+            [ 126.        ,   46.        ,   11.88888889],
+            [ 124.        ,  336.        ,   11.88888889],
+            [ 121.        ,  272.        ,   17.33333333],
+            [ 113.        ,  323.        ,    1.        ]])
+        Notes
+        -----
+        The radius of each blob is approximately :math:`\sqrt{2}\sigma` for
+        a 2-D image and :math:`\sqrt{3}\sigma` for a 3-D image.
+        """
+        image = img_as_float(image)
+
+        # if both min and max sigma are scalar, function returns only one sigma
+        scalar_sigma = (
+            True if np.isscalar(max_sigma) and np.isscalar(min_sigma) else False
+        )
+
+        # Gaussian filter requires that sequence-type sigmas have same
+        # dimensionality as image. This broadcasts scalar kernels
+        if np.isscalar(max_sigma):
+            max_sigma = np.full(image.ndim, max_sigma, dtype=float)
+        if np.isscalar(min_sigma):
+            min_sigma = np.full(image.ndim, min_sigma, dtype=float)
+
+        # Convert sequence types to array
+        min_sigma = np.asarray(min_sigma, dtype=float)
+        max_sigma = np.asarray(max_sigma, dtype=float)
+
+        if log_scale:
+            start, stop = np.log10(min_sigma)[:, None], np.log10(max_sigma)[:, None]
+            space = np.concatenate(
+                [start, stop, np.full_like(start, num_sigma)], axis=1)
+            sigma_list = np.stack([np.logspace(*s) for s in space], axis=1)
+        else:
+            scale = np.linspace(0, 1, num_sigma)[:, None]
+            sigma_list = scale * (max_sigma - min_sigma) + min_sigma
+
+        # computing gaussian laplace
+        # average s**2 provides scale invariance
+        gl_images = [-gaussian_laplace(image, s) * s ** 2
+                     for s in np.mean(sigma_list, axis=1)]
+
+        image_cube = np.stack(gl_images, axis=-1)
+
+        local_maxima = peak_local_max(image_cube, threshold_abs=threshold,
+                                      footprint=np.ones((3,) * (image.ndim + 1)),
+                                      threshold_rel=0.0,
+                                      exclude_border=exclude_border)
+
+        # Catch no peaks
+        if local_maxima.size == 0:
+            return np.empty((0, 3))
+
+        # Convert local_maxima to float64
+        lm = local_maxima.astype(np.float64)
+
+        # translate final column of lm, which contains the index of the
+        # sigma that produced the maximum intensity value, into the sigma
+        sigmas_of_peaks = sigma_list[local_maxima[:, -1]]
+
+        if scalar_sigma:
+            # select one sigma column, keeping dimension
+            sigmas_of_peaks = sigmas_of_peaks[:, 0:1]
+
+        # Remove sigma index and replace with sigmas
+        lm = np.hstack([lm[:, :-1], sigmas_of_peaks])
+
+        return _prune_blobs(lm, overlap)

--- a/starfish/data/__init__.py
+++ b/starfish/data/__init__.py
@@ -112,3 +112,29 @@ def SeqFISH(use_test_data: bool=False):
         f"seqfish{suffix}/experiment.json"
     )
     return Experiment.from_json(url)
+
+
+def STARmap(use_test_data: bool=False):
+    """Loads a STARmap field of view generated from mouse primary visual cortext.
+
+    Parameters
+    ----------
+    use_test_data : bool
+        If true, return a small region of testing data that was visually determined to contain two
+        cells.
+
+    Notes
+    -----
+    starfish received stitched STARmap images. To make it compatible with starfish, we extracted a
+    single field of view with shape (r=6, c=4, z=29, y=1024, x=1024).
+
+    See Also
+    --------
+    Manuscript for STARmap: https://doi.org/10.1126/science.aat5691
+
+    """
+    url = (
+        "https://d2nhj9g34unfro.cloudfront.net/browse/formatted/20190309/"
+        "starmap/experiment.json"
+    )
+    return Experiment.from_json(url)

--- a/starfish/spots/_detector/local_search_blob_detector.py
+++ b/starfish/spots/_detector/local_search_blob_detector.py
@@ -122,6 +122,12 @@ class LocalSearchBlobDetector(SpotFinderAlgorithmBase):
             x_inds = results[:, 2].astype(int)
             intensities = data.values[tuple([z_inds, y_inds, x_inds])]
 
+            # collapse radius if sigma is non-scalar
+            if all(np.isscalar(s) for s in (self.min_sigma, self.max_sigma)):
+                radius = results[:, 3]
+            else:
+                radius = np.mean(results[:, -3:], axis=1)
+
             # construct dataframe
             spot_data = pd.DataFrame(
                 data={
@@ -129,7 +135,7 @@ class LocalSearchBlobDetector(SpotFinderAlgorithmBase):
                     Axes.ZPLANE: z_inds,
                     Axes.Y: y_inds,
                     Axes.X: x_inds,
-                    Features.SPOT_RADIUS: np.mean(results[:, -3:], axis=1)
+                    Features.SPOT_RADIUS: radius
                 }
             )
 
@@ -390,7 +396,7 @@ class LocalSearchBlobDetector(SpotFinderAlgorithmBase):
         return intensity_table
 
     @staticmethod
-    @click.command("BlobDetector")
+    @click.command("LocalSearchBlobDetector")
     @click.option(
         "--min-sigma", default=4, type=int, help="Minimum spot size (in standard deviation).")
     @click.option(

--- a/starfish/spots/_detector/local_search_blob_detector.py
+++ b/starfish/spots/_detector/local_search_blob_detector.py
@@ -1,0 +1,417 @@
+"""
+Note: this blob detector uses the same underlying methods (skimage.blob_log, skimage.blob_dog) as
+the starfish.spots.SpotFinder.BlobDetector. In the future, this and the packages other blob
+detectors should be refactored to merge their functionalities.
+
+See: https://github.com/spacetx/starfish/issues/1005
+"""
+
+from collections import defaultdict
+from typing import Dict, List, Mapping, Optional, Sequence, Tuple, Union
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+from click import Choice
+from sklearn.neighbors import NearestNeighbors
+
+from starfish.compat import blob_dog, blob_log
+from starfish.image._filter.util import determine_axes_to_group_by
+from starfish.imagestack.imagestack import ImageStack
+from starfish.intensity_table.intensity_table import IntensityTable
+from starfish.intensity_table.intensity_table_coordinates import \
+    transfer_physical_coords_from_imagestack_to_intensity_table
+from starfish.types import Axes, Features, Number
+from starfish.util import click
+from ._base import SpotFinderAlgorithmBase
+
+blob_detectors = {
+    'blob_dog': blob_dog,
+    'blob_log': blob_log
+}
+
+
+class LocalSearchBlobDetector(SpotFinderAlgorithmBase):
+
+    def __init__(
+            self,
+            min_sigma: Union[Number, Tuple[Number, ...]],
+            max_sigma: Union[Number, Tuple[Number, ...]],
+            num_sigma: int,
+            threshold: Number,
+            detector_method: str='blob_log',
+            exclude_border: Optional[int]=None,
+            search_radius: int=3,
+            anchor_round: int=1,
+            **detector_kwargs,
+    ) -> None:
+        """Multi-dimensional gaussian spot detector.
+
+        This method is a wrapper for skimage.feature.blob_log that engages in a local radius search
+        to match spots up across rounds. In sparse conditions, the search can be seeded in one round
+        with a relatively large radius. In crowded images, the spots can be seeded in all rounds and
+        consensus filtering can be used to extract codes that are consistently extracted across
+        rounds.
+
+        Parameters
+        ----------
+        min_sigma : float
+            The minimum standard deviation for Gaussian Kernel. Keep this low to
+            detect smaller blobs.
+        max_sigma : float
+            The maximum standard deviation for Gaussian Kernel. Keep this high to
+            detect larger blobs.
+        threshold : float
+            The absolute lower bound for scale space maxima. Local maxima smaller
+            than thresh are ignored. Reduce this to detect blobs with less
+            intensities.
+        detector_method : str ['blob_dog', 'blob_log']
+            Name of the type of detection method used from skimage.feature, default: blob_log.
+        search_radius : int
+            Number of pixels over which to search for spots in other rounds and channels.
+        anchor_round : int
+            The imaging round against which other rounds will be checked for spots in the same
+            approximate pixel location.
+        detector_kwargs : Dict[str, Any]
+            Additional keyword arguments to pass to the detector_method.
+        """
+        self.min_sigma = min_sigma
+        self.max_sigma = max_sigma
+        self.threshold = threshold
+        self.is_volume = True  # TODO test 2-d spot calling
+        self.exclude_border = exclude_border
+        self.search_radius = search_radius
+        self.anchor_round = anchor_round
+        self.detector_kwargs = detector_kwargs
+        try:
+            self.detector_method = blob_detectors[detector_method]
+        except ValueError:
+            raise ValueError(f"Detector method must be one of {list(blob_detectors.keys())}")
+
+    def _spot_finder(self, data: xr.DataArray) -> pd.DataFrame:
+        """Find spots in a data volume.
+
+        Parameters
+        ----------
+        data : xr.DataArray
+            3D (z, y, x) data volume in which spots will be identified.
+
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame wrapping the output of skimage blob_log or blob_dog with named outputs.
+
+        """
+
+        # results = np.ndarray: n_spots x (z, y, x, radius, sigma_z, sigma_y, sigma_x)
+        results = self.detector_method(
+            data,
+            min_sigma=self.min_sigma,
+            max_sigma=self.max_sigma,
+            threshold=self.threshold,
+            exclude_border=self.exclude_border,
+            **self.detector_kwargs
+        )
+
+        # if spots were detected
+        if results.shape[0]:
+
+            # measure intensities
+            z_inds = results[:, 0].astype(int)
+            y_inds = results[:, 1].astype(int)
+            x_inds = results[:, 2].astype(int)
+            intensities = data.values[tuple([z_inds, y_inds, x_inds])]
+
+            # construct dataframe
+            spot_data = pd.DataFrame(
+                data={
+                    "intensity": intensities,
+                    Axes.ZPLANE: z_inds,
+                    Axes.Y: y_inds,
+                    Axes.X: x_inds,
+                    Features.SPOT_RADIUS: np.mean(results[:, -3:], axis=1)
+                }
+            )
+
+        else:
+            spot_data = pd.DataFrame(
+                data=np.array(
+                    [],
+                    dtype=[
+                        ('intensity', float), ('z', int), ('y', int), ('x', int),
+                        (Features.SPOT_RADIUS, float)
+                    ]
+                )
+            )
+
+        return spot_data
+
+    def _find_spots(
+        self,
+        data_stack: ImageStack,
+        verbose: bool=False,
+        n_processes: Optional[int]=None
+    ) -> Dict[Tuple[int, int], np.ndarray]:
+        """Find spots in all (z, y, x) volumes of an ImageStack.
+
+        Parameters
+        ----------
+        data_stack : ImageStack
+            Stack containing spots to find.
+
+        Returns
+        -------
+        Dict[Tuple[int, int], np.ndarray]
+            Dictionary mapping (round, channel) pairs to a spot table generated by skimage blob_log
+            or blob_dog.
+
+        """
+        # find spots in each (r, c) volume
+        transform_results = data_stack.transform(
+            self._spot_finder,
+            group_by=determine_axes_to_group_by(self.is_volume),
+            n_processes=n_processes,
+        )
+
+        # create output dictionary
+        spot_results = {}
+        for spot_calls, axes_dict in transform_results:
+            r = axes_dict[Axes.ROUND]
+            c = axes_dict[Axes.CH]
+            spot_results[r, c] = spot_calls
+
+        return spot_results
+
+    @staticmethod
+    def _merge_spots_by_round(
+        spot_results: Dict[Tuple[int, int], pd.DataFrame]
+    ) -> Dict[int, pd.DataFrame]:
+        """Merge DataFrames containing spots from different channels into one DataFrame per round.
+
+        Executed on the output of
+        Parameters
+        ----------
+        spot_results : Dict[Tuple[int, int], pd.DataFrame]
+            Output of _find_spots. Dictionary mapping (round, channel) volumes to the spots detected
+            in them.
+
+        Returns
+        -------
+        Dict[int, pd.DataFrame]
+            Dictionary mapping round volumes to the spots detected in them. Contains an additional
+            column labeled by Axes.CH which identifies the channel in which a given spot was
+            detected.
+
+        """
+
+        # add channel information to each table and add it to round_data
+        round_data: Mapping[int, List] = defaultdict(list)
+        for (r, c), df in spot_results.items():
+            df[Axes.CH.value] = np.full(df.shape[0], c)
+            round_data[r].append(df)
+
+        # create one dataframe per round
+        round_dataframes = {
+            k: pd.concat(v, axis=0).reset_index().drop('index', axis=1)
+            for k, v in round_data.items()
+        }
+
+        return round_dataframes
+
+    @staticmethod
+    def _match_spots(
+        round_dataframes: Dict[int, pd.DataFrame], search_radius: int, anchor_round: int
+    ) -> Tuple[pd.DataFrame, pd.DataFrame]:
+        """ For each spot in anchor round, find the closest spot within search_radius in all rounds.
+
+        Parameters
+        ----------
+        round_dataframes : Dict[int, pd.DataFrame]
+            Output from _merge_spots_by_round, contains mapping of image volumes from each round to
+            all the spots detected in them.
+        search_radius : int
+            The maximum (euclidean) distance in pixels for a spot to be considered matching in
+            a round subsequent to the anchor round.
+        anchor_round : int
+            The imaging round to seed the local search from.
+
+        Returns
+        -------
+        pd.DataFrame
+            Spots x rounds dataframe containing the distances to the nearest spot. np.nan if
+            no spot is detected within search radius
+        pd.DataFrame
+            Spots x rounds dataframe containing the indices of the nearest spot to the
+            corresponding round_dataframe. np.nan if no spot is detected within search radius.
+
+        """
+        reference_df = round_dataframes[anchor_round]
+        reference_coordinates = reference_df[[Axes.ZPLANE, Axes.Y, Axes.X]]
+
+        dist = pd.DataFrame(
+            data=np.zeros((reference_df.shape[0], len(round_dataframes)), dtype=float),
+            columns=list(round_dataframes.keys())
+        )
+        ind = pd.DataFrame(
+            data=np.zeros((reference_df.shape[0], len(round_dataframes)), dtype=np.int32),
+            columns=list(round_dataframes.keys())
+        )
+
+        # fill data for anchor round; every spot is a perfect match to itself.
+        ind[anchor_round] = np.arange(reference_df.shape[0], dtype=np.int32)
+
+        # get spots matching across rounds
+        for r in sorted(set(round_dataframes.keys()) - {anchor_round, }):
+            query_df = round_dataframes[r]
+            query_coordinates = query_df[[Axes.ZPLANE, Axes.Y, Axes.X]]
+
+            # Build the classifier; chose NN over radius neighbors because data structures are
+            # amenable to vectorization, which improves execution time.
+            # TODO ambrosejcarr use n_neighbors > 1 to break ties, enable codebook-based finding
+            #      use additional axes in dist, ind to retain vectorization.
+            nn = NearestNeighbors(n_neighbors=1)
+            nn.fit(query_coordinates)
+
+            distances, indices = nn.kneighbors(reference_coordinates)
+            dist[r] = distances
+            ind[r] = indices
+
+        return dist, ind
+
+    @staticmethod
+    def _build_intensity_table(
+        round_dataframes: Dict[int, pd.DataFrame],
+        dist: pd.DataFrame,
+        ind: pd.DataFrame,
+        channels: Sequence[int],
+        rounds: Sequence[int],
+        search_radius: int,
+        anchor_round: int,
+    ) -> IntensityTable:
+        """Construct an intensity table from the results of a local search over detected spots
+
+        Parameters
+        ----------
+        round_dataframes : Dict[int, pd.DataFrame]
+            Output from _merge_spots_by_round, contains mapping of image volumes from each round to
+            all the spots detected in them.
+        dist, ind : pd.DataFrame
+            Output from _match_spots, contains distances and indices to the nearest spot for each
+            spot in anchor_round.
+        channels, rounds : Sequence[int]
+            Channels and rounds present in the ImageStack from which spots were detected.
+        search_radius : int
+            The maximum (euclidean) distance in pixels for a spot to be considered matching in
+            a round subsequent to the anchor round.
+        anchor_round : int
+            The imaging round to seed the local search from.
+
+        """
+
+        anchor_df = round_dataframes[anchor_round]
+
+        # create empty IntensityTable filled with np.nan
+        data = np.full((dist.shape[0], len(channels), len(rounds)), fill_value=np.nan)
+        dims = (Features.AXIS, Axes.CH.value, Axes.ROUND.value)
+        coords = {
+            Features.SPOT_RADIUS: (Features.AXIS, anchor_df[Features.SPOT_RADIUS]),
+            Axes.ZPLANE.value: (Features.AXIS, anchor_df[Axes.ZPLANE]),
+            Axes.Y.value: (Features.AXIS, anchor_df[Axes.Y]),
+            Axes.X.value: (Features.AXIS, anchor_df[Axes.X]),
+            Axes.ROUND.value: (Axes.ROUND.value, rounds),
+            Axes.CH.value: (Axes.CH.value, channels)
+        }
+        intensity_table = IntensityTable(data=data, dims=dims, coords=coords)
+
+        # fill IntensityTable
+        for r in rounds:
+
+            # get intensity data and indices
+            spot_indices = ind[r]
+            intensity_data = round_dataframes[r].loc[spot_indices, 'intensity']
+            channel_index = round_dataframes[r].loc[spot_indices, Axes.CH]
+            round_index = np.full(ind.shape[0], fill_value=r, dtype=int)
+            feature_index = np.arange(ind.shape[0], dtype=int)
+
+            # mask spots that are outside the search radius
+            mask = np.asarray(dist[r] < search_radius)  # indices need not match
+            feature_index = feature_index[mask]
+            channel_index = channel_index[mask]
+            round_index = round_index[mask]
+            intensity_data = intensity_data[mask]
+
+            # need numpy indexing to set values in vectorized manner
+            intensity_table.values[feature_index, channel_index, round_index] = intensity_data
+
+        return intensity_table
+
+    def run(
+        self, data: ImageStack, verbose: bool=False, n_processes: Optional[int]=None
+    ) -> IntensityTable:
+        """Find 1-hot coded spots in data.
+
+        Parameters
+        ----------
+        data : ImageStack
+            Image data containing coded spots.
+        verbose : bool
+            If True, report on progress of spot finding.
+        n_processes : Optional[int]
+            Number of processes to devote to spot finding. If None, will use the number of available
+            cpus (Default None).
+
+        Returns
+        -------
+        IntensityTable
+            Contains detected coded spots.
+
+        """
+        per_tile_spot_results = self._find_spots(data, verbose=verbose, n_processes=n_processes)
+
+        per_round_spot_results = self._merge_spots_by_round(per_tile_spot_results)
+
+        distances, indices = self._match_spots(
+            per_round_spot_results,
+            search_radius=self.search_radius, anchor_round=self.anchor_round
+        )
+
+        # TODO implement consensus seeding (SeqFISH)
+
+        intensity_table = self._build_intensity_table(
+            per_round_spot_results, distances, indices,
+            rounds=data.xarray[Axes.ROUND.value].values, channels=data.xarray[Axes.CH.value].values,
+            search_radius=self.search_radius, anchor_round=self.anchor_round
+        )
+
+        transfer_physical_coords_from_imagestack_to_intensity_table(
+            image_stack=data, intensity_table=intensity_table
+        )
+
+        return intensity_table
+
+    @staticmethod
+    @click.command("BlobDetector")
+    @click.option(
+        "--min-sigma", default=4, type=int, help="Minimum spot size (in standard deviation).")
+    @click.option(
+        "--max-sigma", default=6, type=int, help="Maximum spot size (in standard deviation).")
+    @click.option(
+        "--threshold", default=.01, type=float, help="Dots threshold.")
+    @click.option(
+        "--overlap", default=0.5, type=float,
+        help="Dots with overlap of greater than this fraction are combined.")
+    @click.option(
+        "--detector-method", default='blob_log', type=Choice(['blob_log', 'blob_dog']),
+        help="Name of the type of the skimage blob detection method.")
+    @click.option(
+        "--search-radius", default=3, type=int,
+        help="Number of pixels over which to search for spots in other image tiles.")
+    @click.pass_context
+    def _cli(
+        ctx, min_sigma, max_sigma, threshold, overlap, show, detector_method, search_radius
+    ) -> None:
+        instance = LocalSearchBlobDetector(
+            min_sigma, max_sigma, threshold, overlap,
+            detector_method=detector_method, search_radius=search_radius
+        )
+        ctx.obj["component"]._cli_run(ctx, instance)

--- a/starfish/test/spots/detector/test_local_search_blob_detector.py
+++ b/starfish/test/spots/detector/test_local_search_blob_detector.py
@@ -1,0 +1,155 @@
+import numpy as np
+from scipy.ndimage.filters import gaussian_filter
+
+from starfish import ImageStack
+from starfish.spots._detector.local_search_blob_detector import LocalSearchBlobDetector
+from starfish.types import Axes
+
+
+def traversing_code() -> ImageStack:
+    """this code walks in a sequential direction, and should only be detectable from some anchors"""
+    img = np.zeros((3, 2, 20, 50, 50), dtype=np.float32)
+
+    # code 1
+    img[0, 0, 5, 35, 35] = 10
+    img[1, 1, 5, 32, 32] = 10
+    img[2, 0, 5, 29, 29] = 10
+
+    # blur points
+    gaussian_filter(img, (0, 0, 0.5, 1.5, 1.5), output=img)
+
+    return ImageStack.from_numpy_array(img)
+
+
+def multiple_possible_neighbors() -> ImageStack:
+    """this image is intended to be tested with anchor_round in {0, 1}, last round has more spots"""
+    img = np.zeros((3, 2, 20, 50, 50), dtype=np.float32)
+
+    # round 1
+    img[0, 0, 5, 20, 40] = 10
+    img[0, 0, 5, 40, 20] = 10
+
+    # round 2
+    img[1, 1, 5, 20, 40] = 10
+    img[1, 1, 5, 40, 20] = 10
+
+    # round 3
+    img[2, 0, 5, 20, 40] = 10
+    img[2, 0, 5, 35, 35] = 10
+    img[2, 0, 5, 40, 20] = 10
+
+    # blur points
+    gaussian_filter(img, (0, 0, 0.5, 1.5, 1.5), output=img)
+
+    return ImageStack.from_numpy_array(img)
+
+
+def jitter_code() -> ImageStack:
+    """this code has some minor jitter <= 3px at the most distant point"""
+    img = np.zeros((3, 2, 20, 50, 50), dtype=np.float32)
+
+    # code 1
+    img[0, 0, 5, 35, 35] = 10
+    img[1, 1, 5, 34, 35] = 10
+    img[2, 0, 6, 35, 33] = 10
+
+    # blur points
+    gaussian_filter(img, (0, 0, 0.5, 1.5, 1.5), output=img)
+
+    return ImageStack.from_numpy_array(img)
+
+
+def two_perfect_codes() -> ImageStack:
+    """this code has no jitter"""
+    img = np.zeros((3, 2, 20, 50, 50), dtype=np.float32)
+
+    # code 1
+    img[0, 0, 5, 20, 35] = 10
+    img[1, 1, 5, 20, 35] = 10
+    img[2, 0, 5, 20, 35] = 10
+
+    # code 1
+    img[0, 0, 5, 40, 45] = 10
+    img[1, 1, 5, 40, 45] = 10
+    img[2, 0, 5, 40, 45] = 10
+
+    # blur points
+    gaussian_filter(img, (0, 0, 0.5, 1.5, 1.5), output=img)
+
+    return ImageStack.from_numpy_array(img)
+
+
+def local_search_blob_detector(search_radius: int, anchor_channel=0) -> LocalSearchBlobDetector:
+    return LocalSearchBlobDetector(
+        min_sigma=(0.4, 1.2, 1.2),
+        max_sigma=(0.6, 1.7, 1.7),
+        num_sigma=3,
+        threshold=0.1,
+        is_volume=True,
+        overlap=0.5,
+        search_radius=search_radius,
+        anchor_round=anchor_channel,
+    )
+
+
+def test_local_search_blob_detector_two_codes():
+    stack = two_perfect_codes()
+    lsbd = local_search_blob_detector(search_radius=1)
+    intensity_table = lsbd.run(stack, n_processes=1)
+
+    assert intensity_table.shape == (2, 2, 3)
+    assert np.all(intensity_table[0][Axes.X.value] == 45)
+    assert np.all(intensity_table[0][Axes.Y.value] == 40)
+    assert np.all(intensity_table[0][Axes.ZPLANE.value] == 5)
+
+
+def test_local_search_blob_detector_jitter_code():
+    stack = jitter_code()
+    lsbd = local_search_blob_detector(search_radius=3)
+    intensity_table = lsbd.run(stack, n_processes=1)
+
+    assert intensity_table.shape == (1, 2, 3)
+    f, c, r = np.where(~intensity_table.isnull())
+    assert np.all(f == np.array([0, 0, 0]))
+    assert np.all(c == np.array([0, 0, 1]))
+    assert np.all(r == np.array([0, 2, 1]))
+
+    # test again with smaller search radius
+    lsbd = local_search_blob_detector(search_radius=1)
+    intensity_table = lsbd.run(stack, n_processes=1)
+    assert intensity_table.shape == (1, 2, 3)
+    f, c, r = np.where(~intensity_table.isnull())
+    assert np.all(f == np.array([0]))
+    assert np.all(c == np.array([0]))
+    assert np.all(r == np.array([0]))
+
+
+def test_local_search_blob_detector_traversing_code():
+    stack = traversing_code()
+    lsbd = local_search_blob_detector(search_radius=5, anchor_channel=0)
+    intensity_table = lsbd.run(stack, n_processes=1)
+
+    assert intensity_table.shape == (1, 2, 3)
+    f, c, r = np.where(~intensity_table.isnull())
+    assert np.all(f == np.array([0, 0]))
+    assert np.all(c == np.array([0, 1]))
+    assert np.all(r == np.array([0, 1]))
+
+    lsbd = local_search_blob_detector(search_radius=5, anchor_channel=1)
+    intensity_table = lsbd.run(stack, n_processes=1)
+    f, c, r = np.where(~intensity_table.isnull())
+    assert np.all(f == np.array([0, 0, 0]))
+    assert np.all(c == np.array([0, 0, 1]))
+    assert np.all(r == np.array([0, 2, 1]))
+
+
+def test_local_search_blob_detector_multiple_neighbors():
+    stack = multiple_possible_neighbors()
+    lsbd = local_search_blob_detector(search_radius=4, anchor_channel=0)
+    intensity_table = lsbd.run(stack, n_processes=1)
+
+    assert intensity_table.shape == (2, 2, 3)
+    f, c, r = np.where(~intensity_table.isnull())
+    assert np.all(intensity_table[Axes.ZPLANE.value] == (5, 5))
+    assert np.all(intensity_table[Axes.Y.value] == (40, 20))
+    assert np.all(intensity_table[Axes.X.value] == (20, 40))

--- a/starfish/test/spots/detector/test_local_search_blob_detector.py
+++ b/starfish/test/spots/detector/test_local_search_blob_detector.py
@@ -85,7 +85,6 @@ def local_search_blob_detector(search_radius: int, anchor_channel=0) -> LocalSea
         max_sigma=(0.6, 1.7, 1.7),
         num_sigma=3,
         threshold=0.1,
-        is_volume=True,
         overlap=0.5,
         search_radius=search_radius,
         anchor_round=anchor_channel,


### PR DESCRIPTION
This PR adds a Spot Detector that enables a local search across (round, channel) pairs. It is able to overcome minor registration errors in data for which the average registration error is smaller than the average distance to the closest spot. 

This PR seeds the local search in a single round, which is adequate for BaristaSeq and STARmap, but multi-round consensus seeding will be added in future PRs for SeqFISH. 

The private methods have been separated out with an eye towards the eventual spot finding refactor in #1005. 