### PR TITLE
Preserve subpixel offsets from spot detection

### DIFF
--- a/starfish/core/intensity_table/intensity_table.py
+++ b/starfish/core/intensity_table/intensity_table.py
@@ -285,8 +285,14 @@ class IntensityTable(xr.DataArray):
 
     @classmethod
     def synthetic_intensities(
-            cls, codebook, num_z: int=12, height: int=50, width: int=40, n_spots=10,
-            mean_fluor_per_spot=200, mean_photons_per_fluor=50
+            cls,
+            codebook,
+            num_z: int = 12,
+            height: int = 50,
+            width: int = 40,
+            n_spots: int = 10,
+            mean_fluor_per_spot: int = 200,
+            mean_photons_per_fluor: int = 50,
     ) -> "IntensityTable":
         """
         Creates an IntensityTable with synthetic spots, that correspond to valid
@@ -317,8 +323,9 @@ class IntensityTable(xr.DataArray):
 
         # TODO nsofroniew: right now there is no jitter on x-y positions of the spots
         z = np.random.randint(0, num_z, size=n_spots)
-        y = np.random.randint(0, height, size=n_spots)
-        x = np.random.randint(0, width, size=n_spots)
+        y = np.random.uniform(0, height - 1, size=n_spots)
+        x = np.random.uniform(0, width - 1, size=n_spots)
+
         r = np.empty(n_spots)
         r.fill(np.nan)  # radius is a function of the point-spread gaussian size
         spot_attributes = SpotAttributes(

--- a/starfish/core/intensity_table/test/test_intensity_table_coords.py
+++ b/starfish/core/intensity_table/test/test_intensity_table_coords.py
@@ -1,3 +1,4 @@
+import math
 import random
 from collections import OrderedDict
 from typing import Union
@@ -57,13 +58,17 @@ def test_tranfering_physical_coords_to_intensity_table():
     # Assert that the physical coords align with their corresponding pixel coords
     for spot in xc.features:
         pixel_x = spot[Axes.X.value].data
-        physical_x = stack.xarray[Coordinates.X.value][pixel_x]
-        assert np.isclose(spot[Coordinates.X.value], physical_x)
+        pixel_x_floor, pixel_x_ceiling = math.floor(pixel_x), math.ceil(pixel_x)
+        physical_x_floor = stack.xarray[Coordinates.X.value][pixel_x_floor]
+        physical_x_ceiling = stack.xarray[Coordinates.X.value][pixel_x_ceiling]
+        assert physical_x_floor <= spot[Coordinates.X.value] <= physical_x_ceiling
 
     for spot in yc.features:
         pixel_y = spot[Axes.Y.value].data
-        physical_y = stack.xarray[Coordinates.Y.value][pixel_y]
-        assert np.isclose(spot[Coordinates.Y.value], physical_y)
+        pixel_y_floor, pixel_y_ceiling = math.floor(pixel_y), math.ceil(pixel_y)
+        physical_y_floor = stack.xarray[Coordinates.Y.value][pixel_y_floor]
+        physical_y_ceiling = stack.xarray[Coordinates.Y.value][pixel_y_ceiling]
+        assert physical_y_floor <= spot[Coordinates.Y.value] <= physical_y_ceiling
 
     # Assert that zc value is middle of z range
     for spot in zc.features:

--- a/starfish/core/intensity_table/test/test_synthetic_intensities.py
+++ b/starfish/core/intensity_table/test/test_synthetic_intensities.py
@@ -18,7 +18,7 @@ def test_synthetic_intensity_generation():
     a known random seed, that the output spots decode to match a target in the input Codebook
     """
     # set seed to check that codebook is matched. This seed generates 2 instances of GENE_B
-    np.random.seed(1)
+    np.random.seed(2)
     codebook = codebook_array_factory()
     num_z, height, width = 3, 4, 5
     intensities = IntensityTable.synthetic_intensities(
@@ -26,7 +26,7 @@ def test_synthetic_intensity_generation():
         num_z=num_z,
         height=height,
         width=width,
-        n_spots=2
+        n_spots=2,
     )
 
     # sizes should match codebook

--- a/starfish/core/spots/_detect_spots/blob.py
+++ b/starfish/core/spots/_detect_spots/blob.py
@@ -115,7 +115,7 @@ class BlobDetector(DetectSpotsAlgorithmBase):
         fitted_blobs[Features.SPOT_RADIUS] = converted_radius
 
         # convert the array to int so it can be used to index
-        rounded_blobs = SpotAttributes(fitted_blobs.astype(int))
+        rounded_blobs = SpotAttributes(fitted_blobs)
 
         rounded_blobs.data['intensity'] = measure_spot_intensity(
             data_image, rounded_blobs, self.measurement_function)

--- a/starfish/core/spots/_detect_spots/trackpy_local_max_peak_finder.py
+++ b/starfish/core/spots/_detect_spots/trackpy_local_max_peak_finder.py
@@ -133,10 +133,6 @@ class TrackpyLocalMaxPeakFinder(DetectSpotsAlgorithmBase):
             attributes.columns = new_colnames
 
         attributes['spot_id'] = np.arange(attributes.shape[0])
-        # convert these to int so it can be used to index
-        attributes.x = attributes.x.astype(int)
-        attributes.y = attributes.y.astype(int)
-        attributes.z = attributes.z.astype(int)
         return SpotAttributes(attributes)
 
     def run(

--- a/starfish/core/test/factories.py
+++ b/starfish/core/test/factories.py
@@ -214,7 +214,7 @@ class SyntheticData:
                 warnings.simplefilter('ignore', FutureWarning)
                 values = spots.where(spots, drop=True)
 
-            image[round_, ch, values.z, values.y, values.x] = values
+            image[round_, ch, values.z, values.y.astype(int), values.x.astype(int)] = values
 
         intensities.values = img_as_float32(intensities)
 


### PR DESCRIPTION
1. Remove the casts to int.

2. Interpolate the coordinates if there are more than one pixel location, otherwise use sel.

3. Update tests.

Fixes #1310