### PR TITLE
Fix physical coordinate calculator

### DIFF
--- a/starfish/core/imagestack/physical_coordinate_calculator.py
+++ b/starfish/core/imagestack/physical_coordinate_calculator.py
@@ -15,13 +15,11 @@ def _pixel_offset_to_physical_coordinate(
         physical_pixel_size: Number,
         pixel_offset: Optional[int],
         coordinates_at_pixel_offset_0: Number,
-        dimension_size: int,
 ) -> Number:
     """Calculate the physical pixel value at the given index"""
     if pixel_offset:
         # Check for negative index
-        if pixel_offset < 0:
-            pixel_offset = pixel_offset + dimension_size
+        assert pixel_offset >= 0
         return (physical_pixel_size * pixel_offset) + coordinates_at_pixel_offset_0
     return coordinates_at_pixel_offset_0
 
@@ -53,15 +51,19 @@ def recalculate_physical_coordinate_range(
     -------
     The new min and max physical coordinate values of the given dimension
     """
-    physical_pixel_size = _calculate_physical_pixel_size(coord_min, coord_max, dimension_size)
+    physical_pixel_size = _calculate_physical_pixel_size(coord_min, coord_max, dimension_size - 1)
     min_pixel_index = indexer if isinstance(indexer, int) else indexer.start
-    max_pixel_index = indexer if isinstance(indexer, int) else indexer.stop
-    # Add one to max pixel index to get end of pixel
-    max_pixel_index = max_pixel_index + 1 if max_pixel_index else dimension_size
-    new_min = _pixel_offset_to_physical_coordinate(
-        physical_pixel_size, min_pixel_index, coord_min, dimension_size)
-    new_max = _pixel_offset_to_physical_coordinate(
-        physical_pixel_size, max_pixel_index, coord_min, dimension_size)
+    if isinstance(indexer, int):
+        max_pixel_index = indexer
+    elif isinstance(indexer.stop, int):
+        if indexer.stop >= 0:
+            max_pixel_index = indexer.stop - 1
+        else:
+            max_pixel_index = indexer.stop + dimension_size
+    else:
+        max_pixel_index = dimension_size - 1
+    new_min = _pixel_offset_to_physical_coordinate(physical_pixel_size, min_pixel_index, coord_min)
+    new_max = _pixel_offset_to_physical_coordinate(physical_pixel_size, max_pixel_index, coord_min)
     return new_min, new_max
 
 

--- a/starfish/core/imagestack/test/test_physical_coordinate_calculator.py
+++ b/starfish/core/imagestack/test/test_physical_coordinate_calculator.py
@@ -1,0 +1,49 @@
+import numpy as np
+
+from starfish.core.imagestack.physical_coordinate_calculator import \
+    recalculate_physical_coordinate_range
+
+
+COORDS = 0.01, 0.1
+
+
+def test_physical_coordinate_calculator():
+    # coords of the starting pixel should be (0.01, 0.01)
+    start, end = recalculate_physical_coordinate_range(COORDS[0], COORDS[1], 60, 0)
+    assert np.isclose(start, 0.01)
+    assert np.isclose(end, 0.01)
+
+    # coords of the last pixel should be (0.1, 0.1)
+    start, end = recalculate_physical_coordinate_range(COORDS[0], COORDS[1], 60, 59)
+    assert np.isclose(start, 0.1)
+    assert np.isclose(end, 0.1)
+
+    # the original range should be (0.01, 0.1)
+    start, end = recalculate_physical_coordinate_range(COORDS[0], COORDS[1], 60, slice(0, 60))
+    assert np.isclose(start, 0.01)
+    assert np.isclose(end, 0.1)
+
+    # another way of expressing the original range
+    start, end = recalculate_physical_coordinate_range(COORDS[0], COORDS[1], 60, slice(0, -1))
+    assert np.isclose(start, 0.01)
+    assert np.isclose(end, 0.1)
+
+    # yet another way of expressing the original range
+    start, end = recalculate_physical_coordinate_range(COORDS[0], COORDS[1], 60, slice(0, None))
+    assert np.isclose(start, 0.01)
+    assert np.isclose(end, 0.1)
+
+    # and yet another way of expressing the original range
+    start, end = recalculate_physical_coordinate_range(COORDS[0], COORDS[1], 60, slice(None, -1))
+    assert np.isclose(start, 0.01)
+    assert np.isclose(end, 0.1)
+
+    # coords of the first half should be (0.01, 0.0557627)
+    start, end = recalculate_physical_coordinate_range(COORDS[0], COORDS[1], 60, slice(0, 30))
+    assert np.isclose(start, 0.01)
+    assert np.isclose(end, 0.054237288135593)
+
+    # coords of the second half should be (0.01, 0.0557627)
+    start, end = recalculate_physical_coordinate_range(COORDS[0], COORDS[1], 60, slice(30, 60))
+    assert np.isclose(start, 0.055762711864407)
+    assert np.isclose(end, 0.1)


### PR DESCRIPTION
It should reflect that the physical coordinate of a pixel is the top-left corner of a pixel.  Therefore, the last pixel's coordinate should be the top-left corner and is the max of the tile's range.

Test plan: added a test!

Part of #1332