### PR TITLE
cleans up TOC by changing header levels

### DIFF
--- a/docs/source/contributing/index.rst
+++ b/docs/source/contributing/index.rst
@@ -75,7 +75,7 @@ Notebook contributions
   which is an important to keep the notebooks working as starfish evolves.
 
 Debugging Errors
-================
+----------------
 
 First, thank you for using Starfish and SpaceTx-Format! Feedback you provide on features and the
 user experience is critical to making Starfish a successful tool. Because we iterate quickly on this

--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -184,7 +184,7 @@ pre-processing should be applied, please open an issue.
 
 
 Getting started with the CLI
-============================
+----------------------------
 
 The simplest way to get started with starfish for most users will be to try out the
 command-line interface (CLI). After following the :ref:`installation <installation>`
@@ -208,7 +208,7 @@ will print out the subcommands that are available.
 
 
 Data Formatting Examples
-========================
+------------------------
 
 This section provides several examples of how to format data into SpaceTx-Format from a variety of
 types of input data shapes and sizes, demonstrating the flexibility of :py:class:`TileFetcher`.
@@ -221,7 +221,7 @@ types of input data shapes and sizes, demonstrating the flexibility of :py:class
      data_formatting_examples/index.rst
 
 Data Processing examples
-========================
+------------------------
 
 This section provides several examples of how to apply starfish to data from a variety of assay
 types assuming your data is already in spaceTx format.


### PR DESCRIPTION
A few headings were getting dropped into the top-level of the TOC because they were marked up as H1 in the rst instead of H2.

This PR changes them to H2 so that the nav renders them as subnav properly.