### PR TITLE
fixing Clip.SCALE_BY_IMAGE

### DIFF
--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -706,7 +706,7 @@ class ImageStack:
 
         # scale based on values of whole image
         if clip_method == Clip.SCALE_BY_IMAGE:
-            self._data = preserve_float_range(self._data, rescale=True)
+            self._data.data.values = preserve_float_range(self._data.data.values, rescale=True)
 
         return self
 

--- a/starfish/imagestack/test/test_apply.py
+++ b/starfish/imagestack/test/test_apply.py
@@ -84,7 +84,6 @@ def test_apply_clipping_methods():
     assert np.allclose(imagestack.xarray, res.xarray)
     assert isinstance(imagestack.xarray, xr.DataArray)
 
-
     # clip_method 2
     res = imagestack.apply(
         apply_function, clip_method=Clip.SCALE_BY_CHUNK, in_place=False, n_processes=1,

--- a/starfish/imagestack/test/test_apply.py
+++ b/starfish/imagestack/test/test_apply.py
@@ -1,6 +1,7 @@
 import copy
 
 import numpy as np
+import xarray as xr
 
 from starfish.imagestack.imagestack import ImageStack
 from starfish.types import Axes, Clip
@@ -81,6 +82,8 @@ def test_apply_clipping_methods():
         apply_function, clip_method=Clip.SCALE_BY_IMAGE, in_place=False, n_processes=1
     )
     assert np.allclose(imagestack.xarray, res.xarray)
+    assert isinstance(imagestack.xarray, xr.DataArray)
+
 
     # clip_method 2
     res = imagestack.apply(


### PR DESCRIPTION
overwrite the Imagestacks numpy array with the result of preserve_float_range() instead of the xarray 

fixes #1184 