### PR TITLE
Update codebook documentation and harmonize method names

### DIFF
--- a/starfish/codebook/codebook.py
+++ b/starfish/codebook/codebook.py
@@ -68,7 +68,7 @@ class Codebook(xr.DataArray):
         return int(np.dot(*self.shape[1:]))
 
     @classmethod
-    def empty(cls, code_names: Sequence[str], n_channel: int, n_round: int):
+    def zeros(cls, code_names: Sequence[str], n_channel: int, n_round: int):
         """
         Create an empty codebook of shape (code_names, n_channel, n_round)
 
@@ -86,7 +86,7 @@ class Codebook(xr.DataArray):
         Build an empty 2-round 3-channel codebook::
 
             >>> from starfish import Codebook
-            >>> Codebook.empty(['ACTA', 'ACTB'], n_channel=3, n_round=2)
+            >>> Codebook.zeros(['ACTA', 'ACTB'], n_channel=3, n_round=2)
             <xarray.Codebook (target: 2, c: 3, r: 2)>
             array([[[0, 0],
                     [0, 0],

--- a/starfish/codebook/codebook.py
+++ b/starfish/codebook/codebook.py
@@ -25,43 +25,20 @@ from starfish.types import Axes, Features, Number
 class Codebook(xr.DataArray):
     """Codebook for an image-based transcriptomics experiment
 
-    The codebook is a three dimensional tensor whose values are the expected intensity of a spot
-    for each code in each imaging round and each color channel. This class supports the
-    construction of synthetic codebooks for testing, and exposes decode methods to assign target
-    identifiers to spots. This codebook provides an in-memory representation of the codebook
-    defined in the spaceTx format.
+    The codebook is a three dimensional tensor with shape :code:`(feature, channel, round)` whose
+    values are the expected intensity of features (spots or pixels) that correspond to each target
+    (gene or protein) in each of the image tiles of an experiment.
+
+    This class supports the construction of synthetic codebooks for testing, and exposes decode
+    methods to assign target identifiers to spots. This codebook provides an in-memory
+    representation of the codebook defined in the SpaceTx format.
 
     The codebook is a subclass of xarray, and exposes the complete public API of that package in
     addition to the methods and constructors listed below.
 
-    Methods
-    -------
-    from_code_array(code_array, n_round, n_channel)
-        construct a codebook from a spaceTx-spec array of codewords
-
-    from_json(json_codebook, n_round, n_channel)
-        load a codebook from a spaceTx spec-compliant json file
-
-    to_json(filename)
-        save a codebook to json
-
-    synthetic_one_hot_codebook(n_round, n_channel, n_codes, target_names=None)
-        Construct a codebook of random codes where only one channel is on per imaging round.
-        This is the typical codebook format for in-situ sequencing and non-multiplex smFISH
-        experiments.
-
-    decode_euclidean(intensities)
-        find the closest code for each spot in intensities by euclidean distance
-
-    decode_per_round_maximum(intensities)
-        find codes that match the per-channel max intensity for each spot in intensities
-
-    code_length()
-        return the total length of the codes in the codebook
-
     Examples
     --------
-    Build a codebook using ``Codebook.synthetic_one_hot_codebook``::
+    Build a codebook using :py:meth:`Codebook.synthetic_one_hot_codebook`::
 
         >>> from starfish import Codebook
         >>> sd = Codebook.synthetic_one_hot_codebook(n_channel=3, n_round=4, n_codes=2)
@@ -91,34 +68,37 @@ class Codebook(xr.DataArray):
         return int(np.dot(*self.shape[1:]))
 
     @classmethod
-    def _empty_codebook(cls, code_names: Sequence[str], n_channel: int, n_round: int):
-        """create an empty codebook of shape (code_names, n_channel, n_round)
+    def empty(cls, code_names: Sequence[str], n_channel: int, n_round: int):
+        """
+        Create an empty codebook of shape (code_names, n_channel, n_round)
 
         Parameters
         ----------
         code_names : Sequence[str]
-            the targets to be coded
+            The targets to be coded.
         n_channel : int
-            number of channels used to build the codes
+            Number of channels used to build the codes.
         n_round : int
