### PR TITLE
Remove cropping from PixelSpotDetector

### DIFF
--- a/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
+++ b/notebooks/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.ipynb
@@ -245,6 +245,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Crop size\n",
+    "It can be a good idea to eliminate parts of the image that suffer from boundary effects \n",
+    "from signal aquisition (e.g., FOV overlap) and image processing. In this example we do\n",
+    "not crop, but a good default value would be about 40 pixels. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Decode\n",
     "\n",
     "Each assay type also exposes a decoder. A decoder translates each spot (spot_id) in the encoded table into a gene that matches a barcode in the codebook. The goal is to decode and output a quality score, per spot, that describes the confidence in the decoding. Recall that in the MERFISH pipeline, each 'spot' is actually a 16 dimensional vector, one per pixel in the image. From here on, we will refer to these as pixel vectors. Once these pixel vectors are decoded into gene values, contiguous pixels that are decoded to the same gene are labeled as 'spots' via a connected components labeler. We shall refer to the latter as spots.\n",
@@ -262,9 +272,6 @@
     "### Area threshold\n",
     "Contiguous pixels that decode to the same gene are called as spots via connected components labeling. The minimum area of these spots are set by this parameter. The intuition is that pixel vectors, that pass the distance and magnitude thresholds, shold probably not be trusted as genes as the mRNA transcript would be too small for them to be real. This parameter can be set based on microscope resolution and signal amplification strategy.\n",
     "\n",
-    "### Crop size\n",
-    "The crop size crops the image by a number of pixels large enough to eliminate parts of the image that suffer from boundary effects from both signal aquisition (e.g., FOV overlap) and image processing. Here this value is 40.\n",
-    "\n",
     "Given these three thresholds, for each pixel vector, the decoder picks the closest code (minimum distance) that satisfies each of the above thresholds, where the distance is calculated between the code and a normalized intensity vector and throws away subsequent spots that are too small."
    ]
   },
@@ -274,7 +281,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# TODO this crop should be (x, y) = (40, 40) but it was getting eaten by kwargs\n",
     "from starfish.spots import PixelSpotDecoder\n",
     "psd = PixelSpotDecoder.PixelSpotDecoder(\n",
     "    codebook=experiment.codebook,\n",
@@ -284,9 +290,6 @@
     "    min_area=2,\n",
     "    max_area=np.inf,\n",
     "    norm_order=2,\n",
-    "    crop_z=0,\n",
-    "    crop_y=0,\n",
-    "    crop_x=0\n",
     ")\n",
     "\n",
     "initial_spot_intensities, prop_results = psd.run(scaled_image)\n",

--- a/notebooks/py/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
+++ b/notebooks/py/MERFISH_Pipeline_-_U2O2_Cell_Culture_-_1_FOV.py
@@ -152,6 +152,13 @@ for selector in primary_image._iter_axes():
 # EPY: END markdown
 
 # EPY: START markdown
+#### Crop size
+#It can be a good idea to eliminate parts of the image that suffer from boundary effects 
+#from signal aquisition (e.g., FOV overlap) and image processing. In this example we do
+#not crop, but a good default value would be about 40 pixels. 
+# EPY: END markdown
+
+# EPY: START markdown
 ### Decode
 #
 #Each assay type also exposes a decoder. A decoder translates each spot (spot_id) in the encoded table into a gene that matches a barcode in the codebook. The goal is to decode and output a quality score, per spot, that describes the confidence in the decoding. Recall that in the MERFISH pipeline, each 'spot' is actually a 16 dimensional vector, one per pixel in the image. From here on, we will refer to these as pixel vectors. Once these pixel vectors are decoded into gene values, contiguous pixels that are decoded to the same gene are labeled as 'spots' via a connected components labeler. We shall refer to the latter as spots.
@@ -169,14 +176,10 @@ for selector in primary_image._iter_axes():
 #### Area threshold
 #Contiguous pixels that decode to the same gene are called as spots via connected components labeling. The minimum area of these spots are set by this parameter. The intuition is that pixel vectors, that pass the distance and magnitude thresholds, shold probably not be trusted as genes as the mRNA transcript would be too small for them to be real. This parameter can be set based on microscope resolution and signal amplification strategy.
 #
-#### Crop size
-#The crop size crops the image by a number of pixels large enough to eliminate parts of the image that suffer from boundary effects from both signal aquisition (e.g., FOV overlap) and image processing. Here this value is 40.
-#
 #Given these three thresholds, for each pixel vector, the decoder picks the closest code (minimum distance) that satisfies each of the above thresholds, where the distance is calculated between the code and a normalized intensity vector and throws away subsequent spots that are too small.
 # EPY: END markdown
 
 # EPY: START code
