### PR TITLE
Add a mechanism to retrieve PipelineComponent by name

### DIFF
--- a/starfish/image/_filter/__init__.py
+++ b/starfish/image/_filter/__init__.py
@@ -7,7 +7,13 @@ from . import _base
 import_all_submodules(__file__, __package__)
 
 
+COMPONENT_NAME = "filter"
+
+
 class Filter(PipelineComponent):
+    @classmethod
+    def pipeline_component_type_name(cls) -> str:
+        return COMPONENT_NAME
 
     @classmethod
     def _get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
@@ -21,7 +27,7 @@ class Filter(PipelineComponent):
         filtered.export(output)
 
     @staticmethod
-    @click.group("filter")
+    @click.group(COMPONENT_NAME)
     @click.option("-i", "--input", type=click.Path(exists=True))
     @click.option("-o", "--output", required=True)
     @click.pass_context

--- a/starfish/image/_registration/__init__.py
+++ b/starfish/image/_registration/__init__.py
@@ -7,7 +7,14 @@ from . import _base
 import_all_submodules(__file__, __package__)
 
 
+COMPONENT_NAME = "registration"
+
+
 class Registration(PipelineComponent):
+
+    @classmethod
+    def pipeline_component_type_name(cls) -> str:
+        return COMPONENT_NAME
 
     @classmethod
     def _get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
@@ -21,7 +28,7 @@ class Registration(PipelineComponent):
         stack.export(output)
 
     @staticmethod
-    @click.group("registration")
+    @click.group(COMPONENT_NAME)
     @click.option("-i", "--input", type=click.Path(exists=True))
     @click.option("-o", "--output", required=True)
     @click.pass_context

--- a/starfish/image/_segmentation/__init__.py
+++ b/starfish/image/_segmentation/__init__.py
@@ -9,7 +9,14 @@ from . import _base
 import_all_submodules(__file__, __package__)
 
 
+COMPONENT_NAME = "segment"
+
+
 class Segmentation(PipelineComponent):
+
+    @classmethod
+    def pipeline_component_type_name(cls) -> str:
+        return COMPONENT_NAME
 
     @classmethod
     def _get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
@@ -27,7 +34,7 @@ class Segmentation(PipelineComponent):
         imsave(output, label_image)
 
     @staticmethod
-    @click.group("segment")
+    @click.group(COMPONENT_NAME)
     @click.option("--primary-images", required=True, type=click.Path(exists=True))
     @click.option("--nuclei", required=True, type=click.Path(exists=True))
     @click.option("-o", "--output", required=True)

--- a/starfish/spots/_decoder/__init__.py
+++ b/starfish/spots/_decoder/__init__.py
@@ -5,11 +5,17 @@ from starfish.intensity_table.intensity_table import IntensityTable
 from starfish.pipeline import AlgorithmBase, import_all_submodules, PipelineComponent
 from starfish.util import click
 from . import _base
-
 import_all_submodules(__file__, __package__)
 
 
+COMPONENT_NAME = "decode"
+
+
 class Decoder(PipelineComponent):
+
+    @classmethod
+    def pipeline_component_type_name(cls) -> str:
+        return COMPONENT_NAME
 
     @classmethod
     def _get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
@@ -24,7 +30,7 @@ class Decoder(PipelineComponent):
         intensities.save(output)
 
     @staticmethod
-    @click.group("decode")
+    @click.group(COMPONENT_NAME)
     @click.option("-i", "--input", required=True, type=click.Path(exists=True))
     @click.option("-o", "--output", required=True)
     @click.option("--codebook", required=True, type=click.Path(exists=True))

--- a/starfish/spots/_detector/__init__.py
+++ b/starfish/spots/_detector/__init__.py
@@ -1,16 +1,21 @@
 from typing import Type
 
-from starfish.codebook.codebook import Codebook
 from starfish.imagestack.imagestack import ImageStack
 from starfish.pipeline import AlgorithmBase, import_all_submodules, PipelineComponent
 from starfish.types import Axes
 from starfish.util import click
 from . import _base
-
 import_all_submodules(__file__, __package__)
 
 
+COMPONENT_NAME = "detect_spots"
+
+
 class SpotFinder(PipelineComponent):
+
+    @classmethod
+    def pipeline_component_type_name(cls) -> str:
+        return COMPONENT_NAME
 
     @classmethod
     def _get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
