### PR TITLE
Pre-calculate xmin,xmax,ymin,ymax attrs on IntensityTable before overlap processing 

### DIFF
--- a/starfish/core/intensity_table/intensity_table.py
+++ b/starfish/core/intensity_table/intensity_table.py
@@ -153,8 +153,6 @@ class IntensityTable(xr.DataArray):
             5D tensor.
         round_values : Sequence[int]
             The possible values for the round number, in the order that they are in the ImageStack
-        bbox: Optional[Mapping[PhysicalCoordinateTypes, float]]
-            The bounding box of physical space the intensity table exists in.
         args :
             Additional arguments to pass to the xarray constructor.
         kwargs :
@@ -434,7 +432,7 @@ class IntensityTable(xr.DataArray):
             intensity_data,
             pixel_coordinates,
             image_stack.axis_labels(Axes.CH),
-            image_stack.axis_labels(Axes.ROUND)
+            image_stack.axis_labels(Axes.ROUND),
         )
 
     @staticmethod
@@ -454,7 +452,6 @@ class IntensityTable(xr.DataArray):
         Find the overlapping sections between IntensityTables and process them according
         to the given overlap strategy
         """
-
         overlap_pairs = find_overlaps_of_xarrays(intensity_tables)
         for indices in overlap_pairs:
             overlap_method = OVERLAP_STRATEGY_MAP[overlap_strategy]

--- a/starfish/core/intensity_table/intensity_table.py
+++ b/starfish/core/intensity_table/intensity_table.py
@@ -14,12 +14,13 @@ from starfish.core.types import (
     Features,
     LOG,
     OverlapStrategy,
+    PhysicalCoordinateTypes,
     SpotAttributes,
-    STARFISH_EXTRAS_KEY, PhysicalCoordinateTypes)
+    STARFISH_EXTRAS_KEY)
 from starfish.core.util.dtype import preserve_float_range
 from .overlap import (
-    OVERLAP_STRATEGY_MAP,
-    find_overlaps_of_xarrays)
+    find_overlaps_of_xarrays,
+    OVERLAP_STRATEGY_MAP)
 
 
 class IntensityTable(xr.DataArray):
@@ -191,7 +192,8 @@ class IntensityTable(xr.DataArray):
         dims = (Features.AXIS, Axes.CH.value, Axes.ROUND.value)
 
         intensities = cls(intensities, coords, dims, *args, **kwargs)
-        intensities._set_bbox_attrs(intensities, bbox)
+        if intensities.has_physical_coords:
+            intensities._set_bbox_attrs(intensities, bbox)
         return intensities
 
     def get_log(self):
@@ -288,7 +290,6 @@ class IntensityTable(xr.DataArray):
                 PhysicalCoordinateTypes.X_MAX.value not in intensity_table.attrs:
             IntensityTable._set_bbox_attrs(intensity_table)
         return intensity_table
-
 
     @classmethod
     def synthetic_intensities(
@@ -486,7 +487,6 @@ class IntensityTable(xr.DataArray):
             intensity_tables[idx1] = it1
             intensity_tables[idx2] = it2
         return intensity_tables
-
 
     @staticmethod
     def concatenate_intensity_tables(

--- a/starfish/core/intensity_table/overlap.py
+++ b/starfish/core/intensity_table/overlap.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Sequence, Tuple
 
 import xarray as xr
 
-from starfish.core.types import Coordinates, Features, Number, OverlapStrategy
+from starfish.core.types import Features, Number, OverlapStrategy, PhysicalCoordinateTypes
 
 
 class Area:
@@ -66,15 +66,15 @@ def find_overlaps_of_xarrays(xarrays: Sequence[xr.DataArray]) -> Sequence[Tuple[
     for idx1, idx2 in itertools.combinations(range(len(xarrays)), 2):
         xr1 = xarrays[idx1]
         xr2 = xarrays[idx2]
-        area1 = Area(min(xr1[Coordinates.X.value]).data,
-                     max(xr1[Coordinates.X.value]).data,
-                     min(xr1[Coordinates.Y.value]).data,
-                     max(xr1[Coordinates.Y.value]).data)
+        area1 = Area(xr1.attrs[PhysicalCoordinateTypes.X_MIN],
+                     xr1.attrs[PhysicalCoordinateTypes.X_MAX],
+                     xr1.attrs[PhysicalCoordinateTypes.Y_MIN],
+                     xr1.attrs[PhysicalCoordinateTypes.Y_MAX])
 
-        area2 = Area(min(xr2[Coordinates.X.value]).data,
-                     max(xr2[Coordinates.X.value]).data,
-                     min(xr2[Coordinates.Y.value]).data,
-                     max(xr2[Coordinates.Y.value]).data)
+        area2 = Area(xr2.attrs[PhysicalCoordinateTypes.X_MIN],
+                     xr2.attrs[PhysicalCoordinateTypes.X_MAX],
+                     xr2.attrs[PhysicalCoordinateTypes.Y_MIN],
+                     xr2.attrs[PhysicalCoordinateTypes.Y_MAX])
         if Area._overlap(area1, area2):
             all_overlaps.append((idx1, idx2))
     return all_overlaps
@@ -137,15 +137,15 @@ def take_max(it1: xr.DataArray, it2: xr.DataArray):
     it2 : xr.DataArray
         The second overlapping xarray
     """