-# TODO this crop should be (x, y) = (40, 40) but it was getting eaten by kwargs
 from starfish.spots import PixelSpotDecoder
 psd = PixelSpotDecoder.PixelSpotDecoder(
     codebook=experiment.codebook,
@@ -186,9 +189,6 @@ psd = PixelSpotDecoder.PixelSpotDecoder(
     min_area=2,
     max_area=np.inf,
     norm_order=2,
-    crop_z=0,
-    crop_y=0,
-    crop_x=0
 )
 
 initial_spot_intensities, prop_results = psd.run(scaled_image)

--- a/starfish/spots/_pixel_decoder/pixel_spot_decoder.py
+++ b/starfish/spots/_pixel_decoder/pixel_spot_decoder.py
@@ -15,8 +15,8 @@ from .combine_adjacent_features import CombineAdjacentFeatures, ConnectedCompone
 class PixelSpotDecoder(PixelDecoderAlgorithmBase):
     def __init__(
             self, codebook: Codebook, metric: str, distance_threshold: float,
-            magnitude_threshold: int, min_area: int, max_area: int, norm_order: int=2,
-            crop_x: int=0, crop_y: int=0, crop_z: int=0) -> None:
+            magnitude_threshold: int, min_area: int, max_area: int, norm_order: int = 2
+    ) -> None:
         """Decode an image by first coding each pixel, then combining the results into spots
 
         Parameters
@@ -37,10 +37,6 @@ class PixelSpotDecoder(PixelDecoderAlgorithmBase):
         norm_order : int
             order of L_p norm to apply to intensities and codes when using metric_decode to pair
             each intensities to its closest target (default = 2)
-        crop_x, crop_y, crop_z : int
-            number of pixels to crop from the top and bottom of each of the x, y, and z axes of
-            an ImageStack (default = 0)
-
         """
         self.codebook = codebook
         self.metric = metric
@@ -49,9 +45,6 @@ class PixelSpotDecoder(PixelDecoderAlgorithmBase):
         self.min_area = min_area
         self.max_area = max_area
         self.norm_order = norm_order
-        self.crop_x = crop_x
-        self.crop_y = crop_y
-        self.crop_z = crop_z
 
     def run(
             self,
@@ -77,8 +70,7 @@ class PixelSpotDecoder(PixelDecoderAlgorithmBase):
             Results of connected component labeling
 
         """
-        pixel_intensities = IntensityTable.from_image_stack(
-            primary_image, crop_x=self.crop_x, crop_y=self.crop_y, crop_z=self.crop_z)
+        pixel_intensities = IntensityTable.from_image_stack(primary_image)
         decoded_intensities = self.codebook.metric_decode(
             pixel_intensities,
             max_distance=self.distance_threshold,
@@ -122,12 +114,10 @@ class PixelSpotDecoder(PixelDecoderAlgorithmBase):
         help="order of L_p norm to apply to intensities "
         "and codes when using metric_decode to pair each intensities to its closest target"
     )
-    @click.option('--crop-x', type=int, default=0)
-    @click.option('--crop-y', type=int, default=0)
-    @click.option('--crop-z', type=int, default=0)
     @click.pass_context
-    def _cli(ctx, metric, distance_threshold, magnitude_threshold,
-             min_area, max_area, norm_order, crop_x, crop_y, crop_z):
+    def _cli(
+        ctx, metric, distance_threshold, magnitude_threshold, min_area, max_area, norm_order
+    ):
         codebook = ctx.obj["codebook"]
         instance = PixelSpotDecoder(
             codebook=codebook,
@@ -137,8 +127,5 @@ class PixelSpotDecoder(PixelDecoderAlgorithmBase):
             min_area=min_area,
             max_area=max_area,
             norm_order=norm_order,
-            crop_x=crop_x,
-            crop_y=crop_y,
-            crop_z=crop_z
         )
         ctx.obj["component"]._cli_run(ctx, instance)

--- a/starfish/test/full_pipelines/cli/test_merfish_cli.py
+++ b/starfish/test/full_pipelines/cli/test_merfish_cli.py
@@ -75,9 +75,6 @@ class TestWithMerfishData(CLITest, unittest.TestCase):
                 "--distance-threshold", "0.5176",
                 "--magnitude-threshold", "5e-5",
                 "--norm-order", "2",
-                "--crop-x", "0",
-                "--crop-y", "40",
-                "--crop-z", "40"
             ],
         )
 


### PR DESCRIPTION
Cropping can be done separately by the ImageStack.sel method.

Updates the MERFISH notebook to more clearly indicate
that no cropping is being done.

Closes #759 