### PR TITLE
Integrate data processing examples into existing makefile rules.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,9 @@ help-requirements:
 ### INTEGRATION ##############################################
 #
 include notebooks/subdir.mk
+include docs/source/_static/data_processing_examples/subdir.mk
 
-slow: fast run-notebooks docker
+slow: fast run-notebooks run-examples docker
 
 docker:
 	docker build -t $(DOCKER_IMAGE) .

--- a/docs/source/_static/data_processing_examples/subdir.mk
+++ b/docs/source/_static/data_processing_examples/subdir.mk
@@ -1,0 +1,15 @@
+path := docs/source/_static/data_processing_examples
+py_files := $(wildcard $(path)/*.py)
+sh_files := $(wildcard $(path)/*.sh)
+py_run_targets := $(patsubst $(path)/%,run__%,$(py_files))
+sh_run_targets := $(patsubst $(path)/%,run__%,$(sh_files))
+
+PYTHON := ipython
+
+run-examples: $(py_run_targets) $(sh_run_targets)
+
+$(py_run_targets): run__% :
+	[ -e $(path)/$*.skip ] || $(PYTHON) $(path)/$*
+
+$(sh_run_targets): run__% :
+	[ -e $(path)/$*.skip ] || $(SHELL) $(path)/$*


### PR DESCRIPTION
New targets: run-examples, run__$(shell_script_name), and run__$(python_script_name)

Examples:

```
% make run-examples
% make run__iss_cli.sh
% make run__iss_pipeline.py
```