### PR TITLE
Clone a repo, not checkout.

### DIFF
--- a/docs/source/getting_started/installation/index.rst
+++ b/docs/source/getting_started/installation/index.rst
@@ -46,7 +46,7 @@ installed.  Check out the code for starfish and set up a virtualenv_.
 
 .. code-block:: bash
 
-    % git checkout git@github.com:spacetx/starfish.git
+    % git clone git://github.com/spacetx/starfish.git
     % cd starfish
     % python -m venv .venv
     % source .venv/bin/activate


### PR DESCRIPTION
When starting up a dev environment, we should clone the github repo, not check it out.

Furthermore, we should clone from git:// rather than ssh://

Test plan: visual.
