### PR TITLE
RFC: Base calling filter for in situ sequencing

### DIFF
--- a/starfish/core/image/_filter/call_bases.py
+++ b/starfish/core/image/_filter/call_bases.py
@@ -1,11 +1,10 @@
 from functools import partial
-from typing import Optional, Union
+from typing import Optional
 
 import numpy as np
 import xarray as xr
 
 from starfish.core.imagestack.imagestack import ImageStack
-from starfish.core.types import Clip
 from starfish.core.util import click
 from starfish.types import Axes
 from ._base import FilterAlgorithmBase

--- a/starfish/core/image/_filter/call_bases.py
+++ b/starfish/core/image/_filter/call_bases.py
@@ -1,0 +1,118 @@
+from functools import partial
+from typing import Callable, Optional, Union
+
+import numpy as np
+import xarray as xr
+
+from ._base import FilterAlgorithmBase
+from starfish.core.imagestack.imagestack import ImageStack
+from starfish.core.types import Clip
+from starfish.core.util import click
+from starfish.types import Axes
+
+
+class CallBases(FilterAlgorithmBase):
+    def __init__(self, intensity_threshold: float = 0, quality_threshold: float = 0,
+        is_volume: bool = False, expand_dynamic_range: bool = False,
+        clip_method: Union[str, Clip] = Clip.CLIP
+    ) -> None:
+
+        self.intensity_threshold = intensity_threshold
+        self.quality_threshold = quality_threshold
+        self.is_volume = is_volume
+        self.expand_dynamic_range = expand_dynamic_range
+        self.clip_method = clip_method
+
+    _DEFAULT_TESTING_PARAMETERS = {"intensity_threshold": 0, "quality_threshold": 0}
+
+    def _vector_norm(self, x, dim, ord=None):
+        return xr.apply_ufunc(np.linalg.norm, x,
+                              input_core_dims=[[dim]],
+                              kwargs={'ord': ord, 'axis': -1})
+
+    def _call_bases(
+        self, image: xr.DataArray, intensity_threshold: float,
+        quality_threshold: float
+    ) -> xr.DataArray:
+
+        # Get the maximum value for each round/z
+        max_chan = image.argmax(dim=Axes.CH.value)
+        max_values = image.max(dim=Axes.CH.value)
+
+        # Get the norms for each pixel
+        norms = self._vector_norm(x=image, dim=Axes.CH.value)
+
+        # Calculate the base qualities
+        base_qualities = max_values / norms
+
+        # Filter the base call qualities
+        base_qualities_filtered = xr.where(base_qualities < quality_threshold,
+            0, base_qualities)
+
+        # Threshold the intensity values
+        base_qualities_filtered = xr.where(max_values < intensity_threshold,
+            0, base_qualities_filtered)
+
+        # Put the base calls in place
+        base_calls = xr.full_like(other=image, fill_value=0)
+        base_calls[max_chan] = base_qualities_filtered
+
+        return base_calls
+
+    def run(
+            self,
+            stack: ImageStack,
+            in_place: bool = False,
+            verbose: bool = False,
+            n_processes: Optional[int] = None,
+            *args,
+    ) -> ImageStack:
+        """Perform filtering of an image stack
+
+        Parameters
+        ----------
+        stack : ImageStack
+            Stack to be filtered.
+        in_place : bool
+            if True, process ImageStack in-place, otherwise return a new stack
+        verbose : bool
+            if True, report on filtering progress (default = False)
+        n_processes : Optional[int]
+            Number of parallel processes to devote to applying the filter. If None, defaults to
+            the result of os.cpu_count(). (default None)
+
+        Returns
+        -------
+        ImageStack :
+            If in-place is False, return the results of filter as a new stack. Otherwise return the
+            original stack.
+
+        """
+
+        group_by = {Axes.ROUND, Axes.ZPLANE}
+        unmix = partial(
+            self._call_bases, intensity_threshold=self.intensity_threshold,
+            quality_threshold=self.quality_threshold
+        )
+        result = stack.apply(
+            unmix,
+            group_by=group_by, verbose=verbose, in_place=in_place, n_processes=n_processes,
+            clip_method=self.clip_method,
+        )
+        return result
+
+    @staticmethod
+    @click.command("CallBases")
+    @click.option(
+        "--int-thresh", default=0, type=float, help="Intensity threshold for a base call")
+    @click.option(
+        "--qual-thresh", default=0, type=float, help="Quality threshold for a base call")
+    @click.option(
+        "--is-volume", is_flag=True, help="filter 3D volumes")
+    @click.option(
+        "--expand-dynamic-range", is_flag=True,
+        help="linearly scale data to fill [0, 1] after clipping."
+    )
+    @click.pass_context
+    def _cli(ctx, p_min, p_max, is_volume, expand_dynamic_range):
+        ctx.obj["component"]._cli_run(ctx, CallBases(int_thresh, qual_thresh, is_volume, expand_dynamic_range))

