### PR TITLE
[easy] Only run the install napari test on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ jobs:
       after_success:
         - bash <(curl -s https://codecov.io/bash)
     - name: Install Napari
+      if: type = push and branch =~ /^(master|merge)/
       script: pip install .[napari]
     - name: Docker
       if: type = push and branch =~ /^(master|merge)/


### PR DESCRIPTION
This doesn't change often enough to justify running on every branch.