### PR TITLE
Change all ImageStack and Codebook cli params to use the click params

### DIFF
--- a/starfish/image/_filter/_base.py
+++ b/starfish/image/_filter/_base.py
@@ -5,7 +5,7 @@ from starfish.imagestack.imagestack import ImageStack
 from starfish.pipeline.algorithmbase import AlgorithmBase
 from starfish.pipeline.pipelinecomponent import PipelineComponent
 from starfish.util import click
-
+from starfish.util.click.indirectparams import ImageStackParamType
 
 COMPONENT_NAME = "filter"
 
@@ -24,7 +24,7 @@ class Filter(PipelineComponent):
 
     @staticmethod
     @click.group(COMPONENT_NAME)
-    @click.option("-i", "--input", type=click.Path(exists=True))
+    @click.option("-i", "--input", type=ImageStackParamType)
     @click.option("-o", "--output", required=True)
     @click.pass_context
     def _cli(ctx, input, output):
@@ -34,7 +34,7 @@ class Filter(PipelineComponent):
             component=Filter,
             input=input,
             output=output,
-            stack=ImageStack.from_path_or_url(input),
+            stack=input,
         )
 
 

--- a/starfish/image/_registration/_apply_transform/_base.py
+++ b/starfish/image/_registration/_apply_transform/_base.py
@@ -6,7 +6,7 @@ from starfish.imagestack.imagestack import ImageStack
 from starfish.pipeline import PipelineComponent
 from starfish.pipeline.algorithmbase import AlgorithmBase
 from starfish.util import click
-
+from starfish.util.click.indirectparams import ImageStackParamType
 
 COMPONENT_NAME = "apply_transform"
 
@@ -27,7 +27,7 @@ class ApplyTransform(PipelineComponent):
 
     @staticmethod
     @click.group(COMPONENT_NAME)
-    @click.option("-i", "--input", type=click.Path(exists=True))
+    @click.option("-i", "--input", type=ImageStackParamType)
     @click.option("-o", "--output", required=True)
     @click.option("--transformation-list", required=True, type=click.Path(exists=True),
                   help="The list of transformations to apply to the ImageStack.")
@@ -36,9 +36,8 @@ class ApplyTransform(PipelineComponent):
         print("Applying Transform to images...")
         ctx.obj = dict(
             component=ApplyTransform,
-            input=input,
             output=output,
-            stack=ImageStack.from_path_or_url(input),
+            stack=input,
             transformation_list=TransformsList.from_json(transformation_list)
         )
 

--- a/starfish/image/_registration/_learn_transform/_base.py
+++ b/starfish/image/_registration/_learn_transform/_base.py
@@ -3,11 +3,10 @@ from typing import Type
 
 
 from starfish.image._registration.transforms_list import TransformsList
-from starfish.imagestack.imagestack import ImageStack
 from starfish.pipeline.algorithmbase import AlgorithmBase
 from starfish.pipeline.pipelinecomponent import PipelineComponent
 from starfish.util import click
-
+from starfish.util.click.indirectparams import ImageStackParamType
 
 COMPONENT_NAME = "learn_transform"
 
@@ -26,7 +25,7 @@ class LearnTransform(PipelineComponent):
 
     @staticmethod
     @click.group(COMPONENT_NAME)
-    @click.option("-i", "--input", type=click.Path(exists=True))
+    @click.option("-i", "--input", type=ImageStackParamType)
     @click.option("-o", "--output", required=True)
     @click.pass_context
     def _cli(ctx, input, output):
@@ -34,9 +33,8 @@ class LearnTransform(PipelineComponent):
         print("Learning Transforms for images...")
         ctx.obj = dict(
             component=LearnTransform,
-            input=input,
             output=output,
-            stack=ImageStack.from_path_or_url(input),
+            stack=input,
         )
 
 

--- a/starfish/image/_registration/_learn_transform/translation.py
+++ b/starfish/image/_registration/_learn_transform/translation.py
@@ -6,6 +6,7 @@ from starfish.image._registration.transforms_list import TransformsList
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Axes, TransformType
 from starfish.util import click
+from starfish.util.click.indirectparams import ImageStackParamType
 from ._base import LearnTransformBase
 
 
@@ -75,12 +76,14 @@ class Translation(LearnTransformBase):
 
     @staticmethod
     @click.command("Translation")
