### PR TITLE
Add missing files for starfish initialization

### DIFF
--- a/starfish/__init__.py
+++ b/starfish/__init__.py
@@ -20,7 +20,3 @@ from .core.imagestack.imagestack import ImageStack
 from .core.intensity_table.intensity_table import IntensityTable
 from .core.recipe import cli
 from .core.starfish import starfish
-
-
-if __name__ == "__main__":
-    starfish()

--- a/starfish/__main__.py
+++ b/starfish/__main__.py
@@ -1,0 +1,3 @@
+from .core.starfish import starfish
+
+starfish()


### PR DESCRIPTION
`starfish/__main__.py` is so that we can do `python -m starfish`, which is what pycharm does.
`starfish/test/__init__.py` is so that setuptools includes the pipeline tests in the zip file.