### PR TITLE
Fix code coverage detection

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "**/test/*.py"
+  - "starfish/_version.py"


### PR DESCRIPTION
Exclude the test files from the calculations of what code is covered.

Also exclude the file that's autogenerated by versioneer.

This is based on #1111 