### PR TITLE
[Easy] remove unused packages from top-level namespace. 

### DIFF
--- a/starfish/__init__.py
+++ b/starfish/__init__.py
@@ -32,3 +32,5 @@ del get_versions
 
 if __name__ == "__main__":
     starfish()
+
+del warnings, pkg_resources


### PR DESCRIPTION
Remove some easy packages that shouldn't be in the package's top-level namespace

See: https://github.com/spacetx/starfish/issues/1208 for the harder stuff that we should also attend to. 