### PR TITLE
Handle denormalized numbers when normalizing intensities/codebooks

### DIFF
--- a/starfish/core/codebook/codebook.py
+++ b/starfish/core/codebook/codebook.py
@@ -450,7 +450,7 @@ class Codebook(xr.DataArray):
         # if a feature is all zero, the information should be spread across the channel
         n = array.sizes[Axes.CH.value] * array.sizes[Axes.ROUND.value]
         partitioned_intensity = np.linalg.norm(np.full(n, fill_value=1 / n), ord=norm_order) / n
-        array = array.fillna(partitioned_intensity)
+        array.values[np.logical_not(np.isfinite(array.values))] = partitioned_intensity
 
         return array, norm
 


### PR DESCRIPTION
When there are intensities that are near-zero (due to numpy generating some denorm-to-zero values instead of zeros), we sometimes get near-zero total intensity.  When we normalize that, we get infinite values.  Instead of using `fillna`, we replace anything that is not finite with the partitioned value.

Test plan: `make fast` and on the linux docker container, I verified that the code snipped posted by @richardque works now.

Fixes #1365