### PR TITLE
using numpy min/max functions for calculating IntensityTable overlaps

### DIFF
--- a/starfish/core/intensity_table/overlap.py
+++ b/starfish/core/intensity_table/overlap.py
@@ -1,6 +1,7 @@
 import itertools
 from typing import List, Optional, Sequence, Tuple
 
+import numpy as np
 import xarray as xr
 
 from starfish.core.types import Coordinates, Features, Number, OverlapStrategy
@@ -66,15 +67,15 @@ def find_overlaps_of_xarrays(xarrays: Sequence[xr.DataArray]) -> Sequence[Tuple[
     for idx1, idx2 in itertools.combinations(range(len(xarrays)), 2):
         xr1 = xarrays[idx1]
         xr2 = xarrays[idx2]
-        area1 = Area(min(xr1[Coordinates.X.value]).data,
-                     max(xr1[Coordinates.X.value]).data,
-                     min(xr1[Coordinates.Y.value]).data,
-                     max(xr1[Coordinates.Y.value]).data)
+        area1 = Area(np.min(xr1[Coordinates.X.value]),
+                     np.max(xr1[Coordinates.X.value]),
+                     np.min(xr1[Coordinates.Y.value]),
+                     np.max(xr1[Coordinates.Y.value]))
 
-        area2 = Area(min(xr2[Coordinates.X.value]).data,
-                     max(xr2[Coordinates.X.value]).data,
-                     min(xr2[Coordinates.Y.value]).data,
-                     max(xr2[Coordinates.Y.value]).data)
+        area2 = Area(np.min(xr2[Coordinates.X.value]),
+                     np.max(xr2[Coordinates.X.value]),
+                     np.min(xr2[Coordinates.Y.value]),
+                     np.max(xr2[Coordinates.Y.value]))
         if Area._overlap(area1, area2):
             all_overlaps.append((idx1, idx2))
     return all_overlaps
@@ -137,15 +138,15 @@ def take_max(it1: xr.DataArray, it2: xr.DataArray):
     it2 : xr.DataArray
         The second overlapping xarray
     """
-    area1 = Area(min(it1[Coordinates.X.value]).data,
-                 max(it1[Coordinates.X.value]).data,
-                 min(it1[Coordinates.Y.value]).data,
-                 max(it1[Coordinates.Y.value]).data)
+    area1 = Area(np.min(it1[Coordinates.X.value]),
+                 np.max(it1[Coordinates.X.value]),
+                 np.min(it1[Coordinates.Y.value]),
+                 np.max(it1[Coordinates.Y.value]))
 
-    area2 = Area(min(it2[Coordinates.X.value]).data,
-                 max(it2[Coordinates.X.value]).data,
-                 min(it2[Coordinates.Y.value]).data,
-                 max(it2[Coordinates.Y.value]).data)
+    area2 = Area(np.min(it2[Coordinates.X.value]),
+                 np.max(it2[Coordinates.X.value]),
+                 np.min(it2[Coordinates.Y.value]),
+                 np.max(it2[Coordinates.Y.value]))
     intersection_rect = Area.find_intersection(area1, area2)
     if not intersection_rect:
         raise ValueError("The given xarrays do not overlap")


### PR DESCRIPTION
Regular min/max was doing some crazy sorting on our xarray coords. 

This take advantage of numpy's built in min/max functions and Speeds up `IntensityTable.concatenate_intensity_tables(overlap_strategy=TAKE_MAX`) on the three tables provided by @njmei  from 479.860 seconds to  0.216 seconds.

fixes: #1363 