### PR TITLE
[easy] - adding make clean to docs build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ help-unit:
 ### DOCS #####################################################
 #
 docs-%:
-	make -C docs $*
+	make -C docs clean && make -C docs $*
 
 help-docs:
 	$(call print_help, docs-TASK, alias for 'make TASK' in the docs subdirectory)

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ all:	fast
 
 ### UNIT #####################################################
 #
-fast:	lint mypy fast-test docs-html
+fast:	lint mypy fast-test clean-docs docs-html
 
 lint:   lint-non-init lint-init
 
@@ -61,7 +61,10 @@ help-unit:
 ### DOCS #####################################################
 #
 docs-%:
-	make -C docs clean && make -C docs $*
+	make -C docs $*
+
+clean-docs:
+	make -C docs clean
 
 help-docs:
 	$(call print_help, docs-TASK, alias for 'make TASK' in the docs subdirectory)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,7 +43,7 @@ To see the code or report a bug, please visit the `github repository
 
    introduction/introduction
    installation/installation
-   api/index
+   API/index
    contributing
    debugging
    license/index

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,7 +43,7 @@ To see the code or report a bug, please visit the `github repository
 
    introduction/introduction
    installation/installation
-   API/index
+   api/index
    contributing
    debugging
    license/index


### PR DESCRIPTION
So when we delete/rename/reorganize pipeline components the docs build doesn't freakout. 