### PR TITLE
Tooling to support creation of 4D datasets

### DIFF
--- a/starfish/core/experiment/builder/__init__.py
+++ b/starfish/core/experiment/builder/__init__.py
@@ -65,8 +65,22 @@ def _fov_path_generator(parent_toc_path: Path, toc_name: str) -> Path:
     return parent_toc_path.parent / "{}-{}.json".format(parent_toc_path.stem, toc_name)
 
 
+<<<<<<< variant A
 def build_irregular_image(
         tile_coordinates: Iterable[TileIdentifier],
+>>>>>>> variant B
+def build_image(
+        fovs: Sequence[int],
+        rounds: Sequence[int],
+        chs: Sequence[int],
+        zplanes: Optional[Sequence[int]],
+####### Ancestor
+def build_image(
+        fovs: Sequence[int],
+        rounds: Sequence[int],
+        chs: Sequence[int],
+        zplanes: Sequence[int],
+======= end
         image_fetcher: TileFetcher,
         default_shape: Optional[Mapping[Axes, int]] = None,
 ) -> Collection:
@@ -76,8 +90,29 @@ def build_irregular_image(
 
     Parameters
     ----------
+<<<<<<< variant A
     tile_coordinates : Iterable[TileIdentifier]
         Iterable of all the TileCoordinates that are valid in the image.
+>>>>>>> variant B
+    fovs : Sequence[int]
+        Sequence of field of view ids in this image set.
+    rounds : Sequence[int]
+        Sequence of the round numbers in this image set.
+    chs : Sequence[int]
+        Sequence of the ch numbers in this image set.
+    zplanes : Sequence[int]
+        Sequence of the zplane numbers in this image set.  If this is not set, the resulting image
+        is a 4D tensor.
+####### Ancestor
+    fovs : Sequence[int]
+        Sequence of field of view ids in this image set.
+    rounds : Sequence[int]
+        Sequence of the round numbers in this image set.
+    chs : Sequence[int]
+        Sequence of the ch numbers in this image set.
+    zplanes : Sequence[int]
+        Sequence of the zplane numbers in this image set.
+======= end
     image_fetcher : TileFetcher
         Instance of TileFetcher that provides the data for the tile.
     default_shape : Optional[Tuple[int, int]]
@@ -87,6 +122,7 @@ def build_irregular_image(
     -------
     The slicedimage collection representing the image.
     """
+<<<<<<< variant A
     def reducer_to_sets(
             accumulated: Sequence[MutableSet[int]], update: TileIdentifier,
     ) -> Sequence[MutableSet[int]]:
@@ -101,8 +137,42 @@ def build_irregular_image(
 
     fovs, rounds, chs, zplanes = functools.reduce(
         reducer_to_sets, tile_coordinates, initial_value)
+>>>>>>> variant B
+    if zplanes is not None:
+        write_z = True
+        tileset_dimensions = [
+            Coordinates.X,
+            Coordinates.Y,
+            Coordinates.Z,
+            Axes.ZPLANE,
+            Axes.ROUND,
+            Axes.CH,
+            Axes.X,
+            Axes.Y,
+        ]
+        tileset_shape = {Axes.ROUND: len(rounds), Axes.CH: len(chs), Axes.ZPLANE: len(zplanes)}
+    else:
+        zplanes = [0]
+        write_z = False
+        tileset_dimensions = [
+            Coordinates.X,
+            Coordinates.Y,
+            Axes.ROUND,
+            Axes.CH,
+            Axes.X,
+            Axes.Y,
+        ]
+        tileset_shape = {Axes.ROUND: len(rounds), Axes.CH: len(chs)}
+
+    axes_sizes = join_axes_labels(
+        axes_order, rounds=rounds, chs=chs, zplanes=zplanes)
+####### Ancestor
+    axes_sizes = join_axes_labels(
+        axes_order, rounds=rounds, chs=chs, zplanes=zplanes)
+======= end
 
     collection = Collection()
+<<<<<<< variant A
     for expected_fov in fovs:
         fov_images = TileSet(
             [
@@ -119,6 +189,27 @@ def build_irregular_image(
             default_shape,
             ImageFormat.TIFF,
         )
+>>>>>>> variant B
+    for fov_id in fovs:
+        fov_images = TileSet(tileset_dimensions, tileset_shape, default_shape, ImageFormat.TIFF)
+####### Ancestor
+    for fov_id in fovs:
+        fov_images = TileSet(
+            [
+                Coordinates.X,
+                Coordinates.Y,
+                Coordinates.Z,
+                Axes.ZPLANE,
+                Axes.ROUND,
+                Axes.CH,
+                Axes.X,
+                Axes.Y,
+            ],
+            {Axes.ROUND: len(rounds), Axes.CH: len(chs), Axes.ZPLANE: len(zplanes)},
+            default_shape,
+            ImageFormat.TIFF,
+        )
+======= end
 
         for tile_coordinate in tile_coordinates:
             current_fov, current_round, current_ch, current_zplane = astuple(tile_coordinate)
@@ -126,6 +217,7 @@ def build_irregular_image(
             if expected_fov != current_fov:
                 continue
             image = image_fetcher.get_tile(
+<<<<<<< variant A
                 current_fov,
                 current_round,
                 current_ch,
@@ -141,6 +233,34 @@ def build_irregular_image(
                 image.shape,
                 extras=image.extras,
             )
+>>>>>>> variant B
+                fov_id,
+                selector[Axes.ROUND],
+                selector[Axes.CH],
+                selector[Axes.ZPLANE])
+            indicies = {
+                Axes.ROUND: selector[Axes.ROUND],
+                Axes.CH: selector[Axes.CH],
+            }
+            if write_z:
+                indicies[Axes.ZPLANE] = selector[Axes.ZPLANE]
+            tile = Tile(image.coordinates, indicies, image.shape, extras=image.extras)
+####### Ancestor
+                fov_id,
+                selector[Axes.ROUND],
+                selector[Axes.CH],
+                selector[Axes.ZPLANE])
+            tile = Tile(
+                image.coordinates,
+                {
+                    Axes.ZPLANE: (selector[Axes.ZPLANE]),
+                    Axes.ROUND: (selector[Axes.ROUND]),
+                    Axes.CH: (selector[Axes.CH]),
+                },
+                image.shape,
+                extras=image.extras,
+            )
+======= end
             tile.set_numpy_array_future(image.tile_data)
             # Astute readers might wonder why we set this variable.  This is to support in-place
             # experiment construction.  We monkey-patch slicedimage's Tile class such that checksum

--- a/starfish/core/imagestack/test/factories/synthetic_stack.py
+++ b/starfish/core/imagestack/test/factories/synthetic_stack.py
@@ -1,5 +1,11 @@
+from typing import Optional, Sequence
+
 from starfish.core.experiment.builder import build_image, TileFetcher
-from starfish.core.experiment.builder.defaultproviders import OnesTile, tile_fetcher_factory
+from starfish.core.experiment.builder.defaultproviders import (
+    OnesTile,
+    strip_z_coordinates,
+    tile_fetcher_factory,
+)
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Axes
 
@@ -11,6 +17,7 @@ def synthetic_stack(
         tile_height: int = 50,
         tile_width: int = 40,
         tile_fetcher: TileFetcher = None,
+        force_z: bool = True
 ) -> ImageStack:
     """generate a synthetic ImageStack
 
@@ -28,11 +35,18 @@ def synthetic_stack(
             {Axes.Y: tile_height, Axes.X: tile_width},
         )
 
+    zplanes: Optional[Sequence[int]]
+    if num_z != 1 or force_z:
+        zplanes = range(num_z)
+    else:
+        zplanes = None
+        tile_fetcher = strip_z_coordinates(tile_fetcher)
+
     collection = build_image(
         range(1),
         range(num_round),
         range(num_ch),
-        range(num_z),
+        zplanes,
         tile_fetcher,
     )
     tileset = list(collection.all_tilesets())[0][1]


### PR DESCRIPTION
This is a debatable PR.  This adds support to our factories to build 4D datasets.  This makes it easier to test our data loading paths for 4D datasets, but it does come at the cost of significantly complicating the codebase.  I wrote it and some tests, but was reluctant to send it out.  However, before I junk it, I wanted to check with the rest of you. :) 

If we want to test our code against datasets where Z is not provided, we need to be able to build synthetic datasets where Z is not provided.  This is the tooling to make such datasets (not ImageStacks!).  This means the TileSet is fundamentally 4D, with no zplanes, and no z coordinates.