-    @click.option("--reference-stack", required=True, type=click.Path(exists=True),
+    @click.option("--reference-stack", required=True, type=ImageStackParamType,
                   help="The image to align the input ImageStack to.")
     @click.option("--axes", default="r", type=str, help="The axes to iterate over.")
     @click.option("--upsampling", default=1, type=int, help="Upsampling factor.")
     @click.pass_context
     def _cli(ctx, reference_stack, axes, upsampling):
-        ctx.obj["component"]._cli_run(ctx, Translation(
-            reference_stack=ImageStack.from_path_or_url(reference_stack),
-            axes=Axes(axes), upsampling=upsampling))
+        ctx.obj["component"]._cli_run(
+            ctx,
+            Translation(
+                reference_stack=reference_stack,
+                axes=Axes(axes), upsampling=upsampling))

--- a/starfish/image/_segmentation/_base.py
+++ b/starfish/image/_segmentation/_base.py
@@ -7,7 +7,7 @@ from starfish.imagestack.imagestack import ImageStack
 from starfish.pipeline import PipelineComponent
 from starfish.pipeline.algorithmbase import AlgorithmBase
 from starfish.util import click
-
+from starfish.util.click.indirectparams import ImageStackParamType
 
 COMPONENT_NAME = "segment"
 
@@ -31,8 +31,8 @@ class Segmentation(PipelineComponent):
 
     @staticmethod
     @click.group(COMPONENT_NAME)
-    @click.option("--primary-images", required=True, type=click.Path(exists=True))
-    @click.option("--nuclei", required=True, type=click.Path(exists=True))
+    @click.option("--primary-images", required=True, type=ImageStackParamType)
+    @click.option("--nuclei", required=True, type=ImageStackParamType)
     @click.option("-o", "--output", required=True)
     @click.pass_context
     def _cli(ctx, primary_images, nuclei, output):
@@ -41,8 +41,8 @@ class Segmentation(PipelineComponent):
         ctx.obj = dict(
             component=Segmentation,
             output=output,
-            primary_images=ImageStack.from_path_or_url(primary_images),
-            nuclei=ImageStack.from_path_or_url(nuclei),
+            primary_images=primary_images,
+            nuclei=nuclei,
         )
 
 

--- a/starfish/spots/_decoder/_base.py
+++ b/starfish/spots/_decoder/_base.py
@@ -6,7 +6,7 @@ from starfish.intensity_table.intensity_table import IntensityTable
 from starfish.pipeline.algorithmbase import AlgorithmBase
 from starfish.pipeline.pipelinecomponent import PipelineComponent
 from starfish.util import click
-
+from starfish.util.click.indirectparams import CodebookParamType
 
 COMPONENT_NAME = "decode"
 
@@ -28,7 +28,7 @@ class Decoder(PipelineComponent):
     @click.group(COMPONENT_NAME)
     @click.option("-i", "--input", required=True, type=click.Path(exists=True))
     @click.option("-o", "--output", required=True)
-    @click.option("--codebook", required=True, type=click.Path(exists=True))
+    @click.option("--codebook", required=True, type=CodebookParamType)
     @click.pass_context
     def _cli(ctx, input, output, codebook):
         """assign genes to spots"""
@@ -37,7 +37,7 @@ class Decoder(PipelineComponent):
             input=input,
             output=output,
             intensities=IntensityTable.load(input),
-            codebook=Codebook.from_json(codebook),
+            codebook=codebook,
         )
 
 

--- a/starfish/spots/_detector/_base.py
+++ b/starfish/spots/_detector/_base.py
@@ -10,6 +10,7 @@ from starfish.pipeline.algorithmbase import AlgorithmBase
 from starfish.pipeline.pipelinecomponent import PipelineComponent
 from starfish.types import Axes, Number, SpotAttributes
 from starfish.util import click
+from starfish.util.click.indirectparams import ImageStackParamType
 
 COMPONENT_NAME = "detect_spots"
 
@@ -40,12 +41,13 @@ class SpotFinder(PipelineComponent):
 
     @staticmethod
     @click.group(COMPONENT_NAME)
-    @click.option("-i", "--input", required=True, type=click.Path(exists=True))
+    @click.option("-i", "--input", required=True, type=ImageStackParamType)
     @click.option("-o", "--output", required=True)
     @click.option(
         "--blobs-stack",
         default=None,
         required=False,
+        type=ImageStackParamType,
         help="ImageStack that contains the blobs."
     )
     @click.option(
@@ -64,7 +66,7 @@ class SpotFinder(PipelineComponent):
 
         ctx.obj = dict(
             component=SpotFinder,
-            image_stack=ImageStack.from_path_or_url(input),
+            image_stack=input,
             output=output,
             blobs_stack=_blobs_stack,
             blobs_axes=_blobs_axes,

--- a/starfish/spots/_pixel_decoder/_base.py
+++ b/starfish/spots/_pixel_decoder/_base.py
@@ -3,13 +3,13 @@ from typing import Callable, Sequence, Tuple, Type
 
 import numpy as np
 
-from starfish.codebook.codebook import Codebook
 from starfish.imagestack.imagestack import ImageStack
 from starfish.intensity_table.intensity_table import IntensityTable
 from starfish.pipeline.algorithmbase import AlgorithmBase
 from starfish.pipeline.pipelinecomponent import PipelineComponent
 from starfish.types import Number
 from starfish.util import click
+from starfish.util.click.indirectparams import CodebookParamType, ImageStackParamType
 from .combine_adjacent_features import ConnectedComponentDecodingResult
 
 
@@ -31,13 +31,15 @@ class PixelSpotDecoder(PipelineComponent):
 
     @staticmethod
     @click.group(COMPONENT_NAME)
-    @click.option("-i", "--input", required=True, type=click.Path(exists=True))
+    @click.option("-i", "--input", required=True, type=ImageStackParamType)
     @click.option("-o", "--output", required=True)
     @click.option(
-        '--codebook', default=None, required=True, help=(
-            'A spaceTx spec-compliant json file that describes a three dimensional tensor '
-            'whose values are the expected intensity of a spot for each code in each imaging '
-            'round and each color channel.'
+        "--codebook",
+        default=None, required=True, type=CodebookParamType,
+        help=(
+            "A spaceTx spec-compliant json file that describes a three dimensional tensor "
+            "whose values are the expected intensity of a spot for each code in each imaging "
+            "round and each color channel."
         )
     )
     @click.pass_context
@@ -46,9 +48,9 @@ class PixelSpotDecoder(PipelineComponent):
         print('Detecting Spots ...')
         ctx.obj = dict(
             component=PixelSpotDecoder,
-            image_stack=ImageStack.from_path_or_url(input),
+            image_stack=input,
             output=output,
-            codebook=Codebook.from_json(codebook),
+            codebook=codebook,
         )
 
 


### PR DESCRIPTION
#1124 introduced new click param types that directly return an ImageStack or a Codebook.  This refactors the existing cli params to use those types.

Test plan: `make -j fast`

Depends on #1124 