### PR TITLE
[easy] move starfish.util.click into its own package.

### DIFF
--- a/starfish/util/click/__init__.py
+++ b/starfish/util/click/__init__.py
@@ -1,5 +1,3 @@
-from typing import Any, Sequence
-
 from click import (
     argument,
     command,
@@ -13,13 +11,6 @@ from click import (
     Path,
 )
 from click import option as _click_option
-
-
-# Workaround for F401
-__click_imports: Sequence[Any] = [
-    argument, command, Context, echo, group, Group,
-    Option, _click_option, ParamType, pass_context, Path
-]
 
 
 class RequiredParentOption(Option):


### PR DESCRIPTION
I'm going to build other click-related code, and want to keep them together.

Remove the hack to suppress warnings because we don't check for F401 on `__init__.py` files.

Test plan: `make -j lint mypy`