-    area1 = Area(min(it1[Coordinates.X.value]).data,
-                 max(it1[Coordinates.X.value]).data,
-                 min(it1[Coordinates.Y.value]).data,
-                 max(it1[Coordinates.Y.value]).data)
+    area1 = Area(it1.attrs[PhysicalCoordinateTypes.X_MIN],
+                 it1.attrs[PhysicalCoordinateTypes.X_MAX],
+                 it1.attrs[PhysicalCoordinateTypes.Y_MIN],
+                 it1.attrs[PhysicalCoordinateTypes.Y_MAX])
 
-    area2 = Area(min(it2[Coordinates.X.value]).data,
-                 max(it2[Coordinates.X.value]).data,
-                 min(it2[Coordinates.Y.value]).data,
-                 max(it2[Coordinates.Y.value]).data)
+    area2 = Area(it2.attrs[PhysicalCoordinateTypes.X_MIN],
+                 it2.attrs[PhysicalCoordinateTypes.X_MAX],
+                 it2.attrs[PhysicalCoordinateTypes.Y_MIN],
+                 it2.attrs[PhysicalCoordinateTypes.Y_MAX])
     intersection_rect = Area.find_intersection(area1, area2)
     if not intersection_rect:
         raise ValueError("The given xarrays do not overlap")

--- a/starfish/core/intensity_table/test/factories.py
+++ b/starfish/core/intensity_table/test/factories.py
@@ -36,4 +36,5 @@ def create_intensity_table_with_coords(area: Area, n_spots: int=10) -> Intensity
                                            dims=Features.AXIS)
     it[Coordinates.Y.value] = xr.DataArray(np.linspace(area.min_y, area.max_y, n_spots),
                                            dims=Features.AXIS)
+    IntensityTable._set_bbox_attrs(it)
     return it

--- a/starfish/core/intensity_table/test/factories.py
+++ b/starfish/core/intensity_table/test/factories.py
@@ -36,5 +36,4 @@ def create_intensity_table_with_coords(area: Area, n_spots: int=10) -> Intensity
                                            dims=Features.AXIS)
     it[Coordinates.Y.value] = xr.DataArray(np.linspace(area.min_y, area.max_y, n_spots),
                                            dims=Features.AXIS)
-    IntensityTable._set_bbox_attrs(it)
     return it

--- a/starfish/core/intensity_table/test/test_overlap.py
+++ b/starfish/core/intensity_table/test/test_overlap.py
@@ -57,7 +57,8 @@ def test_find_overlaps_of_xarrays():
                                                   min_y=0, max_y=1))
     it3 = create_intensity_table_with_coords(Area(min_x=0, max_x=1,
                                                   min_y=1, max_y=2))
-    overlaps = find_overlaps_of_xarrays([it0, it1, it2, it3])
+    its = list(map(IntensityTable._set_bbox_attrs, [it0, it1, it2, it3]))
+    overlaps = find_overlaps_of_xarrays(its)
     # should have 4 total overlaps
     assert len(overlaps) == 4
     # overlap 1 between it0 and it1:


### PR DESCRIPTION
This specifically addresses #1363. The slowdown was due to repeatedly recalculating the min/max physical coordinates on the IntensityTables when trying to find overlaps. By calculating and storing the bounding box coordinates first, `IntensityTable.concatenate_intensity_tables(overlap_strategy=TAKE_MAX)` on the three tables provided by @njmei  was reduced from 479.860 seconds to 148.285 seconds. This should also scale much better (linearly) now since we only do the expensive min/max calculations once per intensity table at the beginning.  