### PR TITLE
Enable appending to existing napari viewer in display()

### DIFF
--- a/starfish/_display.py
+++ b/starfish/_display.py
@@ -128,7 +128,7 @@ def display(
         ImageStack to display
     spots : IntensityTable
         IntensityTable containing spot information that was generated from the submitted stack.
-    viewer : napari.components._viewer.model.Viewer
+    viewer : napari.Viewer
         Napari viewer to append the ImageStack and/or spots to. If None, creates a new viewer.
         Note: appending is only supported in interactive environments.
     project_axes : Optional[Set[Axes]]


### PR DESCRIPTION
# Overview
This pull request adds the ability to display multiple `ImageStack` objects in the same napari viewer, as discussed in #1086. Towards this, I added the option to pass in a napari `Viewer` object to `display()`. If the user passes in a `Viewer` object, the stack and/or spots are added as new layers in the existing `Viewer`. If `None` (default) is passed, the stack and/or spots are displayed in a new `Viewer`.  Closes #1086.

# Question
I am not sure what to do for the `viewer` type hint (line 111). It seems to me like we are trying to avoid importing napari at the top of `_display.py` to ease the dependency, so I am not sure how to give the `Viewer` class as a type hint. Thoughts?

# Usage
```python
from starfish import data, FieldOfView, display

# Download the ISS sequencing and dot images
experiment = data.ISS(use_test_data=False)
fov = experiment.fov()
primary_image = fov.get_image(FieldOfView.PRIMARY_IMAGES)
dots = fov.get_image('dots')

# View the dots overlaid on the sequencing images
viewer = display(primary_image)
viewer = display(stack=primary_image, viewer=viewer)
```