### PR TITLE
Add pip to docker environment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,7 @@ RUN useradd -m starfish
 USER starfish
 
 # Set up the initial conda environment
-COPY --chown=starfish:starfish docker/environment.yml /src/environment.yml
+COPY --chown=starfish:starfish docker/environment.yml /src/docker/environment.yml
 COPY --chown=starfish:starfish docker/pip-config /src/
 COPY --chown=starfish:starfish REQUIREMENTS* /src/
 WORKDIR /src

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -5,8 +5,9 @@ channels:
 - conda-forge
 dependencies:
 - python>=3.6
+- pip
 - matplotlib==2.1.2
 - numpy==1.16.1
 - pip:
-  - -r REQUIREMENTS-STRICT.txt
+  - -r ../REQUIREMENTS-STRICT.txt
   - jsonpath-rw


### PR DESCRIPTION
After upgrading conda, the following showed up:

```
$ conda env create -n sf01 -f docker/environment.yml
Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.
```