### PR TITLE
Isolate test environment.

### DIFF
--- a/starfish/core/config/test/test_config.py
+++ b/starfish/core/config/test/test_config.py
@@ -200,10 +200,12 @@ def test_starfish_warn(tmpdir, monkeypatch):
             assert len(warnings_) == 1  # type: ignore
 
 
-def test_starfish_environ():
-    assert not StarfishConfig().strict
-    with environ(VALIDATION_STRICT="true"):
-        assert StarfishConfig().strict
+def test_starfish_environ(monkeypatch):
+    with monkeypatch.context() as mc:
+        mc.setenv("STARFISH_CONFIG", "{}")
+        assert not StarfishConfig().strict
+        with environ(VALIDATION_STRICT="true"):
+            assert StarfishConfig().strict
 
 
 def test_starfish_environ_warn(tmpdir, monkeypatch):


### PR DESCRIPTION
StarfishConfig() will read from ~/.starfish/config unless we set STARFISH_CONFIG in the environment.

Test plan: `test_starfish_environ` no longer throws a warning.