### PR TITLE
Move IntensityTable overlap code and tests inside IntensityTable package

### DIFF
--- a/starfish/intensity_table/intensity_table.py
+++ b/starfish/intensity_table/intensity_table.py
@@ -18,7 +18,7 @@ from starfish.types import (
     STARFISH_EXTRAS_KEY
 )
 from starfish.util.dtype import preserve_float_range
-from starfish.util.overlap_utils import (
+from .overlap import (
     find_overlaps_of_xarrays,
     OVERLAP_STRATEGY_MAP,
 )

--- a/starfish/intensity_table/overlap.py
+++ b/starfish/intensity_table/overlap.py
@@ -3,8 +3,7 @@ from typing import List, Optional, Sequence, Tuple
 
 import xarray as xr
 
-from starfish.types import Coordinates, Features, Number
-from starfish.types import OverlapStrategy
+from starfish.types import Coordinates, Features, Number, OverlapStrategy
 
 
 class Area:

--- a/starfish/intensity_table/test/factories.py
+++ b/starfish/intensity_table/test/factories.py
@@ -1,6 +1,39 @@
+import numpy as np
+import xarray as xr
+
 from starfish import IntensityTable
-from starfish.codebook.test.factories import loaded_codebook
+from starfish.codebook.test.factories import codebook_array_factory, loaded_codebook
+from starfish.intensity_table.overlap import Area
+from starfish.types import Coordinates, Features
 
 
 def synthetic_intensity_table() -> IntensityTable:
     return IntensityTable.synthetic_intensities(loaded_codebook(), n_spots=2)
+
+
+def create_intensity_table_with_coords(area: Area, n_spots: int=10) -> IntensityTable:
+    """
+    Creates a 50X50 intensity table with physical coordinates within
+    the given Area.
+
+    Parameters
+    ----------
+    area: Area
+        The area of physical space the IntensityTable should be defined over
+    n_spots:
+        Number of spots to add to the IntensityTable
+    """
+    codebook = codebook_array_factory()
+    it = IntensityTable.synthetic_intensities(
+        codebook,
+        num_z=1,
+        height=50,
+        width=50,
+        n_spots=n_spots
+    )
+    # intensity table 1 has 10 spots, xmin = 0, ymin = 0, xmax = 2, ymax = 1
+    it[Coordinates.X.value] = xr.DataArray(np.linspace(area.min_x, area.max_x, n_spots),
+                                           dims=Features.AXIS)
+    it[Coordinates.Y.value] = xr.DataArray(np.linspace(area.min_y, area.max_y, n_spots),
+                                           dims=Features.AXIS)
+    return it

--- a/starfish/intensity_table/test/test_overlap.py
+++ b/starfish/intensity_table/test/test_overlap.py
@@ -1,44 +1,15 @@
 import numpy as np
-import xarray as xr
 
 from starfish import IntensityTable
-from starfish.codebook.test.factories import codebook_array_factory
-from starfish.types import Coordinates, Features
-from starfish.types._constants import OverlapStrategy
-from starfish.util.overlap_utils import (
+from starfish.intensity_table.overlap import (
     Area,
     find_overlaps_of_xarrays,
     remove_area_of_xarray,
     sel_area_of_xarray
 )
-
-
-def create_intensity_table_with_coords(area: Area, n_spots: int=10) -> IntensityTable:
-    """
-    Creates a 50X50 intensity table with physical coordinates within
-    the given Area.
-
-    Parameters
-    ----------
-    area: Area
-        The area of physical space the IntensityTable should be defined over
-    n_spots:
-        Number of spots to add to the IntensityTable
-    """
-    codebook = codebook_array_factory()
-    it = IntensityTable.synthetic_intensities(
-        codebook,
-        num_z=1,
-        height=50,
-        width=50,
-        n_spots=n_spots
-    )
-    # intensity table 1 has 10 spots, xmin = 0, ymin = 0, xmax = 2, ymax = 1
-    it[Coordinates.X.value] = xr.DataArray(np.linspace(area.min_x, area.max_x, n_spots),
-                                           dims=Features.AXIS)
-    it[Coordinates.Y.value] = xr.DataArray(np.linspace(area.min_y, area.max_y, n_spots),
-                                           dims=Features.AXIS)
-    return it
+from starfish.types import Coordinates, Features
+from starfish.types._constants import OverlapStrategy
+from .factories import create_intensity_table_with_coords
 
 
 def test_find_area_intersection():


### PR DESCRIPTION
IntensityTable overlap code not going to be reused for ImageStack, so might as well keep it together.

Test plan: `pytest -v -n4 starfish/intensity_table/`

Depends on #1169