### PR TITLE
Allow for intensity tables with labeled axes

### DIFF
--- a/starfish/codebook/test/test_metric_decode.py
+++ b/starfish/codebook/test/test_metric_decode.py
@@ -22,7 +22,12 @@ def intensity_table_factory(data: np.ndarray=np.array([[[0, 3], [4, 0]]])) -> In
         columns=[Axes.ZPLANE, Axes.Y, Axes.X, Features.SPOT_RADIUS]
     )
 
-    intensity_table = IntensityTable.from_spot_data(data, SpotAttributes(spot_attributes_data))
+    intensity_table = IntensityTable.from_spot_data(
+        data,
+        SpotAttributes(spot_attributes_data),
+        ch_values=np.arange(data.shape[1]),
+        round_values=np.arange(data.shape[2]),
+    )
     return intensity_table
 
 

--- a/starfish/codebook/test/test_normalize_code_traces.py
+++ b/starfish/codebook/test/test_normalize_code_traces.py
@@ -20,7 +20,11 @@ def intensity_table_factory() -> IntensityTable:
     ).T
     spot_attributes = SpotAttributes(spot_attribute_data)
 
-    intensity_table = IntensityTable.from_spot_data(intensities, spot_attributes)
+    intensity_table = IntensityTable.from_spot_data(
+        intensities, spot_attributes,
+        ch_values=np.arange(intensities.shape[1]),
+        round_values=np.arange(intensities.shape[2]),
+    )
     return intensity_table
 
 

--- a/starfish/codebook/test/test_per_round_max_decode.py
+++ b/starfish/codebook/test/test_per_round_max_decode.py
@@ -21,7 +21,11 @@ def intensity_table_factory(data: np.ndarray=np.array([[[0, 3], [4, 0]]])) -> In
     )
 
     spot_attributes = SpotAttributes(spot_attributes_data)
