### PR TITLE
[RFC] Add TransformsList __repr__

### DIFF
--- a/starfish/core/image/_registration/transforms_list.py
+++ b/starfish/core/image/_registration/transforms_list.py
@@ -37,6 +37,14 @@ class TransformsList:
             self.transforms: List[Tuple[Mapping[Axes, int],
                                         TransformType, GeometricTransform]] = list()
 
+    def __repr__(self) -> str:
+        translation_strings = [
+            f"image_fragment: {t[0]}\ntranslation: y={t[2].translation[0]}, "
+            f"x={t[2].translation[1]}, rotation: {t[2].rotation}, scale: {t[2].scale}"
+            for t in self.transforms
+        ]
+        return "\n".join(translation_strings)
+
     def append(self,
                selectors: Mapping[Axes, int],
                transform_type: TransformType,

--- a/starfish/core/image/_registration/transforms_list.py
+++ b/starfish/core/image/_registration/transforms_list.py
@@ -39,7 +39,7 @@ class TransformsList:
 
     def __repr__(self) -> str:
         translation_strings = [
-            f"image_fragment: {t[0]}\ntranslation: y={t[2].translation[0]}, "
+            f"tile indices: {t[0]}\ntranslation: y={t[2].translation[0]}, "
             f"x={t[2].translation[1]}, rotation: {t[2].rotation}, scale: {t[2].scale}"
             for t in self.transforms
         ]


### PR DESCRIPTION
Right now the TranslationList object is a bit tricky to work with. I often want to print out the translations that I've calculated to test if the data is registered; learning the translations and looking at the results is one of the best non-visual ways to accomplish this. 

Printing out the TranslationList at present returns: 
`<starfish.core.image._registration.transforms_list.TransformsList object at 0x15df55da0>`

This PR adds a `__repr__` that instead prints: 

```
In [10]: translation_list
Out[10]: image_fragment: {<Axes.ROUND: 'r'>: 0, <Axes.ZPLANE: 'z'>: 0, <Axes.CH: 'c'>: 3}
         translation: y=-22.82, x=5.778, rotation: 0.0, scale: 1.0
         image_fragment: {<Axes.ROUND: 'r'>: 1, <Axes.ZPLANE: 'z'>: 0, <Axes.CH: 'c'>: 3}
         translation: y=-22.173, x=1.871, rotation: 0.0, scale: 1.0
         image_fragment: {<Axes.ROUND: 'r'>: 2, <Axes.ZPLANE: 'z'>: 0, <Axes.CH: 'c'>: 3}
         translation: y=-21.899, x=-3.212, rotation: 0.0, scale: 1.0
         image_fragment: {<Axes.ROUND: 'r'>: 3, <Axes.ZPLANE: 'z'>: 0, <Axes.CH: 'c'>: 3}
         translation: y=-14.929, x=-4.391, rotation: 0.0, scale: 1.0
```

However, given that we're talking about extending this class to support `AffineTransform`, which will learn additional information, I wonder if this is adequately general. I propose to merge in this code now, since we only support `SimilarityTransform`, and upgrade the `__repr__` when we've include `AffineTransform`.

Related, @shanaxel42 Something is happening in the learning of the translation that I don't understand. In the ISS notebook, the channels are max-projected, and the resulting data all have `0` as the channel ID when the translation is learned. Yet, here they're presented as applying to channel `3`. 