### PR TITLE
Bump certifi

### DIFF
--- a/REQUIREMENTS-STRICT.txt
+++ b/REQUIREMENTS-STRICT.txt
@@ -2,7 +2,7 @@
 appnope==0.1.0
 backcall==0.1.0
 bleach==3.1.0
-certifi==2018.11.29
+certifi==2019.3.9
 chardet==3.0.4
 Click==7.0
 cloudpickle==0.8.0

--- a/starfish/REQUIREMENTS-STRICT.txt
+++ b/starfish/REQUIREMENTS-STRICT.txt
@@ -2,7 +2,7 @@
 appnope==0.1.0
 backcall==0.1.0
 bleach==3.1.0
-certifi==2018.11.29
+certifi==2019.3.9
 chardet==3.0.4
 Click==7.0
 cloudpickle==0.8.0


### PR DESCRIPTION
It seems like Docker build can't deal with requests to install older versions of certifi other than is installed by travis by default.