### PR TITLE
Ensure that the top level and packaged REQUIREMENTS-STRICT.txt stay consistent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ all:	fast
 
 ### UNIT #####################################################
 #
-fast:	lint mypy fast-test clean-docs docs-html
+fast:	diff-requirements lint mypy fast-test clean-docs docs-html
 
 lint:   lint-non-init lint-init
 
@@ -95,6 +95,9 @@ REQUIREMENTS-STRICT.txt : REQUIREMENTS.txt
 	.$<-env/bin/pip freeze >> $@
 	cp -f $@ starfish/REQUIREMENTS-STRICT.txt
 	rm -rf .$<-env
+
+diff-requirements :
+	diff -q REQUIREMENTS-STRICT.txt starfish/REQUIREMENTS-STRICT.txt
 
 help-requirements:
 	$(call print_help, refresh_all_requirements, regenerate requirements files)

--- a/starfish/REQUIREMENTS-STRICT.txt
+++ b/starfish/REQUIREMENTS-STRICT.txt
@@ -57,7 +57,7 @@ semantic-version==2.6.0
 Send2Trash==1.5.0
 showit==1.1.4
 six==1.12.0
-slicedimage==2.0.0
+slicedimage==3.0.0
 sympy==1.3
 terminado==0.8.1
 testpath==0.4.2


### PR DESCRIPTION
They should if the tooling in Makefile is used to generate REQUIREMENTS-STRICT.txt, but if someone (ahem, me) hand-edits the file, all bets are off.

Fix the inconsistency.

Test plan: `make diff-requirements` without copying the changes over fails