### PR TITLE
Disable numpy-doc inherited class logic

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,7 +64,7 @@ intersphinx_mapping = {'xarray': ('http://xarray.pydata.org/en/stable', None)}
 
 # numpydoc settings
 numpydoc_class_members_toctree = False
-
+numpydoc_show_inherited_class_members = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
Having this set to True means IntensityTable and Codebook try to render all the xarray attributes and methods, instead we should just link to them. 