### PR TITLE
Avoid use of _tile_data.keys()

### DIFF
--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -1072,7 +1072,11 @@ class ImageStack:
             default_tile_shape={Axes.Y: self.tile_shape[0], Axes.X: self.tile_shape[1]},
             extras=self._tile_data.extras,
         )
-        for tilekey in self._tile_data.keys():
+        for axis_val_map in self._iter_axes({Axes.ROUND, Axes.CH, Axes.ZPLANE}):
+            tilekey = TileKey(
+                round=axis_val_map[Axes.ROUND],
+                ch=axis_val_map[Axes.CH],
+                zplane=axis_val_map[Axes.ZPLANE])
             round_, ch, zplane = tilekey.round, tilekey.ch, tilekey.z
             extras: dict = self._tile_data[tilekey]
 


### PR DESCRIPTION
`_tile_data.keys()` returns tiles outside the scope of the imagestack if it has been subselected.  Instead, use `_iter_axes(..)`, which uses the actual xarray coordinates to determine which tiles exist.

Test plan: Add a test that selects and exports an imagestack.

Depends on #1189
Fixes #1154