-            number of imaging rounds used to build the codes
+            Number of imaging rounds used to build the codes.
 
         Examples
         --------
-        >>> from starfish import Codebook
-        >>> Codebook._empty_codebook(['ACTA', 'ACTB'], n_channel=3, n_round=2)
-        <xarray.Codebook (target: 2, c: 3, r: 2)>
-        array([[[0, 0],
-                [0, 0],
-                [0, 0]],
+        Build an empty 3-round 2-channel codebook::
 
-               [[0, 0],
-                [0, 0],
-                [0, 0]]], dtype=uint8)
-        Coordinates:
-          * target     (target) object 'ACTA' 'ACTB'
-          * c          (c) int64 0 1 2
-          * r          (r) int64 0 1
+            >>> from starfish import Codebook
+            >>> Codebook.empty(['ACTA', 'ACTB'], n_channel=3, n_round=2)
+            <xarray.Codebook (target: 2, c: 3, r: 2)>
+            array([[[0, 0],
+                    [0, 0],
+                    [0, 0]],
+
+                   [[0, 0],
+                    [0, 0],
+                    [0, 0]]], dtype=uint8)
+            Coordinates:
+              * target     (target) object 'ACTA' 'ACTB'
+              * c          (c) int64 0 1 2
+              * r          (r) int64 0 1
 
         Returns
         -------
