### PR TITLE
Support for hierarchical directory structures for experiments.

### DIFF
--- a/REQUIREMENTS-STRICT.txt
+++ b/REQUIREMENTS-STRICT.txt
@@ -57,7 +57,7 @@ semantic-version==2.6.0
 Send2Trash==1.5.0
 showit==1.1.4
 six==1.12.0
-slicedimage==2.0.0
+slicedimage==3.0.0
 sympy==1.3
 terminado==0.8.1
 testpath==0.4.2

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -9,7 +9,7 @@ scikit-image>=0.14.0
 scikit-learn
 scipy
 showit >= 1.1.4
-slicedimage == 2.0.0
+slicedimage == 3.0.0
 scikit-learn
 sympy
 tqdm

--- a/starfish/experiment/builder/__init__.py
+++ b/starfish/experiment/builder/__init__.py
@@ -1,5 +1,6 @@
 import json
 import os
+from pathlib import Path
 from typing import (
     Any,
     BinaryIO,
@@ -8,7 +9,6 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
-    Tuple,
     Union,
 )
 
@@ -35,11 +35,11 @@ AUX_IMAGE_NAMES = {
 DEFAULT_DIMENSION_ORDER = (Axes.ZPLANE, Axes.ROUND, Axes.CH)
 
 
-def _tile_opener(toc_path: str, tile: Tile, file_ext: str) -> BinaryIO:
-    tile_basename = os.path.splitext(toc_path)[0]
+def _tile_opener(toc_path: Path, tile: Tile, file_ext: str) -> BinaryIO:
+    base = toc_path.parent / toc_path.stem
     return open(
         "{}-Z{}-H{}-C{}.{}".format(
-            tile_basename,
+            str(base),
             tile.indices[Axes.ZPLANE],
             tile.indices[Axes.ROUND],
             tile.indices[Axes.CH],
@@ -48,12 +48,8 @@ def _tile_opener(toc_path: str, tile: Tile, file_ext: str) -> BinaryIO:
         "wb")
 
 
-def _fov_path_generator(parent_toc_path: str, toc_name: str) -> str:
-    toc_basename = os.path.splitext(os.path.basename(parent_toc_path))[0]
-    return os.path.join(
-        os.path.dirname(parent_toc_path),
-        "{}-{}.json".format(toc_basename, toc_name),
-    )
+def _fov_path_generator(parent_toc_path: Path, toc_name: str) -> Path:
+    return parent_toc_path.parent / "{}-{}.json".format(parent_toc_path.stem, toc_name)
 
 
 def build_image(
@@ -165,6 +161,8 @@ def write_experiment_json(
         Directory to write the files to.
     fov_count : int
         Number of fields of view in this experiment.
+    tile_format : ImageFormat
+        File format to write the tiles as.
     primary_image_dimensions : Mapping[Union[str, Axes], int]
         Dictionary mapping dimension name to dimension size for the primary image.
     aux_name_to_dimensions : Mapping[str, Mapping[Union[str, Axes], int]]

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -1,10 +1,10 @@
 import collections
-import os
 import warnings
 from copy import deepcopy
 from functools import partial
 from itertools import product
 from json import loads
+from pathlib import Path
 from typing import (
     Any,
     Callable,
@@ -1036,8 +1036,8 @@ class ImageStack:
             tileset.add_tile(tile)
 
         if tile_opener is None:
-            def tile_opener(tileset_path, tile, ext):
-                tile_basename = os.path.splitext(tileset_path)[0]
+            def tile_opener(tileset_path: Path, tile, ext):
+                base = tileset_path.parent / tileset_path.stem
                 if Axes.ZPLANE in tile.indices:
                     zval = tile.indices[Axes.ZPLANE]
                     zstr = "-Z{}".format(zval)
@@ -1045,7 +1045,7 @@ class ImageStack:
                     zstr = ""
                 return open(
                     "{}-H{}-C{}{}.{}".format(
-                        tile_basename,
+                        str(base),
                         tile.indices[Axes.ROUND],
                         tile.indices[Axes.CH],
                         zstr,


### PR DESCRIPTION
Pick up https://github.com/spacetx/slicedimage/pull/85, https://github.com/spacetx/slicedimage/pull/86, and https://github.com/spacetx/slicedimage/pull/87.

Code changes to support the API changes.

This will not pass travis until the above PRs are approved, landed, and a new slicedimage package is released.

Test plan: `make -j fast`
Partially addresses #1116