### PR TITLE
Don't try to convert blobs_stack to an ImageStack twice.

### DIFF
--- a/starfish/spots/_detector/_base.py
+++ b/starfish/spots/_detector/_base.py
@@ -61,14 +61,13 @@ class SpotFinder(PipelineComponent):
     def _cli(ctx, input, output, blobs_stack, blobs_axis):
         """detect spots"""
         print('Detecting Spots ...')
-        _blobs_stack = None if blobs_stack is None else ImageStack.from_path_or_url(blobs_stack)
         _blobs_axes = tuple(Axes(_blobs_axis) for _blobs_axis in blobs_axis)
 
         ctx.obj = dict(
             component=SpotFinder,
             image_stack=input,
             output=output,
-            blobs_stack=_blobs_stack,
+            blobs_stack=blobs_stack,
             blobs_axes=_blobs_axes,
         )
 


### PR DESCRIPTION
#1124 ensures that blobs_stack is already an ImageStack, but #1143 still does the conversion.  Merging both created this conflict.

Test plan: `pytest starfish/test/full_pipelines/cli/test_iss.py`