### PR TITLE
clean up max projection

### DIFF
--- a/starfish/core/_display.py
+++ b/starfish/core/_display.py
@@ -235,7 +235,7 @@ def display(
 
     if stack is not None:
         if project_axes is not None:
-            stack = stack.max_proj(*project_axes)
+            stack = stack.reduce(project_axes, func="max")
 
         viewer.add_image(stack.xarray.values,
                          rgb=False,

--- a/starfish/core/errors.py
+++ b/starfish/core/errors.py
@@ -1,3 +1,10 @@
+class DeprecatedAPIError(Exception):
+    """
+    Raised when using an API that has been deprecated.
+    """
+    pass
+
+
 class DataFormatWarning(Warning):
     """
     Warnings given by starfish when the data is not formatted as expected, though not fatally.

--- a/starfish/core/image/Filter/test/test_api_contract.py
+++ b/starfish/core/image/Filter/test/test_api_contract.py
@@ -7,9 +7,7 @@ Contract
 - constructor accepts 3d and 2d data, where default is 2d
 - values emitted by a filter are floats between 0 and 1 (inclusive)
 - exposes a `run`() method
-- run accepts an in-place parameter which defaults to True
 - run always returns an ImageStack (if in-place, returns a reference to the modified input data)
-- run accepts an `n_processes` parameter which determines
 - run accepts a `verbose` parameter, which triggers tqdm to print progress
 
 To add a new filter, simply add default

--- a/starfish/core/image/Segment/watershed.py
+++ b/starfish/core/image/Segment/watershed.py
@@ -76,7 +76,7 @@ class Watershed(SegmentAlgorithm):
         """
 
         # create a 'stain' for segmentation
-        mp = primary_images.max_proj(Axes.CH, Axes.ZPLANE)
+        mp = primary_images.reduce({Axes.CH, Axes.ZPLANE}, func="max")
         mp_numpy = mp._squeezed_numpy(Axes.CH, Axes.ZPLANE)
         stain = np.mean(mp_numpy, axis=0)
         stain = stain / stain.max()
@@ -86,7 +86,7 @@ class Watershed(SegmentAlgorithm):
         disk_size_markers = None
         disk_size_mask = None
 
-        nuclei_mp = nuclei.max_proj(Axes.ROUND, Axes.CH, Axes.ZPLANE)
+        nuclei_mp = nuclei.reduce({Axes.ROUND, Axes.CH, Axes.ZPLANE}, func="max")
         nuclei__mp_numpy = nuclei_mp._squeezed_numpy(Axes.ROUND, Axes.CH, Axes.ZPLANE)
         self._segmentation_instance = _WatershedSegmenter(nuclei__mp_numpy, stain)
         label_image = self._segmentation_instance.segment(

--- a/starfish/core/image/_registration/ApplyTransform/test/test_warp.py
+++ b/starfish/core/image/_registration/ApplyTransform/test/test_warp.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from starfish import data
+from starfish.core.image import Filter
 from starfish.core.image._registration.ApplyTransform.warp import Warp
 from starfish.core.image._registration.LearnTransform.translation import Translation
 from starfish.core.types import Axes
@@ -35,7 +36,7 @@ def test_calculate_translation_transforms_and_apply():
     reference_stack = exp.fov().get_image('dots')
     translation = Translation(reference_stack=reference_stack, axes=Axes.ROUND)
     # Calculate max_proj accrss
-    mp = stack.max_proj(Axes.CH, Axes.ZPLANE)
+    mp = Filter.Reduce((Axes.CH, Axes.ZPLANE)).run(stack)
     transform_list = translation.run(mp)
     apply_transform = Warp()
     warped_stack = apply_transform.run(stack=stack, transforms_list=transform_list)

--- a/starfish/core/image/_registration/LearnTransform/test/test_translation.py
+++ b/starfish/core/image/_registration/LearnTransform/test/test_translation.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from starfish import data
+from starfish.core.image import Filter
 from starfish.core.image._registration.LearnTransform.translation import Translation
 from starfish.core.types import Axes
 
@@ -26,7 +27,7 @@ def test_learn_transforms_translation():
     reference_stack = exp.fov().get_image('dots')
     translation = Translation(reference_stack=reference_stack, axes=Axes.ROUND)
     # Calculate max_proj accrss CH/Z
-    stack = stack.max_proj(Axes.CH, Axes.ZPLANE)
+    stack = Filter.Reduce((Axes.CH, Axes.ZPLANE)).run(stack)
     transform_list = translation.run(stack)
     # assert there's a transofrmation object for each round
     assert len(transform_list.transforms) == stack.num_rounds

--- a/starfish/core/image/_registration/test/test_transforms_list.py
+++ b/starfish/core/image/_registration/test/test_transforms_list.py
@@ -3,6 +3,7 @@ import tempfile
 import numpy as np
 
 from starfish import data
+from starfish.core.image import Filter
 from starfish.core.image._registration.LearnTransform.translation import Translation
 from starfish.core.image._registration.transforms_list import TransformsList
 from starfish.core.types import Axes, TransformType
@@ -17,7 +18,7 @@ def test_export_import_transforms_object():
     reference_stack = exp.fov().get_image('dots')
     translation = Translation(reference_stack=reference_stack, axes=Axes.ROUND)
     # Calculate max_proj accrss CH/Z
-    stack = stack.max_proj(Axes.CH, Axes.ZPLANE)
+    stack = Filter.Reduce((Axes.CH, Axes.ZPLANE)).run(stack)
     transform_list = translation.run(stack)
     _, filename = tempfile.mkstemp()
     # save to tempfile and import

--- a/starfish/core/imagestack/imagestack.py
+++ b/starfish/core/imagestack/imagestack.py
@@ -40,7 +40,7 @@ from slicedimage.io import resolve_path_or_url
 from tqdm import tqdm
 
 from starfish.core.config import StarfishConfig
-from starfish.core.errors import DataFormatWarning
+from starfish.core.errors import DataFormatWarning, DeprecatedAPIError
 from starfish.core.imagestack import indexing_utils
 from starfish.core.imagestack.parser import TileCollectionData, TileKey
 from starfish.core.imagestack.parser.crop import CropParameters, CroppedTileCollectionData
@@ -1143,36 +1143,11 @@ class ImageStack:
             tile_format=tile_format)
 
     def max_proj(self, *dims: Axes) -> "ImageStack":
-        """return a max projection over one or more axis of the image tensor
-
-        Parameters
-        ----------
-        dims : Axes
-            one or more axes to project over
-
-        Returns
-        -------
-        np.ndarray :
-            max projection
-
         """
-        self._ensure_data_loaded()
-        max_projection = self._data.max([dim.value for dim in dims])
-        max_projection = max_projection.expand_dims(tuple(dim.value for dim in dims))
-        max_projection = max_projection.transpose(*self.xarray.dims)
-        physical_coords: MutableMapping[Coordinates, Sequence[Number]] = {}
-        for axis, coord in (
-                (Axes.X, Coordinates.X),
-                (Axes.Y, Coordinates.Y),
-                (Axes.ZPLANE, Coordinates.Z)):
-            if axis in dims:
-                # this axis was projected out of existence.
-                assert coord.value not in max_projection.coords
-                physical_coords[coord] = [np.average(self._data.coords[coord.value])]
-            else:
-                physical_coords[coord] = max_projection.coords[coord.value]
-        max_proj_stack = ImageStack.from_numpy(max_projection.values, coordinates=physical_coords)
-        return max_proj_stack
+        This method is deprecated.  Please ``ImageStack.reduce(axes, func="max")`` to do max
+        projection operations.
+        """
+        raise DeprecatedAPIError("Please Filter.MaxProject to do max projection operations.")
 
     def _squeezed_numpy(self, *dims: Axes):
         """return this ImageStack's data as a squeezed numpy array"""

--- a/starfish/core/spots/DetectSpots/detect.py
+++ b/starfish/core/spots/DetectSpots/detect.py
@@ -222,7 +222,8 @@ def detect_spots(data_stack: ImageStack,
 
     if reference_image is not None:
         if reference_image_max_projection_axes is not None:
-            reference_image = reference_image.max_proj(*reference_image_max_projection_axes)
+            reference_image = reference_image.reduce(
+                reference_image_max_projection_axes, func="max")
             data_image = reference_image._squeezed_numpy(*reference_image_max_projection_axes)
         else:
             data_image = reference_image.xarray


### PR DESCRIPTION
Remove ImageStack.max_proj. Steer users towards using ImageStack.reduce.

Test plan: travis

Addresses comment in https://github.com/spacetx/starfish/pull/1342/files#r288261378
Fixes #220
Depends on #1548 