### PR TITLE
Enable zero-spot decoding

### DIFF
--- a/starfish/core/codebook/codebook.py
+++ b/starfish/core/codebook/codebook.py
@@ -552,6 +552,13 @@ class Codebook(xr.DataArray):
 
         self._validate_decode_intensity_input_matches_codebook_shape(intensities)
 
+        # add empty metadata fields and return
+        if intensities.sizes[Features.AXIS] == 0:
+            intensities[Features.TARGET] = (Features.AXIS, np.empty(0, dtype='U'))
+            intensities[Features.DISTANCE] = (Features.AXIS, np.empty(0, dtype=float))
+            intensities[Features.PASSES_THRESHOLDS] = (Features.AXIS, np.empty(0, dtype=bool))
+            return intensities
+
         # normalize both the intensities and the codebook
         norm_intensities, norms = self._normalize_features(intensities, norm_order=norm_order)
         norm_codes, _ = self._normalize_features(self, norm_order=norm_order)

--- a/starfish/core/codebook/codebook.py
+++ b/starfish/core/codebook/codebook.py
@@ -634,6 +634,13 @@ class Codebook(xr.DataArray):
 
         self._validate_decode_intensity_input_matches_codebook_shape(intensities)
 
+        # add empty metadata fields and return
+        if intensities.sizes[Features.AXIS] == 0:
+            intensities[Features.TARGET] = (Features.AXIS, np.empty(0, dtype='U'))
+            intensities[Features.DISTANCE] = (Features.AXIS, np.empty(0, dtype=float))
+            intensities[Features.PASSES_THRESHOLDS] = (Features.AXIS, np.empty(0, dtype=bool))
+            return intensities
+
         max_channels = intensities.argmax(Axes.CH.value)
         codes = self.argmax(Axes.CH.value)
 

--- a/starfish/core/intensity_table/intensity_table_coordinates.py
+++ b/starfish/core/intensity_table/intensity_table_coordinates.py
@@ -19,15 +19,19 @@ def transfer_physical_coords_from_imagestack_to_intensity_table(
         - Assign those values to the coords arrays for this spot
     """
     # TODO shanaxel42 consider refactoring pixel case where were can just reshape from Imagestack
-    # Add three new coords to xarray (xc, yc, zc)
-    if intensity_table.sizes[Features.AXIS] == 0:
-        return intensity_table
 
     pairs = (
         (Axes.X.value, Coordinates.X.value),
         (Axes.Y.value, Coordinates.Y.value),
         (Axes.ZPLANE.value, Coordinates.Z.value)
     )
+
+    # make sure the intensity table gets empty metadata if there are no intensities
+    if intensity_table.sizes[Features.AXIS] == 0:
+        for axis, coord in pairs:
+            intensity_table[coord] = xr.DataArray(np.zeros((0)), dims='features')
+        return intensity_table
+
     for axis, coord in pairs:
 
         imagestack_pixels: np.ndarray = image_stack.xarray[axis].values

--- a/starfish/core/intensity_table/intensity_table_coordinates.py
+++ b/starfish/core/intensity_table/intensity_table_coordinates.py
@@ -29,7 +29,7 @@ def transfer_physical_coords_from_imagestack_to_intensity_table(
     # make sure the intensity table gets empty metadata if there are no intensities
     if intensity_table.sizes[Features.AXIS] == 0:
         for axis, coord in pairs:
-            intensity_table[coord] = xr.DataArray(np.zeros((0)), dims='features')
+            intensity_table[coord] = xr.DataArray(np.zeros((0)), dims=Features.AXIS)
         return intensity_table
 
     for axis, coord in pairs:

--- a/starfish/core/spots/_decode/test/test_decoding_without_spots.py
+++ b/starfish/core/spots/_decode/test/test_decoding_without_spots.py
@@ -27,3 +27,27 @@ def test_per_round_max_spot_decoding_without_spots():
         table1 = pd.read_csv(filename, index_col=0)
         table2 = pd.read_csv(filename, index_col=0)
         pd.concat([table1, table2], axis=0)
+
+def test_metric_decoding_without_spots():
+
+    codebook, image_stack, max_intensity = two_spot_sparse_coded_data_factory()
+
+    bd = starfish.spots.DetectSpots.BlobDetector(
+        min_sigma=1, max_sigma=1, num_sigma=1, threshold=max_intensity + 0.1)
+    no_spots = bd.run(image_stack)
+
+    decode = starfish.spots.Decode.MetricDistance(
+        codebook, max_distance=0, min_intensity=max_intensity + 0.1
+    )
+    decoded_no_spots: starfish.IntensityTable = decode.run(no_spots)
+
+    decoded_spot_table = decoded_no_spots.to_decoded_spots()
+
+    with TemporaryDirectory() as dir_:
+        filename = os.path.join(dir_, 'test.csv')
+        decoded_spot_table.save_csv(os.path.join(dir_, 'test.csv'))
+
+        # verify we can concatenate two empty tables
+        table1 = pd.read_csv(filename, index_col=0)
+        table2 = pd.read_csv(filename, index_col=0)
+        pd.concat([table1, table2], axis=0)

--- a/starfish/core/spots/_decode/test/test_decoding_without_spots.py
+++ b/starfish/core/spots/_decode/test/test_decoding_without_spots.py
@@ -1,6 +1,7 @@
 import os
-import pandas as pd
 from tempfile import TemporaryDirectory
+
+import pandas as pd
 
 import starfish
 from starfish.core.test.factories import two_spot_sparse_coded_data_factory

--- a/starfish/core/spots/_decode/test/test_decoding_without_spots.py
+++ b/starfish/core/spots/_decode/test/test_decoding_without_spots.py
@@ -1,0 +1,29 @@
+import os
+import pandas as pd
+from tempfile import TemporaryDirectory
+
+import starfish
+from starfish.core.test.factories import two_spot_sparse_coded_data_factory
+
+
+def test_per_round_max_spot_decoding_without_spots():
+
+    codebook, image_stack, max_intensity = two_spot_sparse_coded_data_factory()
+
+    bd = starfish.spots.DetectSpots.BlobDetector(
+        min_sigma=1, max_sigma=1, num_sigma=1, threshold=max_intensity + 0.1)
+    no_spots = bd.run(image_stack)
+
+    decode = starfish.spots.Decode.PerRoundMaxChannel(codebook)
+    decoded_no_spots: starfish.IntensityTable = decode.run(no_spots)
+
+    decoded_spot_table = decoded_no_spots.to_decoded_spots()
+
+    with TemporaryDirectory() as dir_:
+        filename = os.path.join(dir_, 'test.csv')
+        decoded_spot_table.save_csv(os.path.join(dir_, 'test.csv'))
+
+        # verify we can concatenate two empty tables
+        table1 = pd.read_csv(filename, index_col=0)
+        table2 = pd.read_csv(filename, index_col=0)
+        pd.concat([table1, table2], axis=0)


### PR DESCRIPTION
* add missing metadata to empty tables when zero spots are detected
* add missing metadata to empty tables when zero spot tables are passed to a decoder
* verify that empty intensity tables can be converted to decoded_spots
* verify those tables can be loaded and dumped to disk
* write down tests

Fixes #1271 