### PR TITLE
Use the Versions specified in the code

### DIFF
--- a/starfish/core/spacetx_format/test_codebook.py
+++ b/starfish/core/spacetx_format/test_codebook.py
@@ -1,13 +1,12 @@
 import pytest
 from pkg_resources import resource_filename
 
-from starfish.core.codebook._format import DocumentKeys
-from .util import CodebookValidator
+from starfish.core.codebook._format import CURRENT_VERSION, DocumentKeys
+from .util import LatestCodebookValidator
 from .validate_sptx import validate_file
 
 package_name = "starfish"
-current_version = "0.0.0"
-validator = CodebookValidator(version=current_version)
+validator = LatestCodebookValidator()
 
 
 def test_codebook():
@@ -40,4 +39,4 @@ def test_codebook_missing_channel_raises_validation_error():
 def test_codebook_validate():
     example = resource_filename(
         package_name, "spacetx_format/examples/codebook/codebook.json")
-    assert validate_file(example, f"codebook_{current_version}/codebook.json")
+    assert validate_file(example, f"codebook_{CURRENT_VERSION}/codebook.json")

--- a/starfish/core/spacetx_format/test_experiment.py
+++ b/starfish/core/spacetx_format/test_experiment.py
@@ -3,12 +3,11 @@ import warnings
 import pytest
 from pkg_resources import resource_filename
 
-from starfish.core.experiment.version import CURRENT_VERSION
-from .util import ExperimentValidator
+from .util import LatestExperimentValidator
 from .validate_sptx import validate
 
 package_name = "starfish"
-validator = ExperimentValidator(version=CURRENT_VERSION)
+validator = LatestExperimentValidator()
 example = resource_filename(package_name, "spacetx_format/examples/experiment/experiment.json")
 
 

--- a/starfish/core/spacetx_format/test_field_of_view.py
+++ b/starfish/core/spacetx_format/test_field_of_view.py
@@ -1,11 +1,10 @@
 import pytest
 from pkg_resources import resource_filename
 
-from .util import FOVValidator
+from .util import LatestFOVValidator
 
 package_name = "starfish"
-current_version = "0.1.0"
-validator = FOVValidator(version=current_version)
+validator = LatestFOVValidator()
 example = resource_filename(
     package_name, "spacetx_format/examples/field_of_view/field_of_view.json")
 too_large = resource_filename(

--- a/starfish/core/spacetx_format/test_fov_manifest.py
+++ b/starfish/core/spacetx_format/test_fov_manifest.py
@@ -1,11 +1,10 @@
 import pytest
 from pkg_resources import resource_filename
 
-from .util import ManifestValidator
+from .util import LatestManifestValidator
 
 package_name = "starfish"
-current_version = "0.1.0"
-validator = ManifestValidator(version=current_version)
+validator = LatestManifestValidator()
 
 
 def test_fov_manifest():

--- a/starfish/core/spacetx_format/test_fuzz.py
+++ b/starfish/core/spacetx_format/test_fuzz.py
@@ -1,12 +1,11 @@
 import io
 
 from starfish.core.codebook._format import CURRENT_VERSION, DocumentKeys
-from starfish.core.experiment.version import CURRENT_VERSION as EXPERIMENT_VERSION
-from .util import CodebookValidator, ExperimentValidator, Fuzzer
+from .util import Fuzzer, LatestCodebookValidator, LatestExperimentValidator
 
 package_name = "starfish"
-codebook_validator = CodebookValidator(version=CURRENT_VERSION)
-experiment_validator = ExperimentValidator(version=EXPERIMENT_VERSION)
+codebook_validator = LatestCodebookValidator()
+experiment_validator = LatestExperimentValidator()
 
 
 def test_fuzz_mock():


### PR DESCRIPTION
1. Use Version objects instead of strings when possible.
2. Use the authoritative VERSIONs declared in the code instead of duplicating.
3. Use the Latest*Validator primitives to construct the current validators.

Test plan: `pytest -v -n8 starfish/core/spacetx_format/`

This is built on top of #1278