@@ -127,17 +107,17 @@ class Codebook(xr.DataArray):
 
         """
         data = np.zeros((len(code_names), n_channel, n_round), dtype=np.uint8)
-        return cls._create_codebook(code_names, n_channel, n_round, data)
+        return cls.from_numpy(code_names, n_channel, n_round, data)
 
     @classmethod
-    def _create_codebook(
+    def from_numpy(
             cls,
             code_names: Sequence[str],
             n_channel: int,
             n_round: int,
             data: np.ndarray,
     ) -> "Codebook":
-        """create a codebook of shape (code_names, n_channel, n_round) with the given data
+        """create a codebook of shape (code_names, n_channel, n_round) from a 3-d numpy array
 
         Parameters
         ----------
@@ -152,22 +132,28 @@ class Codebook(xr.DataArray):
 
         Examples
         --------
-        >>> import numpy as np
-        >>> from starfish import Codebook
-        >>> data = np.zeros((3, 2, 2), dtype=np.uint8)
-        >>> Codebook._create_codebook(['ACTA', 'ACTB'], n_channel=3, n_round=2, data=data)
-        <xarray.Codebook (target: 2, c: 3, r: 2)>
-        array([[[0, 0],
-                [0, 0],
-                [0, 0]],
+        build a 3-round 2-channel codebook where :code:`ACTA` is specified by intensity in round 0,
+        channel 1, and :code:`ACTB` is coded by fluorescence in rounds 0 and 1, channel 2
+        ::
 
-               [[0, 0],
-                [0, 0],
-                [0, 0]]], dtype=uint8)
-        Coordinates:
-          * target     (target) object 'ACTA' 'ACTB'
-          * c          (c) int64 0 1 2
-          * r          (r) int64 0 1
+            >>> import numpy as np
+            >>> from starfish import Codebook
+            >>> data = np.zeros((2, 3, 2), dtype=np.uint8)
+            >>> data[0, 0, 1] = 1                 # ACTA
+            >>> data[[1, 1], [2, 2], [0, 1]] = 1  # ACTB
+            >>> Codebook.from_numpy(['ACTA', 'ACTB'], n_channel=3, n_round=2, data=data)
+            <xarray.Codebook (target: 2, c: 3, r: 2)>
+            array([[[0, 1],
+                    [0, 0],
+                    [0, 0]],
+
+                   [[0, 0],
+                    [0, 0],
+                    [1, 1]]], dtype=uint8)
+            Coordinates:
+              * target     (target) object 'ACTA' 'ACTB'
+              * c          (c) int64 0 1 2
+              * r          (r) int64 0 1
 
         Returns
         -------
@@ -196,8 +182,12 @@ class Codebook(xr.DataArray):
     @classmethod
     def from_code_array(
             cls, code_array: List[Dict[Union[str, Any], Any]],
-            n_round: Optional[int]=None, n_channel: Optional[int]=None) -> "Codebook":
-        """construct a codebook from a spaceTx-spec array of codewords
+            n_round: Optional[int] = None, n_channel: Optional[int] = None) -> "Codebook":
+        """
+        Construct a codebook from a python list of SpaceTx-Format codewords.
+
+        Note: Loading the SpaceTx-Format codebook with :py:meth:`json.load` will produce a code
+        array that can be passed to this constructor.
 
         Parameters
         ----------
@@ -210,7 +200,8 @@ class Codebook(xr.DataArray):
 
         Examples
         --------
-        Construct a codebook from some array data in python memory::
+        Construct a codebook from some array data in python memory
+        ::
 
             >>> from starfish.types import Axes
             >>> from starfish import Codebook
@@ -300,29 +291,30 @@ class Codebook(xr.DataArray):
                 ch = int(bit[Axes.CH])
                 r = int(bit[Axes.ROUND])
                 data[i, ch, r] = int(bit[Features.CODE_VALUE])
-        return cls._create_codebook(target_names, n_channel, n_round, data)
+        return cls.from_numpy(target_names, n_channel, n_round, data)
 
     @classmethod
-    def from_json(
+    def open_json(
             cls, json_codebook: str,
-            n_round: Optional[int]=None,
-            n_channel: Optional[int]=None,
+            n_round: Optional[int] = None,
+            n_channel: Optional[int] = None,
     ) -> "Codebook":
-        """Load a codebook from a spaceTx spec-compliant json file or a url pointing to such a file
-        Loads configuration from StarfishConfig.
+        """
+        Load a codebook from a SpaceTx Format json file or a url pointing to such a file.
 
         Parameters
         ----------
         json_codebook : str
-            path or url to json file containing a spaceTx codebook
+            Path or url to json file containing a spaceTx codebook.
         n_round : Optional[int]
-            The number of imaging rounds used in the codes. Will be inferred if not provided
+            The number of imaging rounds used in the codes. Will be inferred if not provided.
         n_channel : Optional[int]
-            The number of channels used in the codes. Will be inferred if not provided
+            The number of channels used in the codes. Will be inferred if not provided.
 
         Examples
         --------
-        Create a codebook from in-memory data::
+        Create a codebook from in-memory data
+        ::
 
             >>> from starfish.types import Axes
             >>> from starfish import Codebook
@@ -351,7 +343,7 @@ class Codebook(xr.DataArray):
             >>> with open(json_codebook, 'w') as f:
             >>>     json.dump(codebook, f)
             >>> # read codebook from file
-            >>> Codebook.from_json(json_codebook)
+            >>> Codebook.open_json(json_codebook)
            <xarray.Codebook (target: 2, c: 4, r: 2)>
             array([[[0, 0],
                     [0, 0],
@@ -397,19 +389,13 @@ class Codebook(xr.DataArray):
         return cls.from_code_array(codebook_doc[DocumentKeys.MAPPINGS_KEY], n_round, n_channel)
 
     def to_json(self, filename: str) -> None:
-        """save a codebook to json
-
-        Notes
-        -----
-        This enforces the following typing of codebooks:
-        ch, round : int
-        value : float
-        target : str
+        """
+        Save a codebook to json using SpaceTx Format.
 
         Parameters
         ----------
         filename : str
-            filename
+            The name of the file in which to save the codebook.
 
         """
         code_array = []
@@ -439,9 +425,9 @@ class Codebook(xr.DataArray):
     @staticmethod
     def _normalize_features(
             array: Union["Codebook", IntensityTable],
-            norm_order,
+            norm_order: int,
     ) -> Tuple[Union["Codebook", IntensityTable], np.ndarray]:
-        """unit normalize each feature of array
+        """Unit normalize each feature of array
 
         Parameters
         ----------
@@ -516,21 +502,28 @@ class Codebook(xr.DataArray):
             self,
             intensities: IntensityTable,
     ):
