### PR TITLE
fixes for broken starmap notebook.

### DIFF
--- a/notebooks/STARmap.ipynb
+++ b/notebooks/STARmap.ipynb
@@ -9,14 +9,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "from itertools import product\n",
     "from functools import partial\n",
-    "from typing import Tuple\n",
     "\n",
     "import numpy as np\n",
     "\n",
@@ -27,27 +24,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "%gui qt\n",
-    "import starfish.display"
+    "%gui qt"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 672/672 [00:13<00:00, 49.38it/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "experiment = starfish.data.STARmap(use_test_data=True)\n",
     "stack = experiment['fov_000'].get_image('primary')"
@@ -55,17 +43,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 28/28 [00:00<00:00, 206.46it/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# look at the channel/round projection\n",
     "ch_r_projection = stack.max_proj(Axes.CH, Axes.ROUND)"
@@ -73,22 +53,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<napari_gui.elements._viewer.Viewer at 0x1f31ded68>"
-      ]
-     },
-     "execution_count": 36,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "starfish.display.stack(ch_r_projection)"
+    "starfish.display(ch_r_projection)"
    ]
   },
   {
@@ -102,17 +71,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 6/6 [00:00<00:00, 178.07it/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Starmap only requires translation. Verify that things are registered with a quick \n",
     "# similarity registration. \n",
@@ -140,25 +101,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[array([-2., -2.]),\n",
-       " array([0., 0.]),\n",
-       " array([0., 0.]),\n",
-       " array([0., 0.]),\n",
-       " array([-1.,  0.]),\n",
-       " array([0., 0.])]"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "[t.translation for (t, ind) in transforms]"
    ]
@@ -179,24 +124,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Calculating reference distribution...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "24it [02:24,  6.59s/it]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "mh = starfish.image.Filter.MatchHistograms({Axes.CH, Axes.ROUND})\n",
     "stack = mh.run(stack, in_place=True, verbose=True, n_processes=8)"
@@ -213,10 +143,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "scrolled": false
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "lsbd = starfish.spots._detector.local_search_blob_detector.LocalSearchBlobDetector(\n",
@@ -244,7 +172,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer = starfish.display.stack(stack, intensities, radius_multiplier=0.1, mask_intensities=0.01)"
+    "viewer = starfish.display(stack, intensities, radius_multiplier=0.1, mask_intensities=0.01)"
    ]
   },
   {
@@ -256,7 +184,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -270,7 +198,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer = starfish.display.stack(stack, decoded[decode_mask], radius_multiplier=0.1, mask_intensities=0.1)"
+    "viewer = starfish.display(stack, decoded[decode_mask], radius_multiplier=0.1, mask_intensities=0.1)"
    ]
   }
  ],

--- a/notebooks/py/STARmap.py
+++ b/notebooks/py/STARmap.py
@@ -8,10 +8,7 @@
 # EPY: END markdown
 
 # EPY: START code
-import os
-from itertools import product
 from functools import partial
-from typing import Tuple
 
 import numpy as np
 
@@ -22,7 +19,6 @@ from starfish.types import Axes
 
 # EPY: START code
 # EPY: ESCAPE %gui qt
-import starfish.display
 # EPY: END code
 
 # EPY: START code
@@ -36,7 +32,7 @@ ch_r_projection = stack.max_proj(Axes.CH, Axes.ROUND)
 # EPY: END code
 
 # EPY: START code
-starfish.display.stack(ch_r_projection)
+starfish.display(ch_r_projection)
 # EPY: END code
 
 # EPY: START markdown
@@ -50,7 +46,6 @@ starfish.display.stack(ch_r_projection)
 # similarity registration. 
 
 from skimage.feature import register_translation
-from skimage.transform import warp
 from skimage.transform import SimilarityTransform
 
 def _register_imagestack(target_image, reference_image, upsample_factor=5):
@@ -94,11 +89,11 @@ stack = mh.run(stack, in_place=True, verbose=True, n_processes=8)
 # EPY: END markdown
 
 # EPY: START code
-lsbd = starfish.spots._detector.local_search_blob_detector.LocalSearchBlobDetector(
+lsbd = starfish.spots.SpotFinder.LocalSearchBlobDetector(
     min_sigma=1,
     max_sigma=8,
     num_sigma=10,
-    threshold=np.percentile(np.ravel(substack.xarray.values), 95),
+    threshold=np.percentile(np.ravel(stack.xarray.values), 95),
     exclude_border=2,
     anchor_round=0,
     search_radius=10,
@@ -111,7 +106,7 @@ intensities = lsbd.run(stack, n_processes=8)
 # EPY: END markdown
 
 # EPY: START code
-viewer = starfish.display.stack(stack, intensities, radius_multiplier=0.1, mask_intensities=0.01)
+viewer = starfish.display(stack, intensities, radius_multiplier=0.1, mask_intensities=0.01)
 # EPY: END code
 
 # EPY: START markdown
@@ -124,5 +119,5 @@ decode_mask = decoded['target'] != 'nan'
 # EPY: END code
 
 # EPY: START code
-viewer = starfish.display.stack(stack, decoded[decode_mask], radius_multiplier=0.1, mask_intensities=0.1)
+viewer = starfish.display(stack, decoded[decode_mask], radius_multiplier=0.1, mask_intensities=0.1)
 # EPY: END code


### PR DESCRIPTION
1. Fix for starfish.display.stack being renamed to starfish.display.
2. substack should be stack.
3. Remove unneeded imports.
4. Use public API in notebooks `starfish.spots.SpotFinder.LocalSearchBlobDetector` instead of `starfish.spots._detector.local_search_blob_detector.LocalSearchBlobDetector`
