### PR TITLE
Unify the data provider for cropped loading tests and labeled indices tests.

### DIFF
--- a/starfish/imagestack/test/factories/__init__.py
+++ b/starfish/imagestack/test/factories/__init__.py
@@ -1,3 +1,4 @@
 from .from_codebook import create_imagestack_from_codebook
 from .synthetic_stack import synthetic_stack
+from .unique_tiles import unique_data, unique_tiles_imagestack
 from .with_coords import imagestack_with_coords_factory

--- a/starfish/imagestack/test/factories/unique_tiles.py
+++ b/starfish/imagestack/test/factories/unique_tiles.py
@@ -1,0 +1,101 @@
+from typing import Mapping, Optional, Sequence, Tuple, Union
+
+import numpy as np
+from skimage import img_as_float32
+from slicedimage import ImageFormat
+
+from starfish.experiment.builder import build_image, FetchedTile, tile_fetcher_factory
+from starfish.imagestack.imagestack import ImageStack
+from starfish.imagestack.parser.crop import CropParameters
+from starfish.types import Axes, Coordinates, Number
+
+X_COORDS = 0.01, 0.1
+Y_COORDS = 0.001, 0.01
+Z_COORDS = 0.0001, 0.001
+
+
+def unique_data(
+        round_: int, ch: int, z: int,
+        num_rounds: int, num_chs: int, num_zplanes: int,
+        tile_height: int, tile_width: int,
+) -> np.ndarray:
+    """Return the data for a given tile."""
+    result = np.empty((tile_height, tile_width), dtype=np.uint32)
+    for row in range(tile_height):
+        base_val = tile_width * (
+            row + tile_height * (
+                z + num_zplanes * (
+                    ch + num_chs * (
+                        round_))))
+
+        result[row:] = np.linspace(base_val, base_val + tile_width, tile_width, False)
+    return img_as_float32(result)
+
+
+class UniqueTiles(FetchedTile):
+    """Tiles where the pixel values are unique per round/ch/z."""
+    def __init__(
+            self,
+            # these are the arguments passed in as a result of tile_fetcher_factory's
+            # pass_tile_indices parameter.
+            fov: int, _round: int, ch: int, zplane: int,
+            # these are the arguments we are passing through tile_fetcher_factory.
+            num_rounds: int, num_chs: int, num_zplanes: int, tile_height: int, tile_width: int
+    ) -> None:
+        super().__init__()
+        self._round = _round
+        self._ch = ch
+        self._zplane = zplane
+        self.num_rounds = num_rounds
+        self.num_chs = num_chs
+        self.num_zplanes = num_zplanes
+        self.tile_height = tile_height
+        self.tile_width = tile_width
+
+    @property
+    def shape(self) -> Mapping[Axes, int]:
+        return {Axes.Y: self.tile_height, Axes.X: self.tile_width}
+
+    @property
+    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+        return {
+            Coordinates.X: X_COORDS,
+            Coordinates.Y: Y_COORDS,
+            Coordinates.Z: Z_COORDS,
+        }
+
+    @property
+    def format(self) -> ImageFormat:
+        return ImageFormat.TIFF
+
+    def tile_data(self) -> np.ndarray:
+        return unique_data(
+            self._round, self._ch, self._zplane,
+            self.num_rounds, self.num_chs, self.num_zplanes,
+            self.tile_height, self.tile_width,
+        )
+
+
+def unique_tiles_imagestack(
+        round_labels: Sequence[int],
+        ch_labels: Sequence[int],
+        z_labels: Sequence[int],
+        tile_height: int,
+        tile_width: int,
+        crop_parameters: Optional[CropParameters] = None) -> ImageStack:
+    """Build an imagestack with unique values per tile.
+    """
+    collection = build_image(
+        range(1),
+        round_labels,
+        ch_labels,
+        z_labels,
+        tile_fetcher_factory(
+            UniqueTiles, True,
+            len(round_labels), len(ch_labels), len(z_labels),
+            tile_height, tile_width,
+        ),
+    )
+    tileset = list(collection.all_tilesets())[0][1]
+
+    return ImageStack.from_tileset(tileset, crop_parameters)

