### PR TITLE
ImageStack parsers should provide coordinates as an array

### DIFF
--- a/starfish/core/imagestack/parser/_tiledata.py
+++ b/starfish/core/imagestack/parser/_tiledata.py
@@ -1,4 +1,4 @@
-from typing import Collection, Mapping, Tuple
+from typing import Collection, Mapping, Sequence
 
 import numpy as np
 
@@ -26,7 +26,7 @@ class TileData:
         raise NotImplementedError()
 
     @property
-    def coordinates(self) -> Mapping[Coordinates, Tuple[Number, Number]]:
+    def coordinates(self) -> Mapping[Coordinates, Sequence[Number]]:
         raise NotImplementedError()
 
     @property

--- a/starfish/core/imagestack/test/test_from_numpy_array.py
+++ b/starfish/core/imagestack/test/test_from_numpy_array.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from starfish.core.types import Axes, Coordinates
 from ..imagestack import ImageStack
 
 
@@ -21,3 +22,20 @@ def test_from_numpy_array_automatically_handles_float_conversions():
     x = np.zeros((1, 1, 1, 20, 20), dtype=np.uint16)
     stack = ImageStack.from_numpy(x)
     assert stack.xarray.dtype == np.float32
+
+
+def test_from_numpy_array_coordinates():
+    x = np.zeros((1, 1, 4, 20, 20), dtype=np.float32)
+    coordinates = {
+        Coordinates.X: np.linspace(0, 15, x.shape[-1]),
+        Coordinates.Y: np.linspace(0, 20, x.shape[-2]),
+        Coordinates.Z: [1, 2, 15, 20],
+    }
+    stack = ImageStack.from_numpy(x, coordinates=coordinates)
+
+    assert stack.xarray.isel({Axes.X.value: 0}).coords[Coordinates.X.value] == 0
+    assert stack.xarray.isel({Axes.X.value: -1}).coords[Coordinates.X.value] == 15
+    assert stack.xarray.isel({Axes.Y.value: 0}).coords[Coordinates.Y.value] == 0
+    assert stack.xarray.isel({Axes.Y.value: -1}).coords[Coordinates.Y.value] == 20
+    assert stack.xarray.isel({Axes.ZPLANE.value: 0}).coords[Coordinates.Z.value] == 1
+    assert stack.xarray.isel({Axes.ZPLANE.value: -1}).coords[Coordinates.Z.value] == 20


### PR DESCRIPTION
The coordinates for zplanes need to be a sequence of coordinate values since a start/end range does not work for irregularly spaced coordinates.  To make the API consistent, this PR passes _all_ coordinates to the numpy parser and between the parsers and ImageStack as sequences of coordinate values.

Add a test for from_numpy(..) to verify that construction of an ImageStack from a numpy array with coordinates works correctly.

Test plan: `pytest -v -n4 starfish/core/imagestack/test/`

Depends on #1350 