### PR TITLE
Update IntensityTable documentation and harmonize method names

### DIFF
--- a/docs/source/_static/data_processing_examples/3d_smFISH.py
+++ b/docs/source/_static/data_processing_examples/3d_smFISH.py
@@ -107,7 +107,7 @@ def processing_pipeline(
         spot_attributes = tlmpf.run(primary_image)
         all_intensities.append(spot_attributes)
 
-    spot_attributes = IntensityTable.concatanate_intensity_tables(all_intensities)
+    spot_attributes = IntensityTable.concatenate_intensity_tables(all_intensities)
 
     print("Decoding spots...")
     decoded = codebook.decode_per_round_max(spot_attributes)

--- a/docs/source/_static/example_data_files/README.rst
+++ b/docs/source/_static/example_data_files/README.rst
@@ -9,4 +9,4 @@ as follows:
 pipeline run on testing data and serialized using :py:meth:`DecodedSpots.save`.
 
 2. decoded.nc: A :code:`netcdf` file containing the :py:class:`IntensityTable` output from the ISS
-pipeline run on testing data and serialized using :py:meth:`IntensityTable.save`.
+pipeline run on testing data and serialized using :py:meth:`IntensityTable.to_netcdf`.

--- a/docs/source/help_and_reference/working_with_starfish_outputs/index.rst
+++ b/docs/source/help_and_reference/working_with_starfish_outputs/index.rst
@@ -9,14 +9,14 @@ easy to work with in both Python_ and R_.
 .. _Python: https://www.python.org/
 .. _R: https://www.r-project.org/about.html
 
-To work with the :py:class:`IntensityTable` in python, it's as simple as using that object's load
+To work with the :py:class:`IntensityTable` in python, it's as simple as using that object's open_netcdf
 command:
 
 .. code-block:: python
 
     import starfish
     example_netcdf_file: str = "docs/source/_static/example_data_files/decoded.nc"
-    intensity_table: starfish.IntensityTable = starfish.IntensityTable.load(example_netcdf_file)
+    intensity_table: starfish.IntensityTable = starfish.IntensityTable.open_netcdf(example_netcdf_file)
     print(intensity_table)
 
 in R_, the ncdf4 library allows the :code:`.nc` archive, which is based on hdf5, to be opened.

--- a/starfish/intensity_table/intensity_table.py
+++ b/starfish/intensity_table/intensity_table.py
@@ -86,7 +86,7 @@ class IntensityTable(xr.DataArray):
         return coordinates
 
     @classmethod
-    def empty(
+    def zeros(
             cls, spot_attributes: SpotAttributes, n_ch: int, n_round: int,
     ) -> "IntensityTable":
         """

--- a/starfish/intensity_table/test/test_empty_intensity_table.py
+++ b/starfish/intensity_table/test/test_empty_intensity_table.py
@@ -27,7 +27,7 @@ def test_intensity_table_can_be_created_from_spot_attributes():
         )
     )
 
-    intensities = IntensityTable.empty(
+    intensities = IntensityTable.zeros(
         spot_attributes,
         n_ch=1,
         n_round=3
@@ -51,4 +51,4 @@ def test_from_spot_attributes_throws_type_error_when_passed_a_dataframe():
     )
 
     with pytest.raises(TypeError):
-        IntensityTable.empty(not_spot_attributes, n_ch=1, n_round=3)
+        IntensityTable.zeros(not_spot_attributes, n_ch=1, n_round=3)

--- a/starfish/intensity_table/test/test_empty_intensity_table.py
+++ b/starfish/intensity_table/test/test_empty_intensity_table.py
@@ -27,7 +27,7 @@ def test_intensity_table_can_be_created_from_spot_attributes():
         )
     )
 
-    intensities = IntensityTable.empty_intensity_table(
+    intensities = IntensityTable.empty(
         spot_attributes,
         n_ch=1,
         n_round=3
@@ -51,4 +51,4 @@ def test_from_spot_attributes_throws_type_error_when_passed_a_dataframe():
     )
 
     with pytest.raises(TypeError):
-        IntensityTable.empty_intensity_table(not_spot_attributes, n_ch=1, n_round=3)
+        IntensityTable.empty(not_spot_attributes, n_ch=1, n_round=3)

--- a/starfish/intensity_table/test/test_intensity_table_serialization.py
+++ b/starfish/intensity_table/test/test_intensity_table_serialization.py
@@ -24,8 +24,8 @@ def test_intensity_table_serialization():
     # dump it to disk
     tempdir = tempfile.mkdtemp()
     filename = os.path.join(tempdir, 'test.nc')
-    intensities.save(filename)
+    intensities.to_netcdf(filename)
 
     # verify the data has not changed
-    loaded = intensities.load(filename)
+    loaded = intensities.open_netcdf(filename)
     assert intensities.equals(loaded)

--- a/starfish/intensity_table/test/test_overlap.py
+++ b/starfish/intensity_table/test/test_overlap.py
@@ -115,7 +115,7 @@ def test_take_max():
     it2 = create_intensity_table_with_coords(Area(min_x=1, max_x=2,
                                                   min_y=1, max_y=3), n_spots=20)
 
-    concatenated = IntensityTable.concatanate_intensity_tables(
+    concatenated = IntensityTable.concatenate_intensity_tables(
         [it1, it2], overlap_strategy=OverlapStrategy.TAKE_MAX)
 
     # The overlap section hits half of the spots from each intensity table, 5 from it1

--- a/starfish/intensity_table/test/test_to_mermaid.py
+++ b/starfish/intensity_table/test/test_to_mermaid.py
@@ -24,10 +24,10 @@ def test_to_mermaid_dataframe():
     # without a target assignment, should raise RuntimeError.
     with pytest.raises(RuntimeError):
         with TemporaryDirectory() as dir_:
-            intensities.save_mermaid(os.path.join(dir_, 'test.csv.gz'))
+            intensities.to_mermaid(os.path.join(dir_, 'test.csv.gz'))
 
     # assign targets
     intensities[Features.TARGET] = (Features.AXIS, np.random.choice(list('ABCD'), size=20))
     intensities[Features.DISTANCE] = (Features.AXIS, np.random.rand(20))
     with TemporaryDirectory() as dir_:
-        intensities.save_mermaid(os.path.join(dir_, 'test.csv.gz'))
+        intensities.to_mermaid(os.path.join(dir_, 'test.csv.gz'))

--- a/starfish/spots/_decoder/_base.py
+++ b/starfish/spots/_decoder/_base.py
@@ -21,8 +21,8 @@ class Decoder(PipelineComponent):
         table = ctx.obj["intensities"]
         codes = ctx.obj["codebook"]
         output = ctx.obj["output"]
-        intensities = instance.run(table, codes)
-        intensities.save(output)
+        intensities: IntensityTable = instance.run(table, codes)
+        intensities.to_netcdf(output)
 
     @staticmethod
     @click.group(COMPONENT_NAME)

--- a/starfish/spots/_decoder/_base.py
+++ b/starfish/spots/_decoder/_base.py
@@ -36,7 +36,7 @@ class Decoder(PipelineComponent):
             component=Decoder,
             input=input,
             output=output,
-            intensities=IntensityTable.load(input),
+            intensities=IntensityTable.open_netcdf(input),
             codebook=codebook,
         )
 

--- a/starfish/spots/_detector/_base.py
+++ b/starfish/spots/_detector/_base.py
@@ -27,16 +27,13 @@ class SpotFinder(PipelineComponent):
         blobs_stack = ctx.obj["blobs_stack"]
         blobs_axes = ctx.obj["blobs_axes"]
 
-        intensities = instance.run(
+        intensities: IntensityTable = instance.run(
             image_stack,
             blobs_stack,
             blobs_axes,
         )
 
-        # When run() returns a tuple, we only save the intensities for now
         # TODO ambrosejcarr find a way to save arbitrary detector results
-        if isinstance(intensities, tuple):
-            intensities = intensities[0]
         intensities.to_netcdf(output)
 
     @staticmethod

--- a/starfish/spots/_detector/_base.py
+++ b/starfish/spots/_detector/_base.py
@@ -37,7 +37,7 @@ class SpotFinder(PipelineComponent):
         # TODO ambrosejcarr find a way to save arbitrary detector results
         if isinstance(intensities, tuple):
             intensities = intensities[0]
-        intensities.save(output)
+        intensities.to_netcdf(output)
 
     @staticmethod
     @click.group(COMPONENT_NAME)

--- a/starfish/spots/_detector/detect.py
+++ b/starfish/spots/_detector/detect.py
@@ -98,7 +98,7 @@ def measure_spot_intensities(
     n_round = data_image.shape[Axes.ROUND]
 
     # construct the empty intensity table
-    intensity_table = IntensityTable.empty(
+    intensity_table = IntensityTable.zeros(
         spot_attributes=spot_attributes,
         n_ch=n_ch,
         n_round=n_round,
@@ -149,7 +149,7 @@ def concatenate_spot_attributes_to_intensities(
     # this drop call ensures only x, y, z, radius, and quality, are passed to the IntensityTable
     features_coordinates = all_spots.drop(['spot_id', 'intensity'], axis=1)
 
-    intensity_table = IntensityTable.empty(
+    intensity_table = IntensityTable.zeros(
         SpotAttributes(features_coordinates), n_ch, n_round,
     )
 

--- a/starfish/spots/_detector/detect.py
+++ b/starfish/spots/_detector/detect.py
@@ -98,7 +98,7 @@ def measure_spot_intensities(
     n_round = data_image.shape[Axes.ROUND]
 
     # construct the empty intensity table
-    intensity_table = IntensityTable.empty_intensity_table(
+    intensity_table = IntensityTable.empty(
         spot_attributes=spot_attributes,
         n_ch=n_ch,
         n_round=n_round,
@@ -149,7 +149,7 @@ def concatenate_spot_attributes_to_intensities(
     # this drop call ensures only x, y, z, radius, and quality, are passed to the IntensityTable
     features_coordinates = all_spots.drop(['spot_id', 'intensity'], axis=1)
 
-    intensity_table = IntensityTable.empty_intensity_table(
+    intensity_table = IntensityTable.empty(
         SpotAttributes(features_coordinates), n_ch, n_round,
     )
 

--- a/starfish/spots/_pixel_decoder/_base.py
+++ b/starfish/spots/_pixel_decoder/_base.py
@@ -24,8 +24,11 @@ class PixelSpotDecoder(PipelineComponent):
     @classmethod
     def _cli_run(cls, ctx, instance):
         output = ctx.obj["output"]
-        image_stack = ctx.obj["image_stack"]
+        image_stack: ImageStack = ctx.obj["image_stack"]
         # TODO ambrosejcarr serialize and save ConnectedComponentDecodingResult somehow
+
+        intensities: IntensityTable
+        ccdr: ConnectedComponentDecodingResult
         intensities, ccdr = instance.run(image_stack)
         intensities.to_netcdf(output)
 

--- a/starfish/spots/_pixel_decoder/_base.py
+++ b/starfish/spots/_pixel_decoder/_base.py
@@ -27,7 +27,7 @@ class PixelSpotDecoder(PipelineComponent):
         image_stack = ctx.obj["image_stack"]
         # TODO ambrosejcarr serialize and save ConnectedComponentDecodingResult somehow
         intensities, ccdr = instance.run(image_stack)
-        intensities.save(output)
+        intensities.to_netcdf(output)
 
     @staticmethod
     @click.group(COMPONENT_NAME)

--- a/starfish/spots/_target_assignment/_base.py
+++ b/starfish/spots/_target_assignment/_base.py
@@ -42,7 +42,7 @@ class TargetAssignment(PipelineComponent):
         ctx.obj = dict(
             component=TargetAssignment,
             output=output,
-            intensity_table=IntensityTable.load(intensities),
+            intensity_table=IntensityTable.open_netcdf(intensities),
             label_image=SegmentationMaskCollection.from_disk(label_image)
         )
 

--- a/starfish/spots/_target_assignment/_base.py
+++ b/starfish/spots/_target_assignment/_base.py
@@ -27,7 +27,7 @@ class TargetAssignment(PipelineComponent):
         label_image = ctx.obj["label_image"]
         assigned = instance.run(label_image, intensity_table)
         print(f"Writing intensities, including cell ids to {output}")
-        assigned.save(os.path.join(output))
+        assigned.to_netcdf(os.path.join(output))
 
     @staticmethod
     @click.group(COMPONENT_NAME)

--- a/starfish/spots/_target_assignment/_base.py
+++ b/starfish/spots/_target_assignment/_base.py
@@ -25,7 +25,7 @@ class TargetAssignment(PipelineComponent):
         output = ctx.obj["output"]
         intensity_table = ctx.obj["intensity_table"]
         label_image = ctx.obj["label_image"]
-        assigned = instance.run(label_image, intensity_table)
+        assigned: IntensityTable = instance.run(label_image, intensity_table)
         print(f"Writing intensities, including cell ids to {output}")
         assigned.to_netcdf(os.path.join(output))
 

--- a/starfish/test/full_pipelines/api/test_dartfish.py
+++ b/starfish/test/full_pipelines/api/test_dartfish.py
@@ -147,9 +147,9 @@ def test_dartfish_pipeline_cropped_data():
     # Test serialization / deserialization of IntensityTable log
 
     fp = tempfile.NamedTemporaryFile()
-    spot_intensities.save(fp.name)
+    spot_intensities.to_netcdf(fp.name)
 
-    loaded_intensities = IntensityTable.load(fp.name)
+    loaded_intensities = IntensityTable.open_netcdf(fp.name)
     pipeline_log = loaded_intensities.get_log()
 
     assert pipeline_log[0]['method'] == 'ScaleByPercentile'

--- a/starfish/test/full_pipelines/api/test_iss_api.py
+++ b/starfish/test/full_pipelines/api/test_iss_api.py
@@ -131,8 +131,8 @@ def test_iss_pipeline_cropped_data():
 
     # Test serialization / deserialization of IntensityTable log
     fp = tempfile.NamedTemporaryFile()
-    assigned.save(fp.name)
-    loaded_intensities = IntensityTable.load(fp.name)
+    assigned.to_netcdf(fp.name)
+    loaded_intensities = IntensityTable.open_netcdf(fp.name)
     pipeline_log = loaded_intensities.get_log()
 
     assert pipeline_log[0]['method'] == 'WhiteTophat'

--- a/starfish/test/full_pipelines/cli/_base_cli_test.py
+++ b/starfish/test/full_pipelines/cli/_base_cli_test.py
@@ -29,7 +29,7 @@ class CLITest:
 
     def test_run_pipline(self):
         tempdir = exec.stages(self.stages, self.subdirs, keep_data=True)
-        intensities = IntensityTable.load(os.path.join(tempdir, "results", self.spots_file))
+        intensities = IntensityTable.open_netcdf(os.path.join(tempdir, "results", self.spots_file))
         self.verify_results(intensities)
 
         if os.getenv("TEST_KEEP_DATA") is None:


### PR DESCRIPTION
* Update docs for IntensityTable
* `IntensityTable.empty_intensity_table` --> `IntensityTable.empty`
* `IntensityTable.save` --> `IntensityTable.to_netcdf`
* `IntensityTable.load` --> `IntensityTable.open_netcdf`
* Added #TODO for @shanaxel42 to doc the overlaps code. 

Other changes relate to refactorings of the above methods. 
