### PR TITLE
fix run method docs

### DIFF
--- a/starfish/core/pipeline/algorithmbase.py
+++ b/starfish/core/pipeline/algorithmbase.py
@@ -1,3 +1,4 @@
+import functools
 import inspect
 from abc import ABCMeta, abstractmethod
 from typing import Type
@@ -40,6 +41,7 @@ class AlgorithmBaseType(ABCMeta):
                     ImageStack -> [IntensityTable, ConnectedComponentDecodingResult]
             TODO segmentation and decoding
         """
+        @functools.wraps(func)
         def helper(*args, **kwargs):
             result = func(*args, **kwargs)
             # Scenario 1, Filtering, ApplyTransform


### PR DESCRIPTION
use `functools.wraps` to properly propagate the `__name__` and `__doc__` attributes of `run` methods (as modified with `AlgorithmBaseType.run_with_logging`)

this allows documentation tools to properly capture and build the documentation for these methods whereas it was previously blank:
<img width="541" alt="Screen Shot 2019-05-10 at 2 23 07 PM" src="https://user-images.githubusercontent.com/29165011/57557518-4fbdb280-732f-11e9-8e91-a980b3f9b3fd.png">

note that this is the minimum implementation for such a process; for more feature-complete wrapping, one should use the [`decorator`](https://github.com/micheles/decorator/blob/master/docs/documentation.md) or [`wrapt`](https://wrapt.readthedocs.io/en/latest/quick-start.html) packages