### PR TITLE
Update iss_cli.sh to reflect the contents of test_iss.py

### DIFF
--- a/starfish/test/full_pipelines/cli/test_iss.py
+++ b/starfish/test/full_pipelines/cli/test_iss.py
@@ -46,7 +46,7 @@ class TestWithIssData(CLITest, unittest.TestCase):
                 "--input",
                 f"@{EXPERIMENT_JSON_URL}[fov_001][primary]",
                 "--output", lambda tempdir, *args, **kwargs: os.path.join(
-                    tempdir, "max_projected", "hybridization.json"),
+                    tempdir, "max_projected", "primary_images.json"),
                 "MaxProj",
                 "--dims", "c",
                 "--dims", "z"
@@ -55,7 +55,7 @@ class TestWithIssData(CLITest, unittest.TestCase):
             [
                 "starfish", "learn_transform",
                 "--input", lambda tempdir, *args, **kwargs: os.path.join(
-                    tempdir, "max_projected", "hybridization.json"),
+                    tempdir, "max_projected", "primary_images.json"),
                 "--output", lambda tempdir, *args, **kwargs: os.path.join(
                     tempdir, "transforms", "transforms.json"),
                 "Translation",
@@ -69,7 +69,7 @@ class TestWithIssData(CLITest, unittest.TestCase):
                 "--input",
                 f"@{EXPERIMENT_JSON_URL}[fov_001][primary]",
                 "--output", lambda tempdir, *args, **kwargs: os.path.join(
-                    tempdir, "registered", "hybridization.json"),
+                    tempdir, "registered", "primary_images.json"),
                 "--transformation-list", lambda tempdir, *args, **kwargs: os.path.join(
                     tempdir, "transforms", "transforms.json"),
                 "Warp",
@@ -77,9 +77,9 @@ class TestWithIssData(CLITest, unittest.TestCase):
             [
                 "starfish", "filter",
                 "--input", lambda tempdir, *args, **kwargs: os.path.join(
-                    tempdir, "registered", "hybridization.json"),
+                    tempdir, "registered", "primary_images.json"),
                 "--output", lambda tempdir, *args, **kwargs: os.path.join(
-                    tempdir, "filtered", "hybridization.json"),
+                    tempdir, "filtered", "primary_images.json"),
                 "WhiteTophat",
                 "--masking-radius", "15",
             ],
@@ -104,7 +104,7 @@ class TestWithIssData(CLITest, unittest.TestCase):
             [
                 "starfish", "detect_spots",
                 "--input", lambda tempdir, *args, **kwargs: os.path.join(
-                    tempdir, "filtered", "hybridization.json"),
+                    tempdir, "filtered", "primary_images.json"),
                 "--output", lambda tempdir, *args, **kwargs: os.path.join(
                     tempdir, "results", "spots.nc"),
                 "--blobs-stack", lambda tempdir, *args, **kwargs: os.path.join(
@@ -119,7 +119,7 @@ class TestWithIssData(CLITest, unittest.TestCase):
             [
                 "starfish", "segment",
                 "--primary-images", lambda tempdir, *args, **kwargs: os.path.join(
-                    tempdir, "filtered", "hybridization.json"),
+                    tempdir, "filtered", "primary_images.json"),
                 "--nuclei", lambda tempdir, *args, **kwargs: os.path.join(
                     tempdir, "filtered", "nuclei.json"),
                 "-o", lambda tempdir, *args, **kwargs: os.path.join(


### PR DESCRIPTION
starfish/test/full_pipelines/cli/test_iss.py changed in #1083, but docs/source/usage/iss/iss_cli.sh was never updated.

This is built on top of #1138, and reflects the changes to starfish/test/full_pipelines/cli/test_iss.py in that PR.