### PR TITLE
Add Decoded Spot Table

### DIFF
--- a/docs/source/sptx-format/output_formats/DecodedSpots/index.rst
+++ b/docs/source/sptx-format/output_formats/DecodedSpots/index.rst
@@ -1,0 +1,45 @@
+.. _DecodedSpotsSpecification:
+
+DecodedSpots
+================
+The :py:class:`DecodedSpots` is a 2-dimensional tabular data structure where each record represents
+a spot, and each record contains, at minimum, columns that specify the `x` and `y` coordinates of
+the spot in physical space and the genes that it targets.
+
+Additional columns are not validated, however there are several optional columns with standard
+names. If those data are available, methods that take :py:class:`DecodedSpots` objects may make
+use of them, so it is in users interests to name those columns appropriately.
+
+Required Columns
+----------------
+
+These columns must be present for an object to be constructed.
+
+:code:`target (str):` the gene target for the spot
+
+:code:`x (float):` the x coordinate of the spot in physical space
+
+:code:`y (float):` the y coordinate of the spot in physical space
+
+Optional Columns
+----------------
+
+These columns are not validated, but have special meaning to :py:class:`DecodedSpots`
+
+:code:`z (float):` the z coordinate of the spot in physical space
+
+:code:`target_probability (float):` the quality of the decoding, or probability that the spot is
+associated with the listed target.
+
+:code:`cell (int):` the identifier of the cell that contains this spot.
+
+:code:`cell_probability (float):` the quality of a cell association, or probability that the spot
+is associated with the listed cell.
+
+Implementation
+--------------
+Starfish Implements the :py:class:`DecodedSpots` as a wrapper for the :code:`pd.DataFrame` object
+
+Serialization
+-------------
+:py:class:`DecodedSpots` defines methods to save and load the spot file as a csv file.

--- a/docs/source/sptx-format/output_formats/index.rst
+++ b/docs/source/sptx-format/output_formats/index.rst
@@ -12,4 +12,7 @@ Output Formats
     ExpressionMatrix/index.rst
 
 .. toctree::
+    DecodedSpots/index.rst
+
+.. toctree::
     SegmentationMask/index.rst

--- a/starfish/intensity_table/intensity_table.py
+++ b/starfish/intensity_table/intensity_table.py
@@ -8,7 +8,7 @@ import regional
 import xarray as xr
 
 from starfish.expression_matrix.expression_matrix import ExpressionMatrix
-from starfish.types import Axes, Features, LOG, SpotAttributes, DecodedSpots, STARFISH_EXTRAS_KEY
+from starfish.types import Axes, DecodedSpots, Features, LOG, SpotAttributes, STARFISH_EXTRAS_KEY
 from starfish.util.dtype import preserve_float_range
 
 

--- a/starfish/test/test_decoded_spots.py
+++ b/starfish/test/test_decoded_spots.py
@@ -1,12 +1,12 @@
 import os
+import tempfile
 
 import pandas as pd
 import pytest
-import tempfile
 
 from starfish import IntensityTable
-from starfish.types import Coordinates, DecodedSpots, Features
 from starfish.test import test_utils
+from starfish.types import Coordinates, DecodedSpots, Features
 
 
 def dummy_intensities() -> IntensityTable:
@@ -51,5 +51,3 @@ def test_decoded_spots() -> None:
     # load back into memory
     ds2 = DecodedSpots.load_csv(filename)
     pd.testing.assert_frame_equal(ds.data, ds2.data)
-
-    import pdb; pdb.set_trace()

--- a/starfish/test/test_decoded_spots.py
+++ b/starfish/test/test_decoded_spots.py
@@ -1,0 +1,55 @@
+import os
+
+import pandas as pd
+import pytest
+import tempfile
+
+from starfish import IntensityTable
+from starfish.types import Coordinates, DecodedSpots, Features
+from starfish.test import test_utils
+
+
+def dummy_intensities() -> IntensityTable:
+
+    codebook = test_utils.codebook_array_factory()
+    intensities = IntensityTable.synthetic_intensities(
+        codebook,
+        num_z=10,
+        height=10,
+        width=10,
+        n_spots=5,
+    )
+
+    intensities[Coordinates.Z.value] = (Features.AXIS, [0, 1, 0, 1, 0])
+    intensities[Coordinates.Y.value] = (Features.AXIS, [10, 30, 50, 40, 20])
+    intensities[Coordinates.X.value] = (Features.AXIS, [50.2, 30.2, 60.2, 40.2, 70.2])
+
+    # remove target from dummy to test error messages
+    del intensities[Features.TARGET]
+
+    return intensities
+
+
+def test_decoded_spots() -> None:
+    data = dummy_intensities()
+
+    with pytest.raises(RuntimeError):
+        data.to_decoded_spots()
+
+    # mock decoder run by adding target list
+    data[Features.TARGET] = (Features.AXIS, list('abcde'))
+
+    ds = data.to_decoded_spots()
+
+    assert ds.data.shape[0] == 5
+
+    # test serialization
+    tempdir = tempfile.mkdtemp()
+    filename = os.path.join(tempdir, 'spots.csv')
+    ds.save_csv(filename)
+
+    # load back into memory
+    ds2 = DecodedSpots.load_csv(filename)
+    pd.testing.assert_frame_equal(ds.data, ds2.data)
+
+    import pdb; pdb.set_trace()

