### PR TITLE
Tweak the release procedures so we push to master.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,8 @@ help-install:
 # General release steps:
 # --------------------------------------------------------------
 #
-#  (0) Check out the latest version of the branch for releasing.
+#  (0) Pull master and check out the latest version of master for
+#      releasing.
 #
 #  (1) `make release-changelog` to print a suggested update to
 #      CHANGELOG.md. Replace "XXX" with your intended tag and
@@ -161,18 +162,20 @@ help-install:
 #  (2) Commit all files and remove any untracked files.
 #      `git status` should show nothing.
 #
-#  (3) Run `make release-tag TAG=x.y.z` to tag your release.
+#  (3) Push master to origin, i.e., `git push origin master`.
 #
-#  (4) Run `make release-prep` which:
+#  (4) Run `make release-tag TAG=x.y.z` to tag your release.
+#
+#  (5) Run `make release-prep` which:
 #     - checks the tag
 #     - creates a virtualenv
 #     - builds and installs the sdist
 #
-#  (5) Run `make release-verify` which:
+#  (6) Run `make release-verify` which:
 #     - runs tests
 #     - builds docker
 #
-#  (6) Run `make release-upload` and execute the commands.
+#  (7) Run `make release-upload` and execute the commands.
 #
 #  If anything goes wrong, rollback the various steps:
 #     - delete on docker hub


### PR DESCRIPTION
versioneer depends on the git tag being somewhere in the lineage of master.  This updated procedure tries to get the tag into the lineage of master.