### PR TITLE
Add back ability to set number of processes in spot finders

### DIFF
--- a/starfish/spots/_detector/blob.py
+++ b/starfish/spots/_detector/blob.py
@@ -150,7 +150,7 @@ class BlobDetector(SpotFinderAlgorithmBase):
         blobs_axes : Optional[Tuple[Axes, ...]]
             If blobs_image is provided, blobs_axes must be provided as well.  blobs_axes represents
             the axes across which the blobs image is max projected before spot detection is done.
-        n_processes : Optional[int] = 0,
+        n_processes : Optional[int] = None,
             Number of processes to devote to spot finding.
         """
 

--- a/starfish/spots/_detector/blob.py
+++ b/starfish/spots/_detector/blob.py
@@ -133,6 +133,7 @@ class BlobDetector(SpotFinderAlgorithmBase):
             primary_image: ImageStack,
             blobs_image: Optional[ImageStack] = None,
             blobs_axes: Optional[Tuple[Axes, ...]] = None,
+            n_processes: Optional[int] = None,
             *args,
     ) -> IntensityTable:
         """
@@ -149,6 +150,8 @@ class BlobDetector(SpotFinderAlgorithmBase):
         blobs_axes : Optional[Tuple[Axes, ...]]
             If blobs_image is provided, blobs_axes must be provided as well.  blobs_axes represents
             the axes across which the blobs image is max projected before spot detection is done.
+        n_processes : Optional[int] = 0,
+            Number of processes to devote to spot finding.
         """
 
         intensity_table = detect_spots(
@@ -157,6 +160,7 @@ class BlobDetector(SpotFinderAlgorithmBase):
             reference_image=blobs_image,
             reference_image_max_projection_axes=blobs_axes,
             measurement_function=self.measurement_function,
+            n_processes=n_processes,
             radius_is_gyration=False)
 
         return intensity_table

--- a/starfish/spots/_detector/local_max_peak_finder.py
+++ b/starfish/spots/_detector/local_max_peak_finder.py
@@ -290,7 +290,7 @@ class LocalMaxPeakFinder(SpotFinderAlgorithmBase):
         blobs_axes : Optional[Tuple[Axes, ...]]
             If blobs_image is provided, blobs_axes must be provided as well.  blobs_axes represents
             the axes across which the blobs image is max projected before spot detection is done.
-        n_processes : Optional[int] = 0,
+        n_processes : Optional[int] = None,
             Number of processes to devote to spot finding.
         """
         intensity_table = detect_spots(

--- a/starfish/spots/_detector/local_max_peak_finder.py
+++ b/starfish/spots/_detector/local_max_peak_finder.py
@@ -273,6 +273,7 @@ class LocalMaxPeakFinder(SpotFinderAlgorithmBase):
             primary_image: ImageStack,
             blobs_image: Optional[ImageStack] = None,
             blobs_axes: Optional[Tuple[Axes, ...]] = None,
+            n_processes: Optional[int] = None,
             *args,
     ) -> IntensityTable:
         """
@@ -289,6 +290,8 @@ class LocalMaxPeakFinder(SpotFinderAlgorithmBase):
         blobs_axes : Optional[Tuple[Axes, ...]]
             If blobs_image is provided, blobs_axes must be provided as well.  blobs_axes represents
             the axes across which the blobs image is max projected before spot detection is done.
+        n_processes : Optional[int] = 0,
+            Number of processes to devote to spot finding.
         """
         intensity_table = detect_spots(
             data_stack=primary_image,
@@ -296,6 +299,7 @@ class LocalMaxPeakFinder(SpotFinderAlgorithmBase):
             reference_image=blobs_image,
             reference_image_max_projection_axes=blobs_axes,
             measurement_function=self.measurement_function,
+            n_processes=n_processes,
             radius_is_gyration=False)
 
         return intensity_table

--- a/starfish/spots/_detector/trackpy_local_max_peak_finder.py
+++ b/starfish/spots/_detector/trackpy_local_max_peak_finder.py
@@ -141,6 +141,7 @@ class TrackpyLocalMaxPeakFinder(SpotFinderAlgorithmBase):
             primary_image: ImageStack,
             blobs_image: Optional[ImageStack] = None,
             blobs_axes: Optional[Tuple[Axes, ...]] = None,
+            n_processes: Optional[int] = None,
             *args,
     ) -> IntensityTable:
         """
@@ -157,6 +158,8 @@ class TrackpyLocalMaxPeakFinder(SpotFinderAlgorithmBase):
         blobs_axes : Optional[Tuple[Axes, ...]]
             If blobs_image is provided, blobs_axes must be provided as well.  blobs_axes represents
             the axes across which the blobs image is max projected before spot detection is done.
+        n_processes : Optional[int] = 0,
+            Number of processes to devote to spot finding.
         """
         intensity_table = detect_spots(
             data_stack=primary_image,
@@ -164,6 +167,7 @@ class TrackpyLocalMaxPeakFinder(SpotFinderAlgorithmBase):
             reference_image=blobs_image,
             reference_image_max_projection_axes=blobs_axes,
             measurement_function=self.measurement_function,
+            n_processes=n_processes,
             radius_is_gyration=True)
 
         return intensity_table

--- a/starfish/spots/_detector/trackpy_local_max_peak_finder.py
+++ b/starfish/spots/_detector/trackpy_local_max_peak_finder.py
@@ -158,7 +158,7 @@ class TrackpyLocalMaxPeakFinder(SpotFinderAlgorithmBase):
         blobs_axes : Optional[Tuple[Axes, ...]]
             If blobs_image is provided, blobs_axes must be provided as well.  blobs_axes represents
             the axes across which the blobs image is max projected before spot detection is done.
-        n_processes : Optional[int] = 0,
+        n_processes : Optional[int] = None,
             Number of processes to devote to spot finding.
         """
         intensity_table = detect_spots(


### PR DESCRIPTION
Adds ability to set `n_processes` for 3/4 spot finders which were missing the flag. 