--- a/starfish/types/__init__.py
+++ b/starfish/types/__init__.py
@@ -11,7 +11,7 @@ from ._constants import (
     PhysicalCoordinateTypes,
     STARFISH_EXTRAS_KEY
 )
-from ._spot_attributes import SpotAttributes
 from ._decoded_spots import DecodedSpots
+from ._spot_attributes import SpotAttributes
 
 Number = Union[int, float]

--- a/starfish/types/__init__.py
+++ b/starfish/types/__init__.py
@@ -12,5 +12,6 @@ from ._constants import (
     STARFISH_EXTRAS_KEY
 )
 from ._spot_attributes import SpotAttributes
+from ._decoded_spots import DecodedSpots
 
 Number = Union[int, float]

--- a/starfish/types/_decoded_spots.py
+++ b/starfish/types/_decoded_spots.py
@@ -1,19 +1,15 @@
-import json
-from typing import Iterable
-
-import numpy as np
 import pandas as pd
 
-from starfish.types import Axes, Features
+from starfish.types import Coordinates, Features
 from ._validated_table import ValidatedTable
 
 
 class DecodedSpots(ValidatedTable):
 
     required_fields = {
-        Axes.X.value,          # spot x-coordinate
-        Axes.Y.value,          # spot y-coordinate
-        Features.TARGET,     # spot z-coordinate
+        Coordinates.X.value,          # spot x-coordinate
+        Coordinates.Y.value,          # spot y-coordinate
+        Features.TARGET,     # spot gene target
     }
 
     def __init__(self, decoded_spots: pd.DataFrame) -> None:
@@ -25,26 +21,6 @@ class DecodedSpots(ValidatedTable):
 
         """
         super().__init__(decoded_spots, DecodedSpots.required_fields)
-
-    def save_geojson(self, output_file_name: str) -> None:
-        """Save to geojson for web visualization
-
-        Parameters
-        ----------
-        output_file_name : str
-            name of output json file
-
-        """
-
-        geojson = [
-            {
-                'properties': {'id': int(row.spot_id), 'radius': int(row.r)},
-                'geometry': {'type': 'Point', 'coordinates': [int(row.x), int(row.y)]}
-            } for index, row in self.data.iterrows()
-        ]
-
-        with open(output_file_name, 'w') as f:
-            f.write(json.dumps(geojson))
 
     def save_csv(self, output_file_name: str) -> None:
         self.data.to_csv(output_file_name, index=False)

--- a/starfish/types/_decoded_spots.py
+++ b/starfish/types/_decoded_spots.py
@@ -8,31 +8,23 @@ from starfish.types import Axes, Features
 from ._validated_table import ValidatedTable
 
 
-class SpotAttributes(ValidatedTable):
+class DecodedSpots(ValidatedTable):
 
     required_fields = {
         Axes.X.value,          # spot x-coordinate
         Axes.Y.value,          # spot y-coordinate
-        Axes.ZPLANE.value,     # spot z-coordinate
-        Features.SPOT_RADIUS,  # spot radius
+        Features.TARGET,     # spot z-coordinate
     }
 
-    def __init__(self, spot_attributes: pd.DataFrame) -> None:
-        """Construct a SpotAttributes instance
+    def __init__(self, decoded_spots: pd.DataFrame) -> None:
+        """Construct a decoded_spots instance
 
         Parameters
         ----------
-        spot_attributes : pd.DataFrame
+        decoded_spots : pd.DataFrame
 
         """
-        super().__init__(spot_attributes, SpotAttributes.required_fields)
-
-    @classmethod
-    def empty(cls, extra_fields: Iterable = tuple()) -> "SpotAttributes":
-        """return an empty SpotAttributes object"""
-        fields = list(cls.required_fields.union(extra_fields))
-        dtype = list(zip(fields, [np.object] * len(fields)))
-        return cls(pd.DataFrame(np.array([], dtype=dtype)))
+        super().__init__(decoded_spots, DecodedSpots.required_fields)
 
     def save_geojson(self, output_file_name: str) -> None:
         """Save to geojson for web visualization
@@ -44,7 +36,6 @@ class SpotAttributes(ValidatedTable):
 
         """
 
-        # TODO ambrosejcarr: write a test for this
         geojson = [
             {
                 'properties': {'id': int(row.spot_id), 'radius': int(row.r)},
@@ -54,3 +45,10 @@ class SpotAttributes(ValidatedTable):
 
         with open(output_file_name, 'w') as f:
             f.write(json.dumps(geojson))
+
+    def save_csv(self, output_file_name: str) -> None:
+        self.data.to_csv(output_file_name, index=False)
+
+    @classmethod
+    def load_csv(cls, file_name: str) -> "DecodedSpots":
+        return cls(pd.read_csv(file_name))


### PR DESCRIPTION
Adds a `DecodedSpotTable` and some basic serialization tooling to address #1076. Users who want the underlying dataframe can get it with `DecodedSpotTable.data`. 

See documentation included in PR for more details. 

closes #1076 