--- a/starfish/core/image/_filter/call_bases.py
+++ b/starfish/core/image/_filter/call_bases.py
@@ -28,25 +28,14 @@ class CallBases(FilterAlgorithmBase):
     quality_threshold : float
         Minimum base quality score a pixel must have to be called a base.
         Set to zero for no thresholding.
-    clip_method : Union[str, Clip]
-        (Default Clip.CLIP) Controls the way that data are scaled to retain skimage dtype
-        requirements that float data fall in [0, 1].
-        Clip.CLIP: data above 1 are set to 1, and below 0 are set to 0
-        Clip.SCALE_BY_IMAGE: data above 1 are scaled by the maximum value, with the maximum
-        value calculated over the entire ImageStack
-        Clip.SCALE_BY_CHUNK: data above 1 are scaled by the maximum value, with the maximum
-        value calculated over each slice, where slice shapes are determined by the group_by
-        parameters
     """
 
     def __init__(
-        self, intensity_threshold: float = 0, quality_threshold: float = 0,
-        clip_method: Union[str, Clip] = Clip.CLIP
+        self, intensity_threshold: float = 0, quality_threshold: float = 0
     ) -> None:
 
         self.intensity_threshold = intensity_threshold
         self.quality_threshold = quality_threshold
-        self.clip_method = clip_method
 
     _DEFAULT_TESTING_PARAMETERS = {"intensity_threshold": 0, "quality_threshold": 0}
 
@@ -167,8 +156,7 @@ class CallBases(FilterAlgorithmBase):
         )
         result = stack.apply(
             unmix,
-            group_by=group_by, verbose=verbose, in_place=in_place, n_processes=n_processes,
-            clip_method=self.clip_method,
+            group_by=group_by, verbose=verbose, in_place=in_place, n_processes=n_processes
         )
         return result
 
@@ -178,10 +166,6 @@ class CallBases(FilterAlgorithmBase):
         "--intensity-threshold", default=0, type=float, help="Intensity threshold for a base call")
     @click.option(
         "--quality-threshold", default=0, type=float, help="Quality threshold for a base call")
-    @click.option(
-        "--clip-method", default=Clip.CLIP, type=Clip,
-        help="method to constrain data to [0,1]. options: 'clip', 'scale_by_image', "
-             "'scale_by_chunk'")
     @click.pass_context
     def _cli(ctx, intensity_threshold, quality_threshold, clip_method):
         ctx.obj["component"]._cli_run(

--- a/starfish/core/image/_filter/call_bases.py
+++ b/starfish/core/image/_filter/call_bases.py
@@ -26,7 +26,7 @@ class CallBases(FilterAlgorithmBase):
         Minimum intensity a pixel must have to be called a base.
         Set to zero for no thresholding.
     quality_threshold : float
-        Minimum intensity a pixel must have to be called a base.
+        Minimum base quality score a pixel must have to be called a base.
         Set to zero for no thresholding.
     clip_method : Union[str, Clip]
         (Default Clip.CLIP) Controls the way that data are scaled to retain skimage dtype

--- a/starfish/core/image/_filter/test/test_call_bases.py
+++ b/starfish/core/image/_filter/test/test_call_bases.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from starfish import ImageStack
 from starfish.core.image._filter.call_bases import CallBases
 from starfish.types import Axes
 
@@ -72,6 +73,49 @@ def make_expected_base_calls(intensity_threshold=0, quality_threshold=0):
     return bases_xr
 
 
+def make_image_stack():
+    '''
+        Make a test ImageStack
+
+    '''
+
+    # Make the test image
+    test = np.ones((1, 4, 1, 2, 2), dtype='float32') * 0.5
+
+    x = [0, 0, 1, 1]
+    y = [0, 1, 0, 1]
+
+    for i in range(4):
+        test[0, i, 0, x[i], y[i]] = 1
+    test[0, 0, 0, 0, 0] = 0.75
+
+    # Make the ImageStack
+    test_stack = ImageStack.from_numpy(test)
+
+    return test_stack
+
+
+def make_expected_image_stack():
+    '''
+        Make the expected image stack result
+    '''
+
+    base_calls = np.array(
+        [[[[[0, 0],
+          [0, 0]]],
+          [[[0, 0.755929],
+           [0, 0]]],
+          [[[0, 0],
+           [0.755929, 0]]],
+          [[[0, 0],
+           [0, 0.755929]]]]], dtype='float32'
+    )
+
+    expected_stack = ImageStack.from_numpy(base_calls)
+
+    return expected_stack
+
+
 @pytest.mark.parametrize("int_thresh, qual_thresh", [(0.8, 0), (0, 0.75), (0.8, 0.75)])
 def test_call_bases(int_thresh: float, qual_thresh: float):
 
@@ -88,3 +132,16 @@ def test_call_bases(int_thresh: float, qual_thresh: float):
     )
 
     xr.testing.assert_equal(base_image, expected_result)
+
+
+def test_image_stack_base_call():
+
+    # Get the test stack and expected result
+    test_stack = make_image_stack()
+    expected_result = make_expected_image_stack()
+
+    # Filter
+    bc = CallBases(intensity_threshold=0.8)
+    base_call = bc.run(test_stack, in_place=False)
+
+    xr.testing.assert_equal(base_call.xarray, expected_result.xarray)

--- a/starfish/core/image/_filter/test/test_call_bases.py
+++ b/starfish/core/image/_filter/test/test_call_bases.py
@@ -1,0 +1,96 @@
+import numpy as np
+import xarray as xr
+import pytest
+
+from starfish.types import Axes
+from starfish.core.image._filter.call_bases import CallBases
+
+import numpy as np
+import xarray as xr
+
+from starfish.types import Axes
+from starfish.core.image._filter.call_bases import CallBases
+
+def make_multicolor_image():
+
+    image = np.ones((4, 2, 2), dtype='float32') * 0.25
+
+    x = [0, 0, 1, 1]
+    y = [0, 1, 0, 1]
+
+    for i in range(4):
+        image[i, x[i], y[i]] = 1
+        
+    image[0, 0, 0] = 0.75
+    image[2, 1, 1] = 0.9
+        
+    image_xr = xr.DataArray(image, dims=(Axes.CH.value, Axes.X.value, Axes.Y.value))
+
+    return image_xr
+
+def make_expected_base_calls(intensity_threshold=0, quality_threshold=0):
+
+    if intensity_threshold == 0 and quality_threshold == 0:
+        base_calls = np.array(
+            [[[0.86602545, 0],
+            [0, 0]],
+           [[0, 0.9176629],
+            [0, 0]],
+           [[0, 0],
+            [0.9176629, 0]],
+           [[0, 0],
+            [0, 0.7188852]]], dtype='float32'
+        )
+        
+    elif intensity_threshold == 0.8 and quality_threshold == 0:
+        base_calls = np.array(
+            [[[0, 0],
+            [0, 0]],
+           [[0, 0.9176629],
+            [0, 0]],
+           [[0, 0],
+            [0.9176629, 0]],
+           [[0, 0],
+            [0, 0.7188852]]], dtype='float32'
+        )
+        
+    elif intensity_threshold == 0 and quality_threshold == 0.75:
+        base_calls = np.array(
+            [[[0.86602545, 0],
+            [0, 0]],
+           [[0, 0.9176629],
+            [0, 0]],
+           [[0, 0],
+            [0.9176629, 0]],
+           [[0, 0],
+            [0, 0]]], dtype='float32'
+        )
+        
+    elif intensity_threshold == 0.8 and quality_threshold == 0.75:
+        base_calls = np.array(
+            [[[0, 0],
+            [0, 0]],
+           [[0, 0.9176629],
+            [0, 0]],
+           [[0, 0],
+            [0.9176629, 0]],
+           [[0, 0],
+            [0, 0]]], dtype='float32'
+        )
+
+    bases_xr = xr.DataArray(base_calls, dims=(Axes.CH.value, Axes.X.value, Axes.Y.value))
+
+    return bases_xr
+
+@pytest.mark.parametrize("int_thresh, qual_thresh", [(0.8, 0), (0, 0.75), (0.8, 0.75)])
+def test_call_bases(int_thresh: float, qual_thresh: float):
+
+    # Instantiate the filter
+    cb = CallBases()
+
+    # Make the image and filter
+    image_xr = make_multicolor_image()
+    expected_result = make_expected_base_calls(intensity_threshold=int_thresh, quality_threshold=qual_thresh)
+    base_image = cb._call_bases(image_xr, intensity_threshold=int_thresh, quality_threshold=qual_thresh)
+    
+    xr.testing.assert_equal(base_image, expected_result)

--- a/starfish/core/image/_filter/test/test_call_bases.py
+++ b/starfish/core/image/_filter/test/test_call_bases.py
@@ -1,17 +1,15 @@
 import numpy as np
-import xarray as xr
 import pytest
-
-from starfish.types import Axes
-from starfish.core.image._filter.call_bases import CallBases
-
-import numpy as np
 import xarray as xr
 
-from starfish.types import Axes
 from starfish.core.image._filter.call_bases import CallBases
+from starfish.types import Axes
+
 
 def make_multicolor_image():
+    '''
+        Make a test tile
+    '''
 
     image = np.ones((4, 2, 2), dtype='float32') * 0.25
 
@@ -20,67 +18,59 @@ def make_multicolor_image():
 
     for i in range(4):
         image[i, x[i], y[i]] = 1
-        
+
     image[0, 0, 0] = 0.75
     image[2, 1, 1] = 0.9
-        
+
     image_xr = xr.DataArray(image, dims=(Axes.CH.value, Axes.X.value, Axes.Y.value))
 
     return image_xr
 
-def make_expected_base_calls(intensity_threshold=0, quality_threshold=0):
 
+def make_expected_base_calls(intensity_threshold=0, quality_threshold=0):
+    '''
+        Get the expected results depending on the test thresholds used.
+    '''
     if intensity_threshold == 0 and quality_threshold == 0:
         base_calls = np.array(
-            [[[0.86602545, 0],
-            [0, 0]],
-           [[0, 0.9176629],
-            [0, 0]],
-           [[0, 0],
-            [0.9176629, 0]],
-           [[0, 0],
-            [0, 0.7188852]]], dtype='float32'
+            [[
+                [0.86602545, 0], [0, 0]],
+                [[0, 0.9176629], [0, 0]],
+                [[0, 0], [0.9176629, 0]],
+                [[0, 0], [0, 0.7188852]]], dtype='float32'
         )
-        
+
     elif intensity_threshold == 0.8 and quality_threshold == 0:
         base_calls = np.array(
-            [[[0, 0],
-            [0, 0]],
-           [[0, 0.9176629],
-            [0, 0]],
-           [[0, 0],
-            [0.9176629, 0]],
-           [[0, 0],
-            [0, 0.7188852]]], dtype='float32'
+            [[
+                [0, 0], [0, 0]],
+                [[0, 0.9176629], [0, 0]],
+                [[0, 0], [0.9176629, 0]],
+                [[0, 0], [0, 0.7188852]]], dtype='float32'
         )
-        
+
     elif intensity_threshold == 0 and quality_threshold == 0.75:
         base_calls = np.array(
-            [[[0.86602545, 0],
-            [0, 0]],
-           [[0, 0.9176629],
-            [0, 0]],
-           [[0, 0],
-            [0.9176629, 0]],
-           [[0, 0],
-            [0, 0]]], dtype='float32'
+            [[
+                [0.86602545, 0], [0, 0]],
+                [[0, 0.9176629], [0, 0]],
+                [[0, 0], [0.9176629, 0]],
+                [[0, 0], [0, 0]]], dtype='float32'
         )
-        
+
     elif intensity_threshold == 0.8 and quality_threshold == 0.75:
         base_calls = np.array(
-            [[[0, 0],
-            [0, 0]],
-           [[0, 0.9176629],
-            [0, 0]],
-           [[0, 0],
-            [0.9176629, 0]],
-           [[0, 0],
-            [0, 0]]], dtype='float32'
+            [[
+                [0, 0], [0, 0]],
+                [[0, 0.9176629], [0, 0]],
+                [[0, 0], [0.9176629, 0]],
+                [[0, 0], [0, 0]]], dtype='float32'
         )
 
     bases_xr = xr.DataArray(base_calls, dims=(Axes.CH.value, Axes.X.value, Axes.Y.value))
 
     return bases_xr
+
 
 @pytest.mark.parametrize("int_thresh, qual_thresh", [(0.8, 0), (0, 0.75), (0.8, 0.75)])
 def test_call_bases(int_thresh: float, qual_thresh: float):
@@ -90,7 +80,11 @@ def test_call_bases(int_thresh: float, qual_thresh: float):
 
     # Make the image and filter
     image_xr = make_multicolor_image()
-    expected_result = make_expected_base_calls(intensity_threshold=int_thresh, quality_threshold=qual_thresh)
-    base_image = cb._call_bases(image_xr, intensity_threshold=int_thresh, quality_threshold=qual_thresh)
-    
+    expected_result = make_expected_base_calls(
+        intensity_threshold=int_thresh, quality_threshold=qual_thresh
+    )
+    base_image = cb._call_bases(
+        image_xr, intensity_threshold=int_thresh, quality_threshold=qual_thresh
+    )
+
     xr.testing.assert_equal(base_image, expected_result)


### PR DESCRIPTION
# Overview
As discussed in #1263, this filter component performs base calling for in situ sequencing. The filter determines which base (if any) is represented in each X, Y location in a (round, z plane) slice (i.e., in a (channel, x, y) image). Each pixel value in the resulting image is the base quality score for a given base call.

Currently, the base quality score is calculated as the intensity of the called base divided by the L2 norm of the intensities in all 4 channels (this is how it is done in the original BaristaSeq paper). However, I think it could be useful to add the capability for the user to provide their own custom functions. However, this will likely present challenges for provenance logging. Thoughts, @ambrosejcarr and @dganguli?

# Usage
```python
import numpy as np

from starfish import ImageStack
from starfish.image import Filter

# Make the test image
test = np.ones((1, 4, 1, 2, 2), dtype='uint16') * 0.5

x = [0, 0, 1, 1]
y = [0, 1, 0, 1]

for i in range(4):
    test[0, i, 0, x[i], y[i]] = 1
test[0, 0, 0, 0, 0] = 0.75

# Make the ImageStack
test_stack = ImageStack.from_numpy(test)

# Filter
bc = Filter.CallBases(intensity_threshold=0.8)
base_call = bc.run(test_stack, in_place=False)

base_call.xarray.values
```

In the example above, the test image has intensities as shown below. The field over view is 2 pixels x 2 pixels. Base for channel 0 is "on" in the upper left corner (intensity=0.75), the base for channel 1 is "on" in the upper right hand  corner (intensity=1), the base for channel 2 is "on" in lower left-hand corner (intensity=1), and the base for channel 3 is "on" in the lower right hand corner (intensity=1). The background intensity is uniformly 0.5 for all channels.
```python
array([[[[[0.75, 0.5 ],
          [0.5 , 0.5 ]]],

        [[[0.5 , 1.  ],
          [0.5 , 0.5 ]]],

        [[[0.5 , 0.5 ],
          [1.  , 0.5 ]]],

        [[[0.5 , 0.5 ],
          [0.5 , 1.  ]]]]], dtype=float32)
```
After filtering, we obtain the following. Note that the base 0 intensity in the upper left hand corner was 0.75, so no base was called due to the intensity threshold we set for the filter (`intensity_threshold=0.8`). The base quality for all other bases is `1 / (1^2 + 0.5^2 + 0.5^2 + 0.5^2)^0.5 = 0.755929`.
```python
array([[[[[0.      , 0.      ],
          [0.      , 0.      ]]],

        [[[0.      , 0.755929],
          [0.      , 0.      ]]],

        [[[0.      , 0.      ],
          [0.755929, 0.      ]]],

        [[[0.      , 0.      ],
          [0.      , 0.755929]]]]], dtype=float32)
```
# Testing
I added tests for the base calling and filtering in `starfish/core/image/_filter/test/test_call_bases.py`