### PR TITLE
Fix config value == False

### DIFF
--- a/starfish/core/config/test/test_config.py
+++ b/starfish/core/config/test/test_config.py
@@ -37,6 +37,17 @@ def test_simple_config_value_map():
     assert config.data["a"] == 1
 
 
+def test_simple_config_false():
+    # config says the value is False.  Do we return False?
+    config = Config("{\"a\": false}")
+    assert config.lookup(("a",), None) is False
+
+    # config says the value is not known.  Do we return the default valueS?
+    config = Config("{}")
+    assert config.lookup(("a",), None) is None
+    assert config.lookup(("a",), False) is False
+
+
 def test_simple_config_value_file(tmpdir):
     f = tmpdir.join("config.json")
     f.write(simple_str)

--- a/starfish/core/util/config.py
+++ b/starfish/core/util/config.py
@@ -85,7 +85,7 @@ class Config(object):
                 data = None  # Clear value
                 if value is Config.__NO_VALUE_PASSED:
                     raise
-        if data:
+        if data is not None:
             # If we've reached here without exception,
             # then we've found the value.
             if remove:


### PR DESCRIPTION
If the config value in the config file is false, we currently just return the default value.  The reason is that the test checks for falsey rather than not None, and we fall through.

Test plan: wrote a test that hits this case, and fixed it with the code patch.