### PR TITLE
[Easy] Change IntensityTable x,y,z SpotAttributes to floats for spot-based methods

### DIFF
--- a/starfish/core/spots/_detect_spots/blob.py
+++ b/starfish/core/spots/_detect_spots/blob.py
@@ -114,8 +114,8 @@ class BlobDetector(DetectSpotsAlgorithmBase):
         converted_radius = np.round(fitted_blobs[Features.SPOT_RADIUS] * np.sqrt(3))
         fitted_blobs[Features.SPOT_RADIUS] = converted_radius
 
-        # convert the array to int so it can be used to index
-        rounded_blobs = SpotAttributes(fitted_blobs.astype(int))
+        # Fitted blob attributes need to be kept as floats!
+        rounded_blobs = SpotAttributes(fitted_blobs.astype(float))
 
         rounded_blobs.data['intensity'] = measure_spot_intensity(
             data_image, rounded_blobs, self.measurement_function)

--- a/starfish/core/spots/_detect_spots/trackpy_local_max_peak_finder.py
+++ b/starfish/core/spots/_detect_spots/trackpy_local_max_peak_finder.py
@@ -56,6 +56,8 @@ class TrackpyLocalMaxPeakFinder(DetectSpotsAlgorithmBase):
         name of the function used to calculate the intensity for each identified spot area
     preprocess : boolean
         Set to False to turn off bandpass preprocessing.
+    max_iterations : integer
+        Max number of loops to refine the center of mass, default 10
     is_volume : bool
         if True, run the algorithm on 3d volumes of the provided stack
     verbose : bool
@@ -70,8 +72,8 @@ class TrackpyLocalMaxPeakFinder(DetectSpotsAlgorithmBase):
     def __init__(
             self, spot_diameter, min_mass, max_size, separation, percentile=0,
             noise_size: Tuple[int, int, int] = (1, 1, 1), smoothing_size=None, threshold=None,
-            preprocess: bool = False, measurement_type: str = 'max', is_volume: bool = False,
-            verbose=False) -> None:
+            preprocess: bool = False, max_iterations: int = 10, measurement_type: str = 'max',
+            is_volume: bool = False, verbose=False) -> None:
 
         self.diameter = spot_diameter
         self.minmass = min_mass
@@ -83,6 +85,7 @@ class TrackpyLocalMaxPeakFinder(DetectSpotsAlgorithmBase):
         self.threshold = threshold
         self.measurement_function = self._get_measurement_function(measurement_type)
         self.preprocess = preprocess
+        self.max_iterations = max_iterations
         self.is_volume = is_volume
         self.verbose = verbose
 
@@ -114,7 +117,8 @@ class TrackpyLocalMaxPeakFinder(DetectSpotsAlgorithmBase):
                 smoothing_size=self.smoothing_size,
                 threshold=self.threshold,
                 percentile=self.percentile,
-                preprocess=self.preprocess
+                preprocess=self.preprocess,
+                max_iterations=self.max_iterations,
             )
 
         # when zero spots are detected, 'ep' is missing from the trackpy locate results.
@@ -190,11 +194,13 @@ class TrackpyLocalMaxPeakFinder(DetectSpotsAlgorithmBase):
     @click.option(
         "--smoothing-size", default=None, type=int,
         help="odd integer. Size of boxcar (moving average) filter in pixels. Default is the "
-             "Diameter"
-    )
+             "Diameter")
     @click.option(
         "--preprocess", is_flag=True,
         help="if passed, gaussian and boxcar filtering are applied")
+    @click.option(
+        "--max-iterations", default=10, type=int,
+        help="Max number of loops to refine the center of mass. Default is 10")
     @click.option(
         "--show", default=False, is_flag=True, help="display results visually")
     @click.option(
@@ -206,9 +212,10 @@ class TrackpyLocalMaxPeakFinder(DetectSpotsAlgorithmBase):
         help="indicates that the image stack should be filtered in 3d")
     @click.pass_context
     def _cli(ctx, spot_diameter, min_max, max_size, separation, noise_size, smoothing_size,
-             preprocess, show, percentile, is_volume):
+             preprocess, max_iterations, show, percentile, is_volume):
 
         instance = TrackpyLocalMaxPeakFinder(spot_diameter, min_max, max_size,
                                              separation, noise_size, smoothing_size,
-                                             preprocess, show, percentile, is_volume)
+                                             preprocess, max_iterations, show,
+                                             percentile, is_volume)
         ctx.obj["component"]._cli_run(ctx, instance)

--- a/starfish/core/spots/_detect_spots/trackpy_local_max_peak_finder.py
+++ b/starfish/core/spots/_detect_spots/trackpy_local_max_peak_finder.py
@@ -137,10 +137,8 @@ class TrackpyLocalMaxPeakFinder(DetectSpotsAlgorithmBase):
             attributes.columns = new_colnames
 
         attributes['spot_id'] = np.arange(attributes.shape[0])
-        # convert these to int so it can be used to index
-        attributes.x = attributes.x.astype(int)
-        attributes.y = attributes.y.astype(int)
-        attributes.z = attributes.z.astype(int)
+
+        # Spot attributes need to be kept as floats!
         return SpotAttributes(attributes)
 
     def run(


### PR DESCRIPTION
Spot detection methods return spot coordinates with
sub-pixel resolution. Previously this sub-pixel information
was thrown away due to int conversion (see: #898).

The correct behavior should be to retain sub-pixel
information and modify downstream functions to
properly handle float values for x,y,z pixel
coordinates.

Relates to: #1310

NOTE: This will break functions like: https://github.com/spacetx/starfish/blob/master/starfish/core/intensity_table/intensity_table_coordinates.py and possibly others!