-    intensity_table = IntensityTable.from_spot_data(data, spot_attributes)
+    intensity_table = IntensityTable.from_spot_data(
+        data, spot_attributes,
+        ch_values=np.arange(data.shape[1]),
+        round_values=np.arange(data.shape[2]),
+    )
     return intensity_table
 
 

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import (
     Any,
     Callable,
-    Iterable,
     Iterator,
     List,
     Mapping,
@@ -1000,7 +999,7 @@ class ImageStack:
         """Return the number of z_planes in the ImageStack"""
         return self.xarray.sizes[Axes.ZPLANE]
 
-    def axis_labels(self, axis: Axes) -> Iterable[int]:
+    def axis_labels(self, axis: Axes) -> Sequence[int]:
         """Given an axis, return the sorted unique values for that axis in this ImageStack.  For
         instance, ``imagestack.axis_labels(Axes.ROUND)`` returns all the round ids in this
         imagestack."""

--- a/starfish/intensity_table/test/test_empty_intensity_table.py
+++ b/starfish/intensity_table/test/test_empty_intensity_table.py
@@ -29,8 +29,8 @@ def test_intensity_table_can_be_created_from_spot_attributes():
 
     intensities = IntensityTable.zeros(
         spot_attributes,
-        n_ch=1,
-        n_round=3
+        ch_values=np.arange(1),
+        round_values=np.arange(3)
     )
 
     assert intensities.sizes[Axes.CH] == 1

--- a/starfish/intensity_table/test/test_from_imagestack.py
+++ b/starfish/intensity_table/test/test_from_imagestack.py
@@ -5,6 +5,7 @@ Tests for IntensityTable.from_image_stack method
 import numpy as np
 
 from starfish import ImageStack, IntensityTable
+from starfish.imagestack.test import test_labeled_indices
 from starfish.test.factories import (
     codebook_intensities_image_for_single_synthetic_spot,
     synthetic_spot_pass_through_stack,
@@ -54,3 +55,13 @@ def test_intensity_table_can_be_constructed_from_an_imagestack():
     # the number of channels and rounds should match the ImageStack
     assert intensities.sizes[Axes.CH.value] == c
     assert intensities.sizes[Axes.ROUND.value] == r
+
+
+def test_from_imagestack_labeled_indices():
+    # use the ImageStack with labeled indices from the test.
+    imagestack = test_labeled_indices.setup_imagestack()
+    intensity_table = IntensityTable.from_image_stack(imagestack)
+    assert np.array_equal(
+        intensity_table[Axes.CH.value], np.array(test_labeled_indices.CH_LABELS))
+    assert np.array_equal(
+        intensity_table[Axes.ROUND.value], np.array(test_labeled_indices.ROUND_LABELS))

--- a/starfish/intensity_table/test/test_from_spot_data.py
+++ b/starfish/intensity_table/test/test_from_spot_data.py
@@ -30,18 +30,30 @@ def test_intensity_table_can_be_constructed_from_a_numpy_array_and_spot_attribut
     """
     spot_attributes = spot_attribute_factory(3)
     data = np.zeros(30).reshape(3, 5, 2)
-    intensities = IntensityTable.from_spot_data(data, spot_attributes)
+    intensities = IntensityTable.from_spot_data(
+        data, spot_attributes, np.arange(data.shape[1]), np.arange(data.shape[2]))
 
     assert intensities.shape == data.shape
     assert np.array_equal(intensities.values, data)
 
 
-def test_from_spot_attributes_must_have_aligned_dimensions_spot_attributes_and_data():
+@pytest.mark.parametrize(
+    "num_features, num_ch_values, num_round_values",
+    [
+        (2, 5, 2,),
+        (3, 4, 2,),
+        (3, 5, 1,),
+    ]
+)
+def test_from_spot_attributes_must_have_aligned_dimensions_spot_attributes_and_data(
+        num_features, num_ch_values, num_round_values,
+):
     """
     Number of features must match number of SpotAttributes. Pass two attributes and 3 features and
     verify a ValueError is raised.
     """
-    spot_attributes = spot_attribute_factory(2)
+    spot_attributes = spot_attribute_factory(num_features)
     data = np.zeros(30).reshape(3, 5, 2)
     with pytest.raises(ValueError):
-        IntensityTable.from_spot_data(data, spot_attributes)
+        IntensityTable.from_spot_data(
+            data, spot_attributes, np.arange(num_ch_values), np.arange(num_round_values))

--- a/starfish/spots/_detector/detect.py
+++ b/starfish/spots/_detector/detect.py
@@ -94,14 +94,14 @@ def measure_spot_intensities(
     """
 
     # determine the shape of the intensity table
-    n_ch = data_image.shape[Axes.CH]
-    n_round = data_image.shape[Axes.ROUND]
+    ch_values = data_image.axis_labels(Axes.CH)
+    round_values = data_image.axis_labels(Axes.ROUND)
 
     # construct the empty intensity table
     intensity_table = IntensityTable.zeros(
         spot_attributes=spot_attributes,
-        n_ch=n_ch,
-        n_round=n_round,
+        ch_values=ch_values,
+        round_values=round_values,
     )
 
     # if no spots were detected, return the empty IntensityTable
@@ -109,7 +109,7 @@ def measure_spot_intensities(
         return intensity_table
 
     # fill the intensity table
-    indices = product(range(n_ch), range(n_round))
+    indices = product(ch_values, round_values)
     for c, r in indices:
         image, _ = data_image.get_slice({Axes.CH: c, Axes.ROUND: r})
         blob_intensities: pd.Series = measure_spot_intensity(
@@ -142,15 +142,15 @@ def concatenate_spot_attributes_to_intensities(
         concatenated input SpotAttributes, converted to an IntensityTable object
 
     """
-    n_ch: int = max(inds[Axes.CH] for _, inds in spot_attributes) + 1
-    n_round: int = max(inds[Axes.ROUND] for _, inds in spot_attributes) + 1
+    ch_values: Sequence[int] = sorted(set(inds[Axes.CH] for _, inds in spot_attributes))
+    round_values: Sequence[int] = sorted(set(inds[Axes.ROUND] for _, inds in spot_attributes))
 
     all_spots = pd.concat([sa.data for sa, inds in spot_attributes], sort=True)
     # this drop call ensures only x, y, z, radius, and quality, are passed to the IntensityTable
     features_coordinates = all_spots.drop(['spot_id', 'intensity'], axis=1)
 
     intensity_table = IntensityTable.zeros(
-        SpotAttributes(features_coordinates), n_ch, n_round,
+        SpotAttributes(features_coordinates), ch_values, round_values,
     )
 
     i = 0


### PR DESCRIPTION
Currently, we use the offset of r/c/z to label the axes on the intensity table.  We should instead be using the axes labels from the ImageStack.  This PR makes that change in three key areas:

1. `IntensityTable.empty_intensity_table` now accepts the labels for the axes.
2. `IntensityTable.from_spot_data` now accepts the labels for the axes and verifies that the number of labels matches the intensity data.
3. `IntensityTable.from_image_stack` reads the labels for the zplane axes and assigns them correctly.

Test plan: Add a test that instantiates a labeled ImageStack and derives an IntensityTable from it.  Also ran `make test && make -j run-notebooks`.

Depends on #1178
Fixes #1168