-        # verify that the shapes of the codebook and intensities match
+        """verify that the shapes of the codebook and intensities match"""
         ch_match = intensities.sizes[Axes.CH] == self.sizes[Axes.CH]
         round_match = intensities.sizes[Axes.ROUND] == self.sizes[Axes.ROUND]
         if not (ch_match and round_match):
             raise ValueError(
                 'Codebook and Intensities must have same number of channels and rounds')
 
-    def metric_decode(
+    def decode_metric(
             self, intensities: IntensityTable, max_distance: Number, min_intensity: Number,
             norm_order: int, metric: str='euclidean'
     ) -> IntensityTable:
-        """Assign the closest target by euclidean distance to each feature in an intensity table
+        """
+        Assigns intensity patterns that have been extracted from an :py:class:`ImageStack` and
+        stored in an :py:class:`IntensityTable` by a :py:class:`SpotFinder` to the gene targets that
+        they encode.
 
-        Normalizes both the codes and the features to be unit vectors and finds the closest code
-        for each feature
+        This method carries out the assignment by first normalizing both the codes and the
+        recovered intensities to be unit magnitude using an L2 norm, and then finds the closest
+        code for each feature according to a distance metric (default=euclidean).
+
+        Features greater than :code:`max_distance` from their nearest code, or that have an average
+        intensity below :code:`min_intensity` are not assigned to any feature.
 
         Parameters
         ----------
@@ -550,6 +543,8 @@ class Codebook(xr.DataArray):
         --------
         The available norms for this function can be found at the following link:
         https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.linalg.norm.html
+        The available metrics for this function can be found at the following link:
+        https://docs.scipy.org/doc/scipy-0.14.0/reference/spatial.distance.html
 
         Returns
         -------
@@ -584,15 +579,26 @@ class Codebook(xr.DataArray):
         return IntensityTable(norm_intensities)
 
     def decode_per_round_max(self, intensities: IntensityTable) -> IntensityTable:
-        """decode each feature by selecting the per-imaging-round max-valued channel
+        """
+        Assigns intensity patterns that have been extracted from an :py:class:`ImageStack` and
+        stored in an :py:class:`IntensityTable` by a :py:class:`SpotFinder` to the gene targets that
+        they encode.
+
+        This method carries out the assignment by identifying the maximum-intensity channel for each
+        round, and assigning each spot to a code if the maximum-intensity pattern exists in the
+        codebook.
+
+        This method is only compatible with one-hot codebooks, where exactly one channel is expected
+        to contain fluorescence in each imaging round. This is a common coding strategy for
+        experiments that read out one DNA base with a distinct fluorophore in each imaging round.
 
         Notes
         -----
         - If no code matches the per-round maximum for a feature, it will be assigned 'nan' instead
           of a target value
-        - Numpy's argmax breaks ties by picking the first channel -- this can lead to
-          unexpected results where some features with "tied" channels will decode, but others will
-          be assigned 'nan'.
+        - Numpy's argmax breaks ties by picking the first of the tied values -- this can lead to
+          unexpected results in low-precision images where some features with "tied" channels will
+          decode, but others will be assigned 'nan'.
 
         Parameters
         ----------
@@ -679,7 +685,8 @@ class Codebook(xr.DataArray):
 
         Examples
         --------
-        Create a Codebook with 2 rounds, 3 channels, and 2 codes::
+        Create a Codebook with 2 rounds, 3 channels, and 2 codes
+        ::
 
             >>> from starfish import Codebook
             >>> Codebook.synthetic_one_hot_codebook(n_round=2, n_channel=3, n_codes=2)

--- a/starfish/codebook/codebook.py
+++ b/starfish/codebook/codebook.py
@@ -83,7 +83,7 @@ class Codebook(xr.DataArray):
 
         Examples
         --------
-        Build an empty 3-round 2-channel codebook::
+        Build an empty 2-round 3-channel codebook::
 
             >>> from starfish import Codebook
             >>> Codebook.empty(['ACTA', 'ACTB'], n_channel=3, n_round=2)
@@ -132,7 +132,7 @@ class Codebook(xr.DataArray):
 
         Examples
         --------
-        build a 3-round 2-channel codebook where :code:`ACTA` is specified by intensity in round 0,
+        build a 2-round 3-channel codebook where :code:`ACTA` is specified by intensity in round 0,
         channel 1, and :code:`ACTB` is coded by fluorescence in rounds 0 and 1, channel 2
         ::
 

--- a/starfish/codebook/test/factories.py
+++ b/starfish/codebook/test/factories.py
@@ -35,7 +35,7 @@ def loaded_codebook():
         codebook = Codebook.from_code_array(simple_codebook_array())
         codebook.to_json(tf.name)
 
-        result = Codebook.from_json(tf.name, n_channel=2, n_round=2)
+        result = Codebook.open_json(tf.name, n_channel=2, n_round=2)
     return result
 
 

--- a/starfish/codebook/test/test_from_code_array.py
+++ b/starfish/codebook/test/test_from_code_array.py
@@ -129,7 +129,7 @@ def test_from_code_array_throws_exception_when_data_is_improperly_formatted():
 def test_empty_codebook():
     code_array: List = codebook_array_factory()
     targets = [x[Features.TARGET] for x in code_array]
-    codebook = Codebook._empty_codebook(targets, n_channel=3, n_round=2)
+    codebook = Codebook.empty(targets, n_channel=3, n_round=2)
     assert_sizes(codebook, False)
 
 def test_create_codebook():
@@ -144,5 +144,5 @@ def test_create_codebook():
             r = int(bit[Axes.ROUND])
             data[i, ch, r] = int(bit[Features.CODE_VALUE])
 
-    codebook = Codebook._create_codebook(targets, n_channel=3, n_round=2, data=data)
+    codebook = Codebook.from_numpy(targets, n_channel=3, n_round=2, data=data)
     assert_sizes(codebook)

--- a/starfish/codebook/test/test_from_code_array.py
+++ b/starfish/codebook/test/test_from_code_array.py
@@ -129,7 +129,7 @@ def test_from_code_array_throws_exception_when_data_is_improperly_formatted():
 def test_empty_codebook():
     code_array: List = codebook_array_factory()
     targets = [x[Features.TARGET] for x in code_array]
-    codebook = Codebook.empty(targets, n_channel=3, n_round=2)
+    codebook = Codebook.zeros(targets, n_channel=3, n_round=2)
     assert_sizes(codebook, False)
 
 def test_create_codebook():

--- a/starfish/codebook/test/test_metric_decode.py
+++ b/starfish/codebook/test/test_metric_decode.py
@@ -70,7 +70,7 @@ def test_metric_decode():
     intensities = intensity_table_factory(data)
     codebook = codebook_factory()
 
-    decoded_intensities = codebook.metric_decode(
+    decoded_intensities = codebook.decode_metric(
         intensities,
         max_distance=0.5,
         min_intensity=1,
@@ -113,4 +113,4 @@ def test_unmatched_intensities_and_codebook_table_sizes_throws_value_error():
     codebook = Codebook.from_code_array(codebook_array)
     intensities = intensity_table_factory()
     with pytest.raises(ValueError):
-        codebook.metric_decode(intensities, max_distance=0.5, min_intensity=1, norm_order=1)
+        codebook.decode_metric(intensities, max_distance=0.5, min_intensity=1, norm_order=1)

--- a/starfish/experiment/experiment.py
+++ b/starfish/experiment/experiment.py
@@ -263,7 +263,7 @@ class Experiment:
         _, codebook_name, codebook_baseurl = resolve_url(experiment_document['codebook'],
                                                          baseurl, config.slicedimage)
         codebook_absolute_url = pathjoin(codebook_baseurl, codebook_name)
-        codebook = Codebook.from_json(codebook_absolute_url)
+        codebook = Codebook.open_json(codebook_absolute_url)
 
         extras = experiment_document['extras']
 

--- a/starfish/intensity_table/test/test_from_imagestack.py
+++ b/starfish/intensity_table/test/test_from_imagestack.py
@@ -16,7 +16,7 @@ from starfish.types import Axes
 def test_imagestack_to_intensity_table():
     codebook, intensity_table, image = codebook_intensities_image_for_single_synthetic_spot()
     pixel_intensities = IntensityTable.from_image_stack(image)
-    pixel_intensities = codebook.metric_decode(
+    pixel_intensities = codebook.decode_metric(
         pixel_intensities, max_distance=0, min_intensity=1000, norm_order=2)
     assert isinstance(pixel_intensities, IntensityTable)
 
@@ -24,7 +24,7 @@ def test_imagestack_to_intensity_table():
 def test_imagestack_to_intensity_table_no_noise():
     codebook, intensity_table, image = synthetic_spot_pass_through_stack()
     pixel_intensities = IntensityTable.from_image_stack(image)
-    pixel_intensities = codebook.metric_decode(
+    pixel_intensities = codebook.decode_metric(
         pixel_intensities, max_distance=0, min_intensity=1000, norm_order=2)
     assert isinstance(pixel_intensities, IntensityTable)
 

--- a/starfish/spots/_detector/test/test_synthetic_data.py
+++ b/starfish/spots/_detector/test/test_synthetic_data.py
@@ -27,7 +27,7 @@ def test_round_trip_synthetic_data():
     spots = sd.spots(intensities=intensities)
     gsd = BlobDetector(min_sigma=1, max_sigma=4, num_sigma=5, threshold=0)
     calculated_intensities = gsd.run(spots, blobs_image=spots, blobs_axes=(Axes.ROUND, Axes.CH))
-    decoded_intensities = codebook.metric_decode(
+    decoded_intensities = codebook.decode_metric(
         calculated_intensities,
         max_distance=1,
         min_intensity=0,
@@ -88,7 +88,7 @@ def test_medium_synthetic_stack():
     spots = sd.spots(intensities=intensities)
     gsd = BlobDetector(min_sigma=1, max_sigma=4, num_sigma=5, threshold=1e-4)
     calculated_intensities = gsd.run(spots, blobs_image=spots, blobs_axes=(Axes.ROUND, Axes.CH))
-    calculated_intensities = codebook.metric_decode(
+    calculated_intensities = codebook.decode_metric(
         calculated_intensities, max_distance=1, min_intensity=0, norm_order=2
     )
 

--- a/starfish/spots/_pixel_decoder/pixel_spot_decoder.py
+++ b/starfish/spots/_pixel_decoder/pixel_spot_decoder.py
@@ -71,7 +71,7 @@ class PixelSpotDecoder(PixelDecoderAlgorithmBase):
 
         """
         pixel_intensities = IntensityTable.from_image_stack(primary_image)
-        decoded_intensities = self.codebook.metric_decode(
+        decoded_intensities = self.codebook.decode_metric(
             pixel_intensities,
             max_distance=self.distance_threshold,
             min_intensity=self.magnitude_threshold,

--- a/starfish/test/factories.py
+++ b/starfish/test/factories.py
@@ -418,7 +418,7 @@ def synthetic_dataset_with_truth_values_and_called_spots():
     intensities = gsd.run(data_stack=filtered, blobs_image=filtered)
     assert intensities.shape[0] == 5
 
-    codebook.metric_decode(intensities, max_distance=1, min_intensity=0, norm_order=2)
+    codebook.decode_metric(intensities, max_distance=1, min_intensity=0, norm_order=2)
 
     return codebook, true_intensities, image, intensities
 

--- a/starfish/util/indirectfile/_codebook.py
+++ b/starfish/util/indirectfile/_codebook.py
@@ -18,4 +18,4 @@ class GetCodebook(ConversionRecipe):
         return not input_parameter.startswith("@")
 
     def load(self, input_parameter: str) -> Codebook:
-        return Codebook.from_json(input_parameter)
+        return Codebook.open_json(input_parameter)


### PR DESCRIPTION
* update documentation
* `codebook.empty_codebook` --> `codebook.empty`
* `codebook._create_codebook` --> `codebook.from_numpy`
* `codebook.from_json` --> `codebook.open_json`
* `codebook.metric_decode` --> `codebook.decode_metric`  (enable tab completion of codebook.decode_*)

Other changes are refactorings that relate to the above changes. 