### PR TITLE
Refactor blobs_image api.

### DIFF
--- a/docs/source/usage/iss/iss_pipeline.py
+++ b/docs/source/usage/iss/iss_pipeline.py
@@ -32,9 +32,10 @@ def iss_pipeline(fov, codebook):
         measurement_type='mean',
     )
 
-    mp = fov.get_image('dots').max_proj(Axes.ROUND, Axes.ZPLANE)
-    mp_numpy = mp._squeezed_numpy(Axes.ROUND, Axes.ZPLANE)
-    intensities = p.run(filtered, blobs_image=mp_numpy)
+    intensities = p.run(
+        filtered,
+        blobs_image=fov.get_image('dots'),
+        blobs_axes=(Axes.ROUND, Axes.ZPLANE))
 
     # decode the pixel traces using the codebook
     decoded = codebook.decode_per_round_max(intensities)

--- a/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.ipynb
+++ b/notebooks/ISS_Pipeline_-_Breast_-_1_FOV.ipynb
@@ -259,10 +259,7 @@
     "    warnings.simplefilter(\"ignore\")\n",
     "\n",
     "    # blobs = dots; define the spots in the dots image, but then find them again in the stack.\n",
-    "    dots = dots.max_proj(Axes.ROUND, Axes.ZPLANE)\n",
-    "    dots_numpy = dots._squeezed_numpy(Axes.ROUND, Axes.ZPLANE)\n",
-    "    blobs_image = dots_numpy\n",
-    "    intensities = p.run(registered_image, blobs_image=blobs_image)"
+    "    intensities = p.run(registered_image, blobs_image=dots, blobs_axes=(Axes.ROUND, Axes.ZPLANE))"
    ]
   },
   {

--- a/notebooks/py/ISS_Pipeline_-_Breast_-_1_FOV.py
+++ b/notebooks/py/ISS_Pipeline_-_Breast_-_1_FOV.py
@@ -168,10 +168,7 @@ with warnings.catch_warnings():
     warnings.simplefilter("ignore")
 
     # blobs = dots; define the spots in the dots image, but then find them again in the stack.
-    dots = dots.max_proj(Axes.ROUND, Axes.ZPLANE)
-    dots_numpy = dots._squeezed_numpy(Axes.ROUND, Axes.ZPLANE)
-    blobs_image = dots_numpy
-    intensities = p.run(registered_image, blobs_image=blobs_image)
+    intensities = p.run(registered_image, blobs_image=dots, blobs_axes=(Axes.ROUND, Axes.ZPLANE))
 # EPY: END code
 
 # EPY: START markdown

--- a/starfish/imagestack/test/dataset_fixtures.py
+++ b/starfish/imagestack/test/dataset_fixtures.py
@@ -123,8 +123,6 @@ def synthetic_dataset_with_truth_values_and_called_spots(
 
     wth = WhiteTophat(masking_radius=15)
     filtered = wth.run(image, in_place=False)
-    filtered_mp = filtered.max_proj(Axes.CH, Axes.ROUND)
-    filtered_mp_numpy = filtered_mp._squeezed_numpy(Axes.CH, Axes.ROUND)
 
     min_sigma = 1.5
     max_sigma = 4
@@ -136,7 +134,7 @@ def synthetic_dataset_with_truth_values_and_called_spots(
                        threshold=threshold,
                        measurement_type='max')
 
-    intensities = gsd.run(data_stack=filtered, blobs_image=filtered_mp_numpy)
+    intensities = gsd.run(data_stack=filtered, blobs_image=filtered)
     assert intensities.shape[0] == 5
 
     codebook.metric_decode(intensities, max_distance=1, min_intensity=0, norm_order=2)

--- a/starfish/spots/_detector/blob.py
+++ b/starfish/spots/_detector/blob.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -90,7 +90,7 @@ class BlobDetector(SpotFinderAlgorithmBase):
         Parameters
         ----------
         data_image : Union[np.ndarray, xr.DataArray]
-            ImageStack containing blobs to be detected
+            image containing spots to be detected
 
         Returns
         -------
@@ -130,34 +130,32 @@ class BlobDetector(SpotFinderAlgorithmBase):
 
     def run(
             self,
-            data_stack: ImageStack,
-            blobs_image: Optional[Union[np.ndarray, xr.DataArray]]=None,
-            reference_image_from_max_projection: bool=False,
+            primary_image: ImageStack,
+            blobs_image: Optional[ImageStack] = None,
+            blobs_axes: Optional[Tuple[Axes, ...]] = None,
             *args,
     ) -> IntensityTable:
-        """find spots in an ImageStack
+        """
+        Find spots.
 
         Parameters
         ----------
-        data_stack : ImageStack
-            stack containing spots to find
-        blobs_image : Union[np.ndarray, xr.DataArray]
-        reference_image_from_max_projection : bool
-            if True, compute a reference image from the maximum projection of the channels and
-            z-planes
-
-        Returns
-        -------
-        IntensityTable :
-            3d tensor containing the intensity of spots across channels and imaging rounds
-
+        primary_image : ImageStack
+            ImageStack where we find the spots in.
+        blobs_image : Optional[ImageStack]
+            If provided, spots will be found in the blobs image, and intensities will be measured
+            across rounds and channels. Otherwise, spots are measured independently for each channel
+            and round.
+        blobs_axes : Optional[Tuple[Axes, ...]]
+            If blobs_image is provided, blobs_axes must be provided as well.  blobs_axes represents
+            the axes across which the blobs image is max projected before spot detection is done.
         """
 
         intensity_table = detect_spots(
-            data_stack=data_stack,
+            data_stack=primary_image,
             spot_finding_method=self.image_to_spots,
             reference_image=blobs_image,
-            reference_image_from_max_projection=reference_image_from_max_projection,
+            reference_image_max_projection_axes=blobs_axes,
             measurement_function=self.measurement_function,
             radius_is_gyration=False)
 

--- a/starfish/spots/_detector/local_max_peak_finder.py
+++ b/starfish/spots/_detector/local_max_peak_finder.py
@@ -211,8 +211,8 @@ class LocalMaxPeakFinder(SpotFinderAlgorithmBase):
 
         Parameters
         ----------
-        data_image: Union[np.ndarray, xr.DataArray]
-            image from which spots should be extracted
+        data_image : Union[np.ndarray, xr.DataArray]
+            image containing spots to be detected
 
         Returns
         -------
@@ -270,35 +270,31 @@ class LocalMaxPeakFinder(SpotFinderAlgorithmBase):
 
     def run(
             self,
-            data_stack: ImageStack,
-            blobs_image: Optional[Union[np.ndarray, xr.DataArray]] = None,
-            reference_image_from_max_projection: bool = False,
+            primary_image: ImageStack,
+            blobs_image: Optional[ImageStack] = None,
+            blobs_axes: Optional[Tuple[Axes, ...]] = None,
             *args,
     ) -> IntensityTable:
-        """Find spots.
+        """
+        Find spots.
 
         Parameters
         ----------
-        data_stack : ImageStack
-            Stack where we find the spots in.
-        blobs_image : Union[np.ndarray, xr.DataArray]
+        primary_image : ImageStack
+            ImageStack where we find the spots in.
+        blobs_image : Optional[ImageStack]
             If provided, spots will be found in the blobs image, and intensities will be measured
             across rounds and channels. Otherwise, spots are measured independently for each channel
             and round.
-        reference_image_from_max_projection : bool
-            if True, compute a reference image from the maximum projection of the channels and
-            z-planes
-
-        Returns
-        -------
-        IntensityTable :
-            IntensityTable containing decoded spots
+        blobs_axes : Optional[Tuple[Axes, ...]]
+            If blobs_image is provided, blobs_axes must be provided as well.  blobs_axes represents
+            the axes across which the blobs image is max projected before spot detection is done.
         """
         intensity_table = detect_spots(
-            data_stack=data_stack,
+            data_stack=primary_image,
             spot_finding_method=self.image_to_spots,
             reference_image=blobs_image,
-            reference_image_from_max_projection=reference_image_from_max_projection,
+            reference_image_max_projection_axes=blobs_axes,
             measurement_function=self.measurement_function,
             radius_is_gyration=False)
 

--- a/starfish/spots/_detector/test/test_spot_detection.py
+++ b/starfish/spots/_detector/test/test_spot_detection.py
@@ -81,13 +81,11 @@ def test_spot_detection_with_reference_image(
 
     def call_detect_spots(stack):
 
-        reference_image_mp = stack.max_proj(Axes.CH, Axes.ROUND)
-        reference_image_mp_numpy = reference_image_mp._squeezed_numpy(Axes.CH, Axes.ROUND)
-
         return detect_spots(
             data_stack=stack,
             spot_finding_method=spot_detector.image_to_spots,
-            reference_image=reference_image_mp_numpy,
+            reference_image=stack,
+            reference_image_max_projection_axes=(Axes.ROUND, Axes.CH),
             measurement_function=np.max,
             radius_is_gyration=radius_is_gyration,
             n_processes=1,
@@ -117,7 +115,8 @@ def test_spot_detection_with_reference_image_from_max_projection(
         return detect_spots(
             data_stack=stack,
             spot_finding_method=spot_detector.image_to_spots,
-            reference_image_from_max_projection=True,
+            reference_image=stack,
+            reference_image_max_projection_axes=(Axes.ROUND, Axes.CH),
             measurement_function=np.max,
             radius_is_gyration=radius_is_gyration,
             n_processes=1,

--- a/starfish/spots/_detector/test/test_synthetic_data.py
+++ b/starfish/spots/_detector/test/test_synthetic_data.py
@@ -25,10 +25,8 @@ def test_round_trip_synthetic_data():
     codebook = sd.codebook()
     intensities = sd.intensities(codebook=codebook)
     spots = sd.spots(intensities=intensities)
-    spots_mp = spots.max_proj(Axes.CH, Axes.ROUND)
-    spots_mp_numpy = spots_mp._squeezed_numpy(Axes.CH, Axes.ROUND)
     gsd = BlobDetector(min_sigma=1, max_sigma=4, num_sigma=5, threshold=0)
-    calculated_intensities = gsd.run(spots, blobs_image=spots_mp_numpy)
+    calculated_intensities = gsd.run(spots, blobs_image=spots, blobs_axes=(Axes.ROUND, Axes.CH))
     decoded_intensities = codebook.metric_decode(
         calculated_intensities,
         max_distance=1,
@@ -88,10 +86,8 @@ def test_medium_synthetic_stack():
     valid_locations = valid_z & valid_y & valid_x
     intensities = intensities[np.where(valid_locations)]
     spots = sd.spots(intensities=intensities)
-    spots_mp = spots.max_proj(Axes.CH, Axes.ROUND)
-    spots_mp_numpy = spots_mp._squeezed_numpy(Axes.CH, Axes.ROUND)
     gsd = BlobDetector(min_sigma=1, max_sigma=4, num_sigma=5, threshold=1e-4)
-    calculated_intensities = gsd.run(spots, blobs_image=spots_mp_numpy)
+    calculated_intensities = gsd.run(spots, blobs_image=spots, blobs_axes=(Axes.ROUND, Axes.CH))
     calculated_intensities = codebook.metric_decode(
         calculated_intensities, max_distance=1, min_intensity=0, norm_order=2
     )

--- a/starfish/spots/_detector/trackpy_local_max_peak_finder.py
+++ b/starfish/spots/_detector/trackpy_local_max_peak_finder.py
@@ -7,7 +7,7 @@ from trackpy import locate
 
 from starfish.imagestack.imagestack import ImageStack
 from starfish.intensity_table.intensity_table import IntensityTable
-from starfish.types import SpotAttributes
+from starfish.types import Axes, SpotAttributes
 from starfish.util import click
 from ._base import SpotFinderAlgorithmBase
 from .detect import detect_spots
@@ -58,8 +58,6 @@ class TrackpyLocalMaxPeakFinder(SpotFinderAlgorithmBase):
             name of the function used to calculate the intensity for each identified spot area
         preprocess : boolean
             Set to False to turn off bandpass preprocessing.
-        max_iterations : integer
-            max number of loops to refine the center of mass, default 10
         is_volume : bool
             if True, run the algorithm on 3d volumes of the provided stack
         verbose : bool
@@ -85,13 +83,13 @@ class TrackpyLocalMaxPeakFinder(SpotFinderAlgorithmBase):
         self.is_volume = is_volume
         self.verbose = verbose
 
-    def image_to_spots(self, image: Union[np.ndarray, xr.DataArray]) -> SpotAttributes:
+    def image_to_spots(self, data_image: Union[np.ndarray, xr.DataArray]) -> SpotAttributes:
         """
 
         Parameters
         ----------
-        image : np.ndarray
-            three-dimensional numpy array containing spots to detect
+        data_image : np.ndarray
+            three-dimensional image containing spots to be detected
 
         Returns
         -------
@@ -99,12 +97,12 @@ class TrackpyLocalMaxPeakFinder(SpotFinderAlgorithmBase):
             spot attributes table for all detected spots
 
         """
-        image = np.asarray(image)
+        data_image = np.asarray(data_image)
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', FutureWarning)  # trackpy numpy indexing warning
             warnings.simplefilter('ignore', UserWarning)  # yielded if black images
             attributes = locate(
-                image,
+                data_image,
                 diameter=self.diameter,
                 minmass=self.minmass,
                 maxsize=self.maxsize,
@@ -126,7 +124,7 @@ class TrackpyLocalMaxPeakFinder(SpotFinderAlgorithmBase):
         new_colnames = [
             'y', 'x', 'total_intensity', 'radius', 'eccentricity', 'intensity', 'raw_mass', 'ep'
         ]
-        if len(image.shape) == 3:
+        if len(data_image.shape) == 3:
             attributes.columns = ['z'] + new_colnames
         else:
             attributes.columns = new_colnames
@@ -140,9 +138,9 @@ class TrackpyLocalMaxPeakFinder(SpotFinderAlgorithmBase):
 
     def run(
             self,
-            data_stack: ImageStack,
-            blobs_image: Optional[Union[np.ndarray, xr.DataArray]]=None,
-            reference_image_from_max_projection: bool=False,
+            primary_image: ImageStack,
+            blobs_image: Optional[ImageStack] = None,
+            blobs_axes: Optional[Tuple[Axes, ...]] = None,
             *args,
     ) -> IntensityTable:
         """
@@ -150,22 +148,21 @@ class TrackpyLocalMaxPeakFinder(SpotFinderAlgorithmBase):
 
         Parameters
         ----------
-        data_stack : ImageStack
-            Stack where we find the spots in.
-        blobs_image : Union[np.ndarray, xr.DataArray]
+        primary_image : ImageStack
+            ImageStack where we find the spots in.
+        blobs_image : Optional[ImageStack]
             If provided, spots will be found in the blobs image, and intensities will be measured
             across rounds and channels. Otherwise, spots are measured independently for each channel
             and round.
-        reference_image_from_max_projection : bool
-            if True, compute a reference image from the maximum projection of the channels and
-            z-planes
-
+        blobs_axes : Optional[Tuple[Axes, ...]]
+            If blobs_image is provided, blobs_axes must be provided as well.  blobs_axes represents
+            the axes across which the blobs image is max projected before spot detection is done.
         """
         intensity_table = detect_spots(
-            data_stack=data_stack,
+            data_stack=primary_image,
             spot_finding_method=self.image_to_spots,
             reference_image=blobs_image,
-            reference_image_from_max_projection=reference_image_from_max_projection,
+            reference_image_max_projection_axes=blobs_axes,
             measurement_function=self.measurement_function,
             radius_is_gyration=True)
 

--- a/starfish/test/full_pipelines/cli/test_iss.py
+++ b/starfish/test/full_pipelines/cli/test_iss.py
@@ -118,6 +118,7 @@ class TestWithIssData(CLITest, unittest.TestCase):
                     tempdir, "results", "spots.nc"),
                 "--blobs-stack", lambda tempdir, *args, **kwargs: os.path.join(
                     tempdir, "filtered", "dots.json"),
+                "--blobs-axis", "r", "--blobs-axis", "c",
                 "BlobDetector",
                 "--min-sigma", "4",
                 "--max-sigma", "6",

--- a/starfish/util/click/__init__.py
+++ b/starfish/util/click/__init__.py
@@ -1,5 +1,6 @@
 from click import (
     argument,
+    Choice,
     command,
     Context,
     echo,


### PR DESCRIPTION
High level goal: detect spots should accept imagestacks and not numpy arrays.

1. blobs_image is, at the user's interaction level, an ImageStack.  Internally, `starfish.spots._detector.detect.detect_spots` will convert it to a numpy array.  This is to allow the code path where we don't have a reference image to continue taking advantage of ImageStack's apply/transform logic.
2. Because the way we generate the blobs_image (max projection) happens on different axes, it must be explicitly provided to `detect_spots`.
3. Other small and insignificant changes.

Test plan: `make -j test run_notebooks`