### PR TITLE
[easy] Bump slicedimage requirement to 3.1.0

### DIFF
--- a/REQUIREMENTS-STRICT.txt
+++ b/REQUIREMENTS-STRICT.txt
@@ -58,7 +58,7 @@ semantic-version==2.6.0
 Send2Trash==1.5.0
 showit==1.1.4
 six==1.12.0
-slicedimage==3.0.0
+slicedimage==3.1.0
 sympy==1.4
 terminado==0.8.2
 testpath==0.4.2

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -9,7 +9,7 @@ scikit-image>=0.14.0
 scikit-learn
 scipy
 showit >= 1.1.4
-slicedimage == 3.0.0
+slicedimage==3.1.0
 scikit-learn
 sympy
 tqdm

--- a/starfish/REQUIREMENTS-STRICT.txt
+++ b/starfish/REQUIREMENTS-STRICT.txt
@@ -58,7 +58,7 @@ semantic-version==2.6.0
 Send2Trash==1.5.0
 showit==1.1.4
 six==1.12.0
-slicedimage==3.0.0
+slicedimage==3.1.0
 sympy==1.4
 terminado==0.8.2
 testpath==0.4.2


### PR DESCRIPTION
Key change is that json files are read in parallel.  (see https://github.com/spacetx/slicedimage/pull/91)