### PR TITLE
Conda pip

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,7 +46,7 @@ COPY --chown=starfish:starfish docker/pip-config /src/
 COPY --chown=starfish:starfish REQUIREMENTS* /src/
 WORKDIR /src
 ENV PIP_CONFIG_FILE=/src/pip-config
-RUN conda env create -f environment.yml \
+RUN conda env create -f docker/environment.yml \
     && conda clean -tipsy
 
 # Prepare for build

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,7 @@ RUN useradd -m starfish
 USER starfish
 
 # Set up the initial conda environment
-COPY --chown=starfish:starfish docker/environment.yml /src/environment.yml
+COPY --chown=starfish:starfish docker/environment.yml /src/docker/environment.yml
 COPY --chown=starfish:starfish docker/pip-config /src/
 COPY --chown=starfish:starfish REQUIREMENTS* /src/
 WORKDIR /src

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -5,8 +5,9 @@ channels:
 - conda-forge
 dependencies:
 - python>=3.6
+- pip
 - matplotlib==2.1.2
 - numpy==1.16.1
 - pip:
-  - -r REQUIREMENTS-STRICT.txt
+  - -r ../REQUIREMENTS-STRICT.txt
   - jsonpath-rw


### PR DESCRIPTION
Take 2 of gh-1256 with a fix for `make docker`. (I was bit by the fact that it's not run on regular PRs). The motivation for this is to keep docker/environment.yml generally useful as a way to setup a local conda environment. For development, `pip install -r REQUIREMENTS-CI.txt` is needed:

Test plan:
```
conda env create -n sf -f docker/environment.yml
source activate sf
pip install -r REQUIREMENTS-CI.txt
```