@@ -41,7 +46,7 @@ class SpotFinder(PipelineComponent):
         intensities.save(output)
 
     @staticmethod
-    @click.group("detect_spots")
+    @click.group(COMPONENT_NAME)
     @click.option("-i", "--input", required=True, type=click.Path(exists=True))
     @click.option("-o", "--output", required=True)
     @click.option(

--- a/starfish/spots/_pixel_decoder/__init__.py
+++ b/starfish/spots/_pixel_decoder/__init__.py
@@ -3,14 +3,19 @@ from typing import Type
 from starfish.codebook.codebook import Codebook
 from starfish.imagestack.imagestack import ImageStack
 from starfish.pipeline import AlgorithmBase, import_all_submodules, PipelineComponent
-from starfish.types import Axes
 from starfish.util import click
 from . import _base
-
 import_all_submodules(__file__, __package__)
 
 
+COMPONENT_NAME = "detect_pixels"
+
+
 class PixelSpotDecoder(PipelineComponent):
+
+    @classmethod
+    def pipeline_component_type_name(cls) -> str:
+        return COMPONENT_NAME
 
     @classmethod
     def _get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
@@ -25,7 +30,7 @@ class PixelSpotDecoder(PipelineComponent):
         intensities.save(output)
 
     @staticmethod
-    @click.group("detect_pixels")
+    @click.group(COMPONENT_NAME)
     @click.option("-i", "--input", required=True, type=click.Path(exists=True))
     @click.option("-o", "--output", required=True)
     @click.option(

--- a/starfish/spots/_target_assignment/__init__.py
+++ b/starfish/spots/_target_assignment/__init__.py
@@ -4,13 +4,20 @@ from typing import Type
 from skimage.io import imread
 
 from starfish.intensity_table.intensity_table import IntensityTable
-from starfish.pipeline import AlgorithmBase, PipelineComponent
+from starfish.pipeline import AlgorithmBase, import_all_submodules, PipelineComponent
 from starfish.util import click
-from . import label
 from ._base import TargetAssignmentAlgorithm
+import_all_submodules(__file__, __package__)
+
+
+COMPONENT_NAME = "target_assignment"
 
 
 class TargetAssignment(PipelineComponent):
+
+    @classmethod
+    def pipeline_component_type_name(cls) -> str:
+        return COMPONENT_NAME
 
     @classmethod
     def _get_algorithm_base_class(cls) -> Type[AlgorithmBase]:
@@ -26,7 +33,7 @@ class TargetAssignment(PipelineComponent):
         assigned.save(os.path.join(output))
 
     @staticmethod
-    @click.group("target_assignment")
+    @click.group(COMPONENT_NAME)
     @click.option("--label-image", required=True, type=click.Path(exists=True))
     @click.option("--intensities", required=True, type=click.Path(exists=True))
     @click.option("-o", "--output", required=True)

--- a/starfish/test/image/filter/test_api_contract.py
+++ b/starfish/test/image/filter/test_api_contract.py
@@ -17,7 +17,7 @@ parameters for the constructor (omit is_volume), and it will be tested against t
 way of registration to the FilterAlgorithmBase
 """
 
-from typing import Dict
+from typing import Mapping, Type
 
 import numpy as np
 import pytest
@@ -26,7 +26,7 @@ from starfish import ImageStack
 from starfish.image import Filter
 from starfish.image._filter.max_proj import MaxProj
 
-methods: Dict = Filter._algorithm_to_class_map()
+methods: Mapping[str, Type] = Filter._algorithm_to_class_map()
 
 
 def generate_default_data():

--- a/starfish/test/pipelinecomponent/test_pipelinecomponent_by_name.py
+++ b/starfish/test/pipelinecomponent/test_pipelinecomponent_by_name.py
@@ -1,0 +1,6 @@
+from starfish.pipeline.pipelinecomponent import PipelineComponentType
+from starfish.spots import Decoder
+
+
+def test_pipelinecomponent_by_name():
+    assert PipelineComponentType.get_pipeline_component_type_by_name("decode") == Decoder


### PR DESCRIPTION
For running pipeline recipes, we will need to refer to pipeline components by name.  To facilitate that, we will adds a map between the pipeline component name and its implementing class.

We mandate each PipelineComponent provide a name, and we source that from the same variable that defines the CLI command name.

Test plan: see new test.