### PR TITLE
Simplify the code for verify tile dtype and shape.

### DIFF
--- a/starfish/imagestack/test/test_slicedimage_dtype.py
+++ b/starfish/imagestack/test/test_slicedimage_dtype.py
@@ -100,8 +100,8 @@ def test_int_type_promotion():
             tile_fetcher=CornerDifferentDtype(np.int32, np.int8),
         )
         assert len(warnings_) == 2
-        assert issubclass(warnings_[0].category, DataFormatWarning)
-        assert issubclass(warnings_[1].category, UserWarning)
+        assert issubclass(warnings_[0].category, UserWarning)
+        assert issubclass(warnings_[1].category, DataFormatWarning)
     expected = img_as_float32(np.ones(
         (NUM_ROUND,
          NUM_CH,
@@ -123,8 +123,8 @@ def test_uint_type_promotion():
             tile_fetcher=CornerDifferentDtype(np.uint32, np.uint8),
         )
         assert len(warnings_) == 2
-        assert issubclass(warnings_[0].category, DataFormatWarning)
-        assert issubclass(warnings_[1].category, UserWarning)
+        assert issubclass(warnings_[0].category, UserWarning)
+        assert issubclass(warnings_[1].category, DataFormatWarning)
     expected = img_as_float32(np.ones(
         (NUM_ROUND,
          NUM_CH,
@@ -146,8 +146,8 @@ def test_float_type_demotion():
             tile_fetcher=CornerDifferentDtype(np.float64, np.float32),
         )
         assert len(warnings_) == 2
-        assert issubclass(warnings_[0].category, DataFormatWarning)
-        assert issubclass(warnings_[1].category, UserWarning)
+        assert issubclass(warnings_[0].category, UserWarning)
+        assert issubclass(warnings_[1].category, DataFormatWarning)
     expected = np.ones(
         (NUM_ROUND,
          NUM_CH,


### PR DESCRIPTION
1. `set_slice` will catch mismatched tile sizes, so we don't need that.
2. aggregate all the dtypes, and verify that len(data type kinds) == 1 and len(data type sizes) == 1.

Test plan: `pytest -v -n4 starfish/imagestack`