--- a/starfish/imagestack/test/imagestack_test_utils.py
+++ b/starfish/imagestack/test/imagestack_test_utils.py
@@ -4,7 +4,7 @@ from typing import Mapping, Optional, Sequence, Tuple, Union
 import numpy as np
 
 from starfish.imagestack.imagestack import ImageStack
-from starfish.types import Axes, Coordinates, Number
+from starfish.types import Axes, Coordinates
 
 
 def verify_stack_data(
@@ -16,21 +16,6 @@ def verify_stack_data(
     matches the expected data.
     """
     tile_data, axes = stack.get_slice(selectors)
-    assert np.array_equal(tile_data, expected_data)
-
-    return tile_data, axes
-
-
-def verify_stack_fill(
-        stack: ImageStack,
-        selectors: Mapping[Axes, Union[int, slice]],
-        expected_fill_value: Number,
-) -> Tuple[np.ndarray, Sequence[Axes]]:
-    """Given an imagestack and a set of selectors, verify that the data referred to by the selectors
-    matches an expected fill value.
-    """
-    tile_data, axes = stack.get_slice(selectors)
-    expected_data = np.full(tile_data.shape, expected_fill_value, np.float32)
     assert np.array_equal(tile_data, expected_data)
 
     return tile_data, axes

--- a/starfish/imagestack/test/test_cropped_load.py
+++ b/starfish/imagestack/test/test_cropped_load.py
@@ -2,89 +2,36 @@
 These tests center around creating an ImageStack but selectively loading data from the original
 TileSet.
 """
-from typing import Mapping, Optional, Tuple, Union
-
-import numpy as np
-from skimage import img_as_float32
-from slicedimage import ImageFormat
-
-from starfish.experiment.builder import build_image, FetchedTile, tile_fetcher_factory
 from starfish.imagestack.imagestack import ImageStack
 from starfish.imagestack.parser.crop import CropParameters
 from starfish.imagestack.physical_coordinate_calculator import (
     get_physical_coordinates_of_z_plane,
     recalculate_physical_coordinate_range
 )
-from starfish.types import Axes, Coordinates, Number
+from starfish.types import Axes
+from .factories.unique_tiles import (
+    unique_data, unique_tiles_imagestack, X_COORDS, Y_COORDS, Z_COORDS,
+)
 from .imagestack_test_utils import verify_physical_coordinates, verify_stack_data
 
 NUM_ROUND = 3
 NUM_CH = 4
-NUM_Z = 2
+NUM_ZPLANE = 2
 
 ROUND_LABELS = list(range(NUM_ROUND))
 CH_LABELS = list(range(NUM_CH))
-Z_LABELS = list(range(NUM_Z))
+ZPLANE_LABELS = list(range(NUM_ZPLANE))
 HEIGHT = 40
 WIDTH = 60
 
-X_COORDS = 0.01, 0.1
-Y_COORDS = 0.001, 0.01
-Z_COORDS = 0.0001, 0.001
+
+def expected_data(round_: int, ch: int, zplane: int):
+    return unique_data(round_, ch, zplane, NUM_ROUND, NUM_CH, NUM_ZPLANE, HEIGHT, WIDTH)
 
 
-def data(round_: int, ch: int, z: int) -> np.ndarray:
-    """Return the data for a given tile."""
-    result = np.empty((HEIGHT, WIDTH), dtype=np.uint32)
-    for row in range(HEIGHT):
-        base_val = ((((((round_ * NUM_CH) + ch) * NUM_Z) + z) * HEIGHT) + row) * WIDTH
-
-        result[row:] = np.linspace(base_val, base_val + WIDTH, WIDTH, False)
-    return img_as_float32(result)
-
-
-class UniqueTiles(FetchedTile):
-    """Tiles where the pixel values are unique per round/ch/z."""
-    def __init__(self, fov: int, _round: int, ch: int, zplane: int) -> None:
-        super().__init__()
-        self._round = _round
-        self._ch = ch
-        self._zplane = zplane
-
-    @property
-    def shape(self) -> Mapping[Axes, int]:
-        return {Axes.Y: HEIGHT, Axes.X: WIDTH}
-
-    @property
-    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
-        return {
-            Coordinates.X: X_COORDS,
-            Coordinates.Y: Y_COORDS,
-            Coordinates.Z: Z_COORDS,
-        }
-
-    @property
-    def format(self) -> ImageFormat:
-        return ImageFormat.TIFF
-
-    def tile_data(self) -> np.ndarray:
-        return data(self._round, self._ch, self._zplane)
-
-
-def setup_imagestack(crop_parameters: Optional[CropParameters]) -> ImageStack:
-    """Build an imagestack with labeled indices (i.e., indices that do not start at 0 or are not
-    sequential non-negative integers).
-    """
-    collection = build_image(
-        range(1),
-        ROUND_LABELS,
-        CH_LABELS,
-        Z_LABELS,
-        tile_fetcher_factory(UniqueTiles, True),
-    )
-    tileset = list(collection.all_tilesets())[0][1]
-
-    return ImageStack.from_tileset(tileset, crop_parameters)
+def setup_imagestack(crop_parameters: CropParameters) -> ImageStack:
+    return unique_tiles_imagestack(
+        ROUND_LABELS, CH_LABELS, ZPLANE_LABELS, HEIGHT, WIDTH, crop_parameters)
 
 
 def test_crop_rcz():
@@ -102,17 +49,17 @@ def test_crop_rcz():
 
     assert stack.axis_labels(Axes.ROUND) == rounds
     assert stack.axis_labels(Axes.CH) == chs
-    assert stack.axis_labels(Axes.ZPLANE) == Z_LABELS
+    assert stack.axis_labels(Axes.ZPLANE) == ZPLANE_LABELS
 
     for round_ in stack.axis_labels(Axes.ROUND):
         for ch in stack.axis_labels(Axes.CH):
             for zplane in stack.axis_labels(Axes.ZPLANE):
-                expected_data = data(round_, ch, zplane)
+                expected_tile_data = expected_data(round_, ch, zplane)
 
                 verify_stack_data(
                     stack,
                     {Axes.ROUND: round_, Axes.CH: ch, Axes.ZPLANE: zplane},
-                    expected_data,
+                    expected_tile_data,
                 )
     expected_z_coordinates = get_physical_coordinates_of_z_plane(Z_COORDS)
     verify_physical_coordinates(
@@ -136,7 +83,7 @@ def test_crop_xy():
 
     assert stack.axis_labels(Axes.ROUND) == ROUND_LABELS
     assert stack.axis_labels(Axes.CH) == CH_LABELS
-    assert stack.axis_labels(Axes.ZPLANE) == Z_LABELS
+    assert stack.axis_labels(Axes.ZPLANE) == ZPLANE_LABELS
 
     assert stack.raw_shape[3] == Y_SLICE[1] - Y_SLICE[0]
     assert stack.raw_shape[4] == X_SLICE[1] - X_SLICE[0]
@@ -144,13 +91,14 @@ def test_crop_xy():
     for round_ in stack.axis_labels(Axes.ROUND):
         for ch in stack.axis_labels(Axes.CH):
             for zplane in stack.axis_labels(Axes.ZPLANE):
-                expected_data = data(round_, ch, zplane)
-                expected_data = expected_data[Y_SLICE[0]:Y_SLICE[1], X_SLICE[0]:X_SLICE[1]]
+                expected_tile_data = expected_data(round_, ch, zplane)
+                expected_tile_data = expected_tile_data[
+                    Y_SLICE[0]:Y_SLICE[1], X_SLICE[0]:X_SLICE[1]]
 
                 verify_stack_data(
                     stack,
                     {Axes.ROUND: round_, Axes.CH: ch, Axes.ZPLANE: zplane},
-                    expected_data,
+                    expected_tile_data,
                 )
 
     # the coordinates should be rescaled.  verify that the coordinates on the ImageStack

--- a/starfish/imagestack/test/test_labeled_indices.py
+++ b/starfish/imagestack/test/test_labeled_indices.py
@@ -2,16 +2,15 @@
 These tests center around creating an ImageStack with labeled indices and verifying that operations
 on such an ImageStack work.
 """
-from typing import Mapping, Tuple, Union
-
 import numpy as np
-from slicedimage import ImageFormat
 
-from starfish.experiment.builder import build_image, FetchedTile, tile_fetcher_factory
 from starfish.imagestack.imagestack import ImageStack
 from starfish.imagestack.physical_coordinate_calculator import get_physical_coordinates_of_z_plane
-from starfish.types import Axes, Coordinates, Number
-from .imagestack_test_utils import verify_physical_coordinates, verify_stack_fill
+from starfish.types import Axes
+from .factories.unique_tiles import (
+    unique_data, unique_tiles_imagestack, X_COORDS, Y_COORDS, Z_COORDS,
+)
+from .imagestack_test_utils import verify_physical_coordinates, verify_stack_data
 
 ROUND_LABELS = (1, 4, 6)
 CH_LABELS = (2, 4, 6, 8)
@@ -21,66 +20,16 @@ WIDTH = 4
 
 NUM_ROUND = len(ROUND_LABELS)
 NUM_CH = len(CH_LABELS)
-NUM_Z = len(ZPLANE_LABELS)
-X_COORDS = 0.01, 0.01
-Y_COORDS = 0.001, 0.001
-Z_COORDS = 0.0001, 0.0001
+NUM_ZPLANE = len(ZPLANE_LABELS)
 
 
-def fill_value(round_: int, ch: int, z: int) -> float:
-    """Return the expected fill value for a given tile."""
-    round_idx = ROUND_LABELS.index(round_)
-    ch_idx = CH_LABELS.index(ch)
-    z_idx = ZPLANE_LABELS.index(z)
-    return float((((round_idx * NUM_CH) + ch_idx) * NUM_Z) + z_idx) / (NUM_ROUND * NUM_CH * NUM_Z)
-
-
-class UniqueTiles(FetchedTile):
-    """Tiles where the pixel values are unique per round/ch/z."""
-    def __init__(self, fov: int, _round: int, ch: int, zplane: int) -> None:
-        super().__init__()
-        self._round = _round
-        self._ch = ch
-        self._zplane = zplane
-
-    @property
-    def shape(self) -> Mapping[Axes, int]:
-        return {Axes.Y: HEIGHT, Axes.X: WIDTH}
-
-    @property
-    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
-        return {
-            Coordinates.X: X_COORDS,
-            Coordinates.Y: Y_COORDS,
-            Coordinates.Z: Z_COORDS,
-
-        }
-
-    @property
-    def format(self) -> ImageFormat:
-        return ImageFormat.TIFF
-
-    def tile_data(self) -> np.ndarray:
-        return np.full(
-            shape=(HEIGHT, WIDTH),
-            fill_value=fill_value(self._round, self._ch, self._zplane),
-            dtype=np.float32)
+def expected_data(round_: int, ch: int, zplane: int):
+    return unique_data(round_, ch, zplane, NUM_ROUND, NUM_CH, NUM_ZPLANE, HEIGHT, WIDTH)
 
 
 def setup_imagestack() -> ImageStack:
-    """Build an imagestack with labeled indices (i.e., indices that do not start at 0 or are not
-    sequential non-negative integers).
-    """
-    collection = build_image(
-        range(1),
-        ROUND_LABELS,
-        CH_LABELS,
-        ZPLANE_LABELS,
-        tile_fetcher_factory(UniqueTiles, True),
-    )
-    tileset = list(collection.all_tilesets())[0][1]
-
-    return ImageStack.from_tileset(tileset)
+    return unique_tiles_imagestack(
+        ROUND_LABELS, CH_LABELS, ZPLANE_LABELS, HEIGHT, WIDTH)
 
 
 def test_labeled_indices_read():
@@ -92,10 +41,10 @@ def test_labeled_indices_read():
     for round_ in stack.axis_labels(Axes.ROUND):
         for ch in stack.axis_labels(Axes.CH):
             for zplane in stack.axis_labels(Axes.ZPLANE):
-                verify_stack_fill(
+                verify_stack_data(
                     stack,
                     {Axes.ROUND: round_, Axes.CH: ch, Axes.ZPLANE: zplane},
-                    fill_value(round_, ch, zplane),
+                    expected_data(round_, ch, zplane),
                 )
 
 
@@ -116,12 +65,12 @@ def test_labeled_indices_set_slice():
                     if (selector[Axes.ROUND] == round_
                             and selector[Axes.CH] == ch
                             and selector[Axes.ZPLANE] == zplane):
-                        expected_fill_value = 0
+                        expected_fill_value = zeros
                     else:
-                        expected_fill_value = fill_value(
+                        expected_fill_value = expected_data(
                             selector[Axes.ROUND], selector[Axes.CH], selector[Axes.ZPLANE])
 
-                    verify_stack_fill(stack, selector, expected_fill_value)
+                    verify_stack_data(stack, selector, expected_fill_value)
 
 
 def test_labeled_indices_sel_single_tile():
@@ -137,9 +86,9 @@ def test_labeled_indices_sel_single_tile():
             assert subselected.axis_labels(index_type) == [selector[index_type]]
 
         # verify that the subselected stack has the correct data.
-        expected_fill_value = fill_value(
+        expected_tile_data = expected_data(
             selector[Axes.ROUND], selector[Axes.CH], selector[Axes.ZPLANE])
-        verify_stack_fill(stack, selector, expected_fill_value)
+        verify_stack_data(stack, selector, expected_tile_data)
 
         # assert that the physical coordinate values are what we expect.
     verify_physical_coordinates(
@@ -166,9 +115,9 @@ def test_labeled_indices_sel_slice():
 
     for selectors in subselected._iter_axes({Axes.ROUND, Axes.CH, Axes.ZPLANE}):
         # verify that the subselected stack has the correct data.
-        expected_fill_value = fill_value(
+        expected_tile_data = expected_data(
             selectors[Axes.ROUND], selectors[Axes.CH], selectors[Axes.ZPLANE])
-        verify_stack_fill(subselected, selectors, expected_fill_value)
+        verify_stack_data(subselected, selectors, expected_tile_data)
 
         # verify that each tile in the subselected stack has the correct physical coordinates.
     verify_physical_coordinates(
@@ -192,10 +141,10 @@ def test_labeled_indices_apply():
     for round_ in stack.axis_labels(Axes.ROUND):
         for ch in stack.axis_labels(Axes.CH):
             for zplane in stack.axis_labels(Axes.ZPLANE):
-                verify_stack_fill(
+                verify_stack_data(
                     stack,
                     {Axes.ROUND: round_, Axes.CH: ch, Axes.ZPLANE: zplane},
-                    fill_value(round_, ch, zplane),
+                    expected_data(round_, ch, zplane),
                 )
 
     output = stack.apply(multiply, value=0.5)
@@ -203,8 +152,8 @@ def test_labeled_indices_apply():
     for round_ in stack.axis_labels(Axes.ROUND):
         for ch in stack.axis_labels(Axes.CH):
             for zplane in stack.axis_labels(Axes.ZPLANE):
-                verify_stack_fill(
+                verify_stack_data(
                     output,
                     {Axes.ROUND: round_, Axes.CH: ch, Axes.ZPLANE: zplane},
-                    fill_value(round_, ch, zplane) * 0.5,
+                    expected_data(round_, ch, zplane) * 0.5,
                 )


### PR DESCRIPTION
They're nearly the same, so let's just unify them.  The plan is to reuse this for labeled ImageStack -> IntensityTable tests.

Depends on #1177, will be needed for #1168.