### PR TITLE
Additional support code for building experiments in-place.

### DIFF
--- a/starfish/experiment/builder/__init__.py
+++ b/starfish/experiment/builder/__init__.py
@@ -134,6 +134,11 @@ def build_image(
                 extras=image.extras,
             )
             tile.set_numpy_array_future(image.tile_data)
+            # Astute readers might wonder why we set this variable.  This is to support in-place
+            # experiment construction.  We monkey-patch slicedimage's Tile class such that checksum
+            # computation is done by finding the FetchedTile object, which allows us to calculate
+            # the checksum of the original file.
+            tile.provider = image
             fov_images.add_tile(tile)
         collection.add_partition("fov_{:03}".format(fov_id), fov_images)
     return collection
@@ -151,6 +156,8 @@ def write_experiment_json(
         postprocess_func: Optional[Callable[[dict], dict]]=None,
         default_shape: Optional[Mapping[Axes, int]]=None,
         dimension_order: Sequence[Axes]=(Axes.ZPLANE, Axes.ROUND, Axes.CH),
+        fov_path_generator: Callable[[Path, str], Path] = _fov_path_generator,
+        tile_opener: Callable[[Path, Tile, str], BinaryIO] = _tile_opener,
 ) -> None:
     """
     Build and returns a top-level experiment description with the following characteristics:
@@ -195,6 +202,10 @@ def write_experiment_json(
           (ROUND=1, CH=0, Z=1)
           (ROUND=1, CH=1, Z=1)
         (default = (Axes.Z, Axes.ROUND, Axes.CH))
+    fov_path_generator : Callable[[Path, str], Path]
+        Generates the path for a FOV's json file.  If one is not provided, the default generates
+        the FOV's json file at the same level as the top-level json file for an image.
+    tile_opener : Callable[[Path, Tile, str], BinaryIO]
     """
     if primary_tile_fetcher is None:
         primary_tile_fetcher = tile_fetcher_factory(RandomNoiseTile)
@@ -221,8 +232,8 @@ def write_experiment_json(
         primary_image,
         os.path.join(path, "primary_images.json"),
         pretty=True,
-        partition_path_generator=_fov_path_generator,
-        tile_opener=_tile_opener,
+        partition_path_generator=fov_path_generator,
+        tile_opener=tile_opener,
         tile_format=tile_format,
     )
     experiment_doc['images']['primary'] = "primary_images.json"
@@ -243,8 +254,8 @@ def write_experiment_json(
             auxiliary_image,
             os.path.join(path, "{}.json".format(aux_name)),
             pretty=True,
-            partition_path_generator=_fov_path_generator,
-            tile_opener=_tile_opener,
+            partition_path_generator=fov_path_generator,
+            tile_opener=tile_opener,
             tile_format=tile_format,
         )
         experiment_doc['images'][aux_name] = "{}.json".format(aux_name)

--- a/starfish/experiment/builder/inplace.py
+++ b/starfish/experiment/builder/inplace.py
@@ -1,0 +1,72 @@
+"""To build experiments in-place, a few things must be done:
+
+1. Call enable_inplace_mode().
+2. Call write_experiment_json with tile_opener=inplace_tile_opener.
+3. The TileFetcher should return an instance of a InplaceTileFetcher.
+
+"""
+
+
+import abc
+import io
+import sys
+from pathlib import Path
+from typing import BinaryIO
+
+from slicedimage import Tile
+
+from .providers import FetchedTile
+
+
+def sha256_get(tile_self):
+    return tile_self.provider.sha256
+
+
+def sha256_set(tile_self, value):
+    pass
+
+
+def enable_inplace_mode():
+    Tile.sha256 = property(sha256_get, sha256_set)
+
+
+def inplace_tile_opener(toc_path: Path, tile: Tile, file_ext: str) -> BinaryIO:
+    return DevNull(tile.provider.filepath)
+
+
+class DevNull(io.BytesIO):
+    """A class meant to mimic an open(filepath, 'wb') operation but
+    prevents any actual writing, reading, or seeking.
+    This class is an ugly hack to prevent the slicedimage
+    Writer.generate_partition_document() function from needlessly creating
+    a copy of image data.
+    See: https://docs.python.org/3/library/io.html
+    See also: cpython/Lib/_pyio.py
+    """
+    def __init__(self, filepath: str, *args, **kwargs):
+        super(DevNull, self).__init__(*args, **kwargs)
+        self.name = filepath
+
+    def read(self, size=-1):
+        raise NotImplementedError()
+
+    def write(self, b):
+        return sys.getsizeof(b)
+
+    def seek(self, pos, whence=0):
+        raise NotImplementedError()
+
+
+class InplaceFetchedTile(FetchedTile):
+    """Data formatters that operate in-place should return tiles that extend this class."""
+    @property
+    @abc.abstractmethod
+    def filepath(self) -> Path:
+        """Returns the path of the source tile."""
+        raise NotImplementedError()
+
+    @property
+    @abc.abstractmethod
+    def sha256(self):
+        """Returns the sha256 checksum of the source tile."""
+        raise NotImplementedError()


### PR DESCRIPTION
Since tiffs record the timestamp that they were written, we cannot calculate the checksums using the normal slicedimage write path.  We add a reference to track from the slicedimage Tile -> FetchedTile, and use that to calculate the checksum.

Test plan: proof of concept script.
Depends on #1126 

This will not pass travis until the PRs referenced in #1126 are landed.