### PR TITLE
Ajc speed up combine adjacent features

### DIFF
--- a/docs/source/_static/tutorials/exec_image_corrections.py
+++ b/docs/source/_static/tutorials/exec_image_corrections.py
@@ -47,7 +47,7 @@ gradient = xr.DataArray(
 
 # introduce the gradient, overwriting the ImageStack
 data = image_2d.xarray.values / gradient.values
-image_2d = starfish.ImageStack.from_numpy_array(data)
+image_2d = starfish.ImageStack.from_numpy(data)
 
 # display the resulting image
 plt.imshow(np.squeeze(image_2d.xarray.values))

--- a/starfish/image/_filter/test/test_api_contract.py
+++ b/starfish/image/_filter/test/test_api_contract.py
@@ -31,7 +31,7 @@ methods: Mapping[str, Type] = Filter._algorithm_to_class_map()
 
 def generate_default_data():
     data = np.random.rand(2, 2, 2, 40, 50).astype(np.float32)
-    return ImageStack.from_numpy_array(data)
+    return ImageStack.from_numpy(data)
 
 
 @pytest.mark.parametrize('filter_class', methods.values())

--- a/starfish/image/_filter/test/test_filter.py
+++ b/starfish/image/_filter/test/test_filter.py
@@ -10,7 +10,7 @@ from starfish.types import Clip, Number
 
 def random_data_image_stack_factory():
     data = np.random.uniform(0, 1, 100).reshape(1, 1, 1, 10, 10).astype(np.float32)
-    return ImageStack.from_numpy_array(data)
+    return ImageStack.from_numpy(data)
 
 
 @pytest.mark.parametrize('sigma, is_volume', [

--- a/starfish/image/_filter/test/test_histogram_matching.py
+++ b/starfish/image/_filter/test/test_histogram_matching.py
@@ -15,7 +15,7 @@ def test_match_histograms():
 
     # because of how the image was structured, every volume should be the same after
     # quantile normalization
-    stack = ImageStack.from_numpy_array(image)
+    stack = ImageStack.from_numpy(image)
     mh = MatchHistograms({Axes.CH, Axes.ROUND})
     results = mh.run(stack)
     assert len(np.unique(results.xarray.sum(("x", "y", "z")))) == 1

--- a/starfish/image/_filter/test/test_linear_unmixing.py
+++ b/starfish/image/_filter/test/test_linear_unmixing.py
@@ -16,7 +16,7 @@ def setup_linear_unmixing_test():
 
     # Create a single pixel with zero intensity
     im[0, 0, 0, 0, 0] = 0
-    stack = ImageStack.from_numpy_array(im)
+    stack = ImageStack.from_numpy(im)
 
     # Create coefficients matrix
     coeff_mat = np.array(

--- a/starfish/image/_filter/test/test_zero_by_channel_magnitude.py
+++ b/starfish/image/_filter/test/test_zero_by_channel_magnitude.py
@@ -9,7 +9,7 @@ def create_imagestack_with_magnitude_scale():
     data = np.repeat(data[None, :], 2, axis=0)
     # reshape data into a 2-channel, (1, 11, 1) image in (x, y, z)
     data = data.reshape(1, 2, 1, 11, 1)
-    imagestack = ImageStack.from_numpy_array(data)
+    imagestack = ImageStack.from_numpy(data)
     return imagestack
 
 

--- a/starfish/imagestack/imagestack.py
+++ b/starfish/imagestack/imagestack.py
@@ -296,7 +296,7 @@ class ImageStack:
         return cls.from_url(relativeurl, baseurl, aligned_group)
 
     @classmethod
-    def from_numpy_array(
+    def from_numpy(
             cls,
             array: np.ndarray,
             index_labels: Optional[Mapping[Axes, Sequence[int]]]=None,
@@ -1149,7 +1149,7 @@ class ImageStack:
         max_projection = self._data.max([dim.value for dim in dims])
         max_projection = max_projection.expand_dims(tuple(dim.value for dim in dims))
         max_projection = max_projection.transpose(*self.xarray.dims)
-        max_proj_stack = self.from_numpy_array(max_projection.values)
+        max_proj_stack = self.from_numpy(max_projection.values)
         return max_proj_stack
 
     def _squeezed_numpy(self, *dims: Axes):

--- a/starfish/imagestack/test/factories/from_codebook.py
+++ b/starfish/imagestack/test/factories/from_codebook.py
@@ -31,4 +31,4 @@ def create_imagestack_from_codebook(
 
     # blur with a small non-isotropic kernel TODO make kernel smaller.
     imagestack_data = gaussian_filter(imagestack_data, sigma=(0, 0, 0.7, 1.5, 1.5))
-    return ImageStack.from_numpy_array(imagestack_data)
+    return ImageStack.from_numpy(imagestack_data)

--- a/starfish/imagestack/test/test_apply.py
+++ b/starfish/imagestack/test/test_apply.py
@@ -65,7 +65,7 @@ def test_apply_clipping_methods():
     # set one value to max
     data[1, 1, 1, 1, 1] = 1
 
-    imagestack = ImageStack.from_numpy_array(data)
+    imagestack = ImageStack.from_numpy(data)
 
     # max value after multiplication == 2, all other values == 1
     def apply_function(x):

--- a/starfish/imagestack/test/test_from_numpy_array.py
+++ b/starfish/imagestack/test/test_from_numpy_array.py
@@ -7,17 +7,17 @@ from starfish.imagestack.imagestack import ImageStack
 def test_from_numpy_array_raises_error_when_incorrect_dims_passed():
     array = np.ones((2, 2), dtype=np.float32)
     # verify this method works with the correct shape
-    image = ImageStack.from_numpy_array(array.reshape((1, 1, 1, 2, 2)))
+    image = ImageStack.from_numpy(array.reshape((1, 1, 1, 2, 2)))
     assert isinstance(image, ImageStack)
 
     with pytest.raises(ValueError):
-        ImageStack.from_numpy_array(array.reshape((1, 1, 2, 2)))
-        ImageStack.from_numpy_array(array.reshape((1, 2, 2)))
-        ImageStack.from_numpy_array(array)
-        ImageStack.from_numpy_array(array.reshape((1, 1, 1, 1, 2, 2)))
+        ImageStack.from_numpy(array.reshape((1, 1, 2, 2)))
+        ImageStack.from_numpy(array.reshape((1, 2, 2)))
+        ImageStack.from_numpy(array)
+        ImageStack.from_numpy(array.reshape((1, 1, 1, 1, 2, 2)))
 
 
 def test_from_numpy_array_automatically_handles_float_conversions():
     x = np.zeros((1, 1, 1, 20, 20), dtype=np.uint16)
-    stack = ImageStack.from_numpy_array(x)
+    stack = ImageStack.from_numpy(x)
     assert stack.xarray.dtype == np.float32

--- a/starfish/imagestack/test/test_max_proj.py
+++ b/starfish/imagestack/test/test_max_proj.py
@@ -7,7 +7,7 @@ from starfish.types import Axes
 def test_max_projection_preserves_dtype():
     original_dtype = np.float32
     array = np.ones((2, 2, 2), dtype=original_dtype)
-    image = ImageStack.from_numpy_array(array.reshape((1, 1, 2, 2, 2)))
+    image = ImageStack.from_numpy(array.reshape((1, 1, 2, 2, 2)))
 
     max_projection = image.max_proj(Axes.CH, Axes.ROUND, Axes.ZPLANE)
     assert max_projection.xarray.dtype == original_dtype

--- a/starfish/intensity_table/intensity_table_coordinates.py
+++ b/starfish/intensity_table/intensity_table_coordinates.py
@@ -1,4 +1,3 @@
-import numpy as np
 import xarray as xr
 
 from starfish.imagestack.imagestack import ImageStack
@@ -6,9 +5,9 @@ from starfish.intensity_table.intensity_table import IntensityTable
 from starfish.types import Axes, Coordinates, Features
 
 
-def transfer_physical_coords_from_imagestack_to_intensity_table(image_stack: ImageStack,
-                                                                intensity_table: IntensityTable
-                                                                ) -> IntensityTable:
+def transfer_physical_coords_from_imagestack_to_intensity_table(
+        image_stack: ImageStack, intensity_table: IntensityTable
+) -> IntensityTable:
     """
     Transfers physical coordinates from an Imagestack's coordinates xarray to an intensity table
 
@@ -20,30 +19,19 @@ def transfer_physical_coords_from_imagestack_to_intensity_table(image_stack: Ima
     """
     # TODO shanaxel42 consider refactoring pixel case where were can just reshape from Imagestack
     # Add three new coords to xarray (xc, yc, zc)
-    num_features = intensity_table.sizes[Features.AXIS]
-    intensity_table[Coordinates.X.value] = xr.DataArray(np.zeros(num_features, np.float32),
-                                                        dims='features')
-    intensity_table[Coordinates.Y.value] = xr.DataArray(np.zeros(num_features, np.float32),
-                                                        dims='features')
-    intensity_table[Coordinates.Z.value] = xr.DataArray(np.zeros(num_features, np.float32),
-                                                        dims='features')
-    for ind, spot in intensity_table.groupby(Features.AXIS):
-        # Iterate through r, ch per spot
-        for ch, _round in np.ndindex(spot.data.shape):
-            # if non zero value set coords
-            if spot[ch][_round].data == 0:
-                continue
-            # get pixel coords of this tile
-            pixel_x = spot.coords[Axes.X].data
-            pixel_y = spot.coords[Axes.Y].data
-            pixel_z = spot.coords[Axes.ZPLANE].data
-            # Grab physical coordinates from imagestack.coords
-            physical_x = image_stack.xarray[Coordinates.X.value][pixel_x]
-            physical_y = image_stack.xarray[Coordinates.Y.value][pixel_y]
-            physical_z = image_stack.xarray[Coordinates.Z.value][pixel_z]
-            # Assign to coordinates arrays
-            intensity_table[Coordinates.X.value][ind] = physical_x
-            intensity_table[Coordinates.Y.value][ind] = physical_y
-            intensity_table[Coordinates.Z.value][ind] = physical_z
-            break
+    if intensity_table.sizes[Features.AXIS] == 0:
+        return intensity_table
+
+    pairs = (
+        (Axes.X.value, Coordinates.X.value),
+        (Axes.Y.value, Coordinates.Y.value),
+        (Axes.ZPLANE.value, Coordinates.Z.value)
+    )
+    for px, coord in pairs:
+        pixels = image_stack.xarray[px].values
+        feature_inds = intensity_table[px].values.astype(int)
+        pixel_inds = pixels[feature_inds]
+        coordinates = image_stack.xarray[coord][pixel_inds]
+        intensity_table[coord] = xr.DataArray(coordinates.values, dims='features')
+
     return intensity_table

--- a/starfish/intensity_table/intensity_table_coordinates.py
+++ b/starfish/intensity_table/intensity_table_coordinates.py
@@ -1,3 +1,4 @@
+import numpy as np
 import xarray as xr
 
 from starfish.imagestack.imagestack import ImageStack
@@ -27,11 +28,13 @@ def transfer_physical_coords_from_imagestack_to_intensity_table(
         (Axes.Y.value, Coordinates.Y.value),
         (Axes.ZPLANE.value, Coordinates.Z.value)
     )
-    for px, coord in pairs:
-        pixels = image_stack.xarray[px].values
-        feature_inds = intensity_table[px].values.astype(int)
-        pixel_inds = pixels[feature_inds]
-        coordinates = image_stack.xarray[coord][pixel_inds]
+    for axis, coord in pairs:
+
+        imagestack_pixels: np.ndarray = image_stack.xarray[axis].values
+        intensity_table_pixels: np.ndarray = intensity_table[axis].values.astype(int)
+        pixel_inds: np.ndarray = imagestack_pixels[intensity_table_pixels]
+        coordinates: xr.DataArray = image_stack.xarray[coord][pixel_inds]
+
         intensity_table[coord] = xr.DataArray(coordinates.values, dims='features')
 
     return intensity_table

--- a/starfish/intensity_table/test/test_concatenate.py
+++ b/starfish/intensity_table/test/test_concatenate.py
@@ -9,7 +9,7 @@ def test_intensity_table_concatenation():
 
     r, c, z, y, x = 3, 3, 2, 2, 5
     data = np.zeros(180, dtype=np.float32).reshape(r, c, z, y, x)
-    image_stack = ImageStack.from_numpy_array(data)
+    image_stack = ImageStack.from_numpy(data)
     intensities = IntensityTable.from_image_stack(image_stack)
 
     intensities2 = intensities.copy()

--- a/starfish/intensity_table/test/test_from_imagestack.py
+++ b/starfish/intensity_table/test/test_from_imagestack.py
@@ -38,7 +38,7 @@ def test_intensity_table_can_be_constructed_from_an_imagestack():
     """
     r, c, z, y, x = 1, 5, 2, 2, 5
     data = np.zeros(100, dtype=np.float32).reshape(r, c, z, y, x)
-    image_stack = ImageStack.from_numpy_array(data)
+    image_stack = ImageStack.from_numpy(data)
     intensities = IntensityTable.from_image_stack(image_stack)
 
     # there should be 100 features

--- a/starfish/intensity_table/test/test_intensity_table_serialization.py
+++ b/starfish/intensity_table/test/test_intensity_table_serialization.py
@@ -18,7 +18,7 @@ def test_intensity_table_serialization():
 
     # create an IntensityTable
     data = np.zeros(100, dtype=np.float32).reshape(1, 5, 2, 2, 5)
-    image_stack = ImageStack.from_numpy_array(data)
+    image_stack = ImageStack.from_numpy(data)
     intensities = IntensityTable.from_image_stack(image_stack)
 
     # dump it to disk

--- a/starfish/intensity_table/test/test_stack_intensity_table_reshaping.py
+++ b/starfish/intensity_table/test/test_stack_intensity_table_reshaping.py
@@ -13,7 +13,7 @@ def test_reshaping_between_stack_and_intensities():
     the created Imagestack is the same as the original
     """
     np.random.seed(777)
-    image = ImageStack.from_numpy_array(np.random.rand(1, 2, 3, 4, 5).astype(np.float32))
+    image = ImageStack.from_numpy(np.random.rand(1, 2, 3, 4, 5).astype(np.float32))
     pixel_intensities = IntensityTable.from_image_stack(image, 0, 0, 0)
     image_shape = (image.shape['z'], image.shape['y'], image.shape['x'])
     image_from_pixels = pixel_intensities_to_imagestack(pixel_intensities, image_shape)
@@ -45,4 +45,4 @@ def pixel_intensities_to_imagestack(
         intensities.sizes[Axes.CH],
         intensities.sizes[Axes.ROUND]])
     data = data.transpose(4, 3, 0, 1, 2)
-    return ImageStack.from_numpy_array(data)
+    return ImageStack.from_numpy(data)

--- a/starfish/intensity_table/test/test_to_mermaid.py
+++ b/starfish/intensity_table/test/test_to_mermaid.py
@@ -18,7 +18,7 @@ def test_to_mermaid_dataframe():
     """
     r, c, z, y, x = 1, 5, 2, 2, 5
     data = np.zeros(100, dtype=np.float32).reshape(r, c, z, y, x)
-    image_stack = ImageStack.from_numpy_array(data)
+    image_stack = ImageStack.from_numpy(data)
     intensities = IntensityTable.from_image_stack(image_stack)
 
     # without a target assignment, should raise RuntimeError.

--- a/starfish/multiprocessing/test/test_multiprocessing.py
+++ b/starfish/multiprocessing/test/test_multiprocessing.py
@@ -126,7 +126,7 @@ def test_imagestack_deepcopy(nitems: int=10) -> None:
     shape = (nitems, 3, 4, 5, 6)
     dtype = np.float32
     source = np.zeros(shape, dtype=np.float32)
-    imagestack = ImageStack.from_numpy_array(source)
+    imagestack = ImageStack.from_numpy(source)
     imagestack_copy = copy.deepcopy(imagestack)
     _start_process_to_test_shmem(
         array_holder=imagestack_copy._data._backing_mp_array,
@@ -151,7 +151,7 @@ def test_imagestack_xarray_deepcopy(nitems: int=10) -> None:
     shape = (nitems, 3, 4, 5, 6)
     dtype = np.float32
     source = np.zeros(shape, dtype=dtype)
-    imagestack = ImageStack.from_numpy_array(source)
+    imagestack = ImageStack.from_numpy(source)
     with warnings.catch_warnings(record=True) as warnings_:
         copy.deepcopy(imagestack.xarray)
         assert len(warnings_) == 1  # type: ignore

--- a/starfish/spots/_detector/test/test_local_search_blob_detector.py
+++ b/starfish/spots/_detector/test/test_local_search_blob_detector.py
@@ -18,7 +18,7 @@ def traversing_code() -> ImageStack:
     # blur points
     gaussian_filter(img, (0, 0, 0.5, 1.5, 1.5), output=img)
 
-    return ImageStack.from_numpy_array(img)
+    return ImageStack.from_numpy(img)
 
 
 def multiple_possible_neighbors() -> ImageStack:
@@ -41,7 +41,7 @@ def multiple_possible_neighbors() -> ImageStack:
     # blur points
     gaussian_filter(img, (0, 0, 0.5, 1.5, 1.5), output=img)
 
-    return ImageStack.from_numpy_array(img)
+    return ImageStack.from_numpy(img)
 
 
 def jitter_code() -> ImageStack:
@@ -56,7 +56,7 @@ def jitter_code() -> ImageStack:
     # blur points
     gaussian_filter(img, (0, 0, 0.5, 1.5, 1.5), output=img)
 
-    return ImageStack.from_numpy_array(img)
+    return ImageStack.from_numpy(img)
 
 
 def two_perfect_codes() -> ImageStack:
@@ -76,7 +76,7 @@ def two_perfect_codes() -> ImageStack:
     # blur points
     gaussian_filter(img, (0, 0, 0.5, 1.5, 1.5), output=img)
 
-    return ImageStack.from_numpy_array(img)
+    return ImageStack.from_numpy(img)
 
 
 def local_search_blob_detector(search_radius: int, anchor_channel=0) -> LocalSearchBlobDetector:

--- a/starfish/spots/_detector/test/test_spot_detection.py
+++ b/starfish/spots/_detector/test/test_spot_detection.py
@@ -20,7 +20,7 @@ _, SPARSE_IMAGESTACK, SPARSE_MAX_INTENSITY = two_spot_sparse_coded_data_factory(
 _, BLANK_IMAGESTACK, BLANK_MAX_INTENSITY = two_spot_informative_blank_coded_data_factory()
 
 # make sure that all spot finders handle empty arrays
-EMPTY_IMAGESTACK = ImageStack.from_numpy_array(np.zeros((4, 2, 10, 100, 100), dtype=np.float32))
+EMPTY_IMAGESTACK = ImageStack.from_numpy(np.zeros((4, 2, 10, 100, 100), dtype=np.float32))
 
 
 def simple_gaussian_spot_detector() -> BlobDetector:

--- a/starfish/spots/_pixel_decoder/test/test_calculate_mean_pixel_traces.py
+++ b/starfish/spots/_pixel_decoder/test/test_calculate_mean_pixel_traces.py
@@ -25,7 +25,7 @@ def labeled_intensities_factory() -> Tuple[IntensityTable, np.ndarray, np.ndarra
           [[.2, .3], [.5, .5]]]],
         dtype=np.float32
     )
-    image_stack = ImageStack.from_numpy_array(data.reshape(1, 2, 2, 2, 2))
+    image_stack = ImageStack.from_numpy(data.reshape(1, 2, 2, 2, 2))
     intensity_table = IntensityTable.from_image_stack(image_stack)
     intensity_table[Features.DISTANCE] = (Features.AXIS, np.zeros(intensity_table.shape[0]))
     label_image = np.array(

--- a/starfish/spots/_pixel_decoder/test/test_intensities_to_decoded_image.py
+++ b/starfish/spots/_pixel_decoder/test/test_intensities_to_decoded_image.py
@@ -32,7 +32,7 @@ def decoded_intensity_table_factory() -> Tuple[IntensityTable, np.ndarray]:
     labels_with_nan[labels == '0'] = 'nan'
 
     # create an intensity table and add the labels
-    image_stack = ImageStack.from_numpy_array(data)
+    image_stack = ImageStack.from_numpy(data)
     intensities = IntensityTable.from_image_stack(image_stack)
     intensities[Features.TARGET] = (Features.AXIS, np.ravel(labels_with_nan))
 

--- a/starfish/spots/_target_assignment/label.py
+++ b/starfish/spots/_target_assignment/label.py
@@ -1,6 +1,8 @@
+import numpy as np
+
 from starfish.intensity_table.intensity_table import IntensityTable
 from starfish.segmentation_mask import SegmentationMaskCollection
-from starfish.types import Axes, Features
+from starfish.types import Features
 from starfish.util import click
 from ._base import TargetAssignmentAlgorithm
 
@@ -22,31 +24,27 @@ class Label(TargetAssignmentAlgorithm):
         intensities: IntensityTable,
         in_place: bool,
     ) -> IntensityTable:
-        cell_ids = []
 
-        # for each spot, test whether the spot falls inside the area of each mask
-        for spot in intensities:
-            for mask in masks:
-                sel = {Axes.X.value: spot[Axes.X.value],
-                       Axes.Y.value: spot[Axes.Y.value]}
-                if mask.ndim == 3:
-                    sel[Axes.ZPLANE.value] = spot[Axes.ZPLANE.value]
+        intensities[Features.CELL_ID] = (
+            Features.AXIS,
+            np.full(intensities.sizes[Features.AXIS], fill_value='nan', dtype='<U8')
+        )
 
-                try:
-                    if mask.sel(sel):
-                        cell_id = mask.name
-                        break
-                except KeyError:
-                    pass
-            else:
-                cell_id = ''
+        for mask in masks:
+            y_min, y_max = float(mask.y.min()), float(mask.y.max())
+            x_min, x_max = float(mask.x.min()), float(mask.x.max())
 
-            cell_ids.append(cell_id)
+            in_bbox = intensities.where(
+                (intensities.y >= y_min)
+                & (intensities.y <= y_max)
+                & (intensities.x >= x_min)
+                & (intensities.x <= x_max),
+                drop=True
+            )
 
-        if not in_place:
-            intensities = intensities.copy()
-
-        intensities[Features.CELL_ID] = (Features.AXIS, cell_ids)
+            in_mask = mask.sel_points(y=in_bbox.y, x=in_bbox.x)
+            spot_ids = in_bbox[Features.SPOT_ID][in_mask.values]
+            intensities[Features.CELL_ID].loc[spot_ids] = mask.name
 
         return intensities
 

--- a/starfish/test/factories.py
+++ b/starfish/test/factories.py
@@ -244,7 +244,7 @@ class SyntheticData:
             warnings.simplefilter('ignore', UserWarning)
             image = img_as_float32(image)
 
-        return ImageStack.from_numpy_array(image)
+        return ImageStack.from_numpy(image)
 
 
 def two_spot_one_hot_coded_data_factory() -> Tuple[Codebook, ImageStack, float]:


### PR DESCRIPTION
* replace xarray groupby with pandas groupby in `combine_adjacent_features`, resulting in > 1000x speed up of the method and a 5x speed up in the pixel spot decoder. 

Sorry for the unclean diff, my PR's aren't stacked and I merged a few.  `starfish/spots/_pixel_decoder/combine_adjacent_features.py` contains the only changes not covered by other PRs. 

Before: 
![image](https://user-images.githubusercontent.com/5239152/56376647-6c564700-61d6-11e9-8ac6-16232296063e.png)

After: 
![image](https://user-images.githubusercontent.com/5239152/56376688-8728bb80-61d6-11e9-86a4-cf7c5c51fcaa.png)



* Note that `create_spot_attributes` may also be possible to speed up, further increasing the speed of this function. 

cc @shanaxel42 @kne42 for awareness, xarray devs really aren't kidding when they say:

> Note that for one-dimensional data, it is usually faster to rely on pandas’ implementation of the same pipeline.

ref: http://xarray.pydata.org/en/stable/groupby.html