### PR TITLE
Fix data processing examples.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,9 @@ help-requirements:
 include notebooks/subdir.mk
 include docs/source/_static/data_processing_examples/subdir.mk
 
-slow: fast run-notebooks run-examples docker
+test-examples: export TESTING=1
+test-examples: run-examples
+slow: fast run-notebooks test-examples docker
 
 docker:
 	docker build -f docker/Dockerfile -t $(DOCKER_IMAGE) .

--- a/docs/source/_static/data_processing_examples/iss_cli.sh
+++ b/docs/source/_static/data_processing_examples/iss_cli.sh
@@ -8,13 +8,13 @@ URL=https://d2nhj9g34unfro.cloudfront.net/20181005/ISS-TEST/experiment.json
 
 starfish validate experiment $URL
 
-starfish filter \
+starfish Filter \
     -i @${URL}'[fov_001][primary]' \
     -o /tmp/starfish/max_projected/primary_images.json \
-    MaxProj \
+    MaxProject \
     --dims c --dims z
 
-starfish learn_transform \
+starfish LearnTransform \
     -i /tmp/starfish/max_projected/primary_images.json \
     -o /tmp/starfish/transforms/transforms.json \
     Translation \
@@ -22,41 +22,42 @@ starfish learn_transform \
     --upsampling 1000 \
     --axes r
 
-starfish apply_transform \
+starfish ApplyTransform \
     -i @$URL'[fov_001][primary]' \
     -o /tmp/starfish/registered/primary_images.json \
     --transformation-list /tmp/starfish/transforms/transforms.json \
     Warp
 
-starfish filter \
+starfish Filter \
     -i /tmp/starfish/registered/primary_images.json \
     -o /tmp/starfish/filtered/primary_images.json \
     WhiteTophat \
     --masking-radius 15
 
-starfish filter \
+starfish Filter \
     -i @$URL'[fov_001][nuclei]'  \
     -o /tmp/starfish/filtered/nuclei.json \
     WhiteTophat \
     --masking-radius 15
 
-starfish filter \
+starfish Filter \
     -i @$URL'[fov_001][dots]'  \
     -o /tmp/starfish/filtered/dots.json \
     WhiteTophat \
     --masking-radius 15
 
-starfish detect_spots \
+starfish DetectSpots \
     --input /tmp/starfish/filtered/primary_images.json \
     --output /tmp/starfish/results/spots.nc \
     --blobs-stack /tmp/starfish/filtered/dots.json \
+    --blobs-axis r --blobs-axis c \
     BlobDetector \
     --min-sigma 4 \
     --max-sigma 6 \
     --num-sigma 20 \
     --threshold 0.01
 
-starfish segment \
+starfish Segment \
     --primary-images /tmp/starfish/filtered/primary_images.json \
     --nuclei /tmp/starfish/filtered/nuclei.json \
     -o /tmp/starfish/results/label_image.png \
@@ -65,15 +66,14 @@ starfish segment \
     --input-threshold .22 \
     --min-distance 57
 
-starfish target_assignment \
+starfish AssignTargets \
     --label-image /tmp/starfish/results/label_image.png \
     --intensities /tmp/starfish/results/spots.nc \
     --output /tmp/starfish/results/targeted-spots.nc \
     Label
 
-starfish decode \
+starfish Decode \
     -i /tmp/starfish/results/targeted-spots.nc \
     --codebook @$URL \
     -o /tmp/starfish/results/decoded-spots.nc \
-    PerRoundMaxChannelDecoder
-
+    PerRoundMaxChannel


### PR DESCRIPTION
1. Add a `test-examples` rule that sets TESTING=1, and runs the examples.  Rationale: the data processing examples might rationally be run with multiple FOVs.  In our testing environment, we likely will only want to run a single FOV.  Happy to change the logic for this if this rationale does not hold.
2. Update `docs/source/_static/data_processing_examples/iss_cli.sh` to match `starfish/test/full_pipelines/cli/test_iss.py`

Test plan: `make -j test-examples`

NOT IN THIS PR: any integration into travis