### PR TITLE
Add concatenate method for ExpressionMatrix

### DIFF
--- a/starfish/core/expression_matrix/concatenate.py
+++ b/starfish/core/expression_matrix/concatenate.py
@@ -21,7 +21,7 @@ def concatenate(expression_matrices: Iterable[ExpressionMatrix]) -> ExpressionMa
     -------
     ExpressionMatrix :
         Concatenated expression matrix containing all input cells. Missing gene values are filled
-        with np.NaN
+        with np.nan
 
     See Also
     --------

--- a/starfish/core/expression_matrix/concatenate.py
+++ b/starfish/core/expression_matrix/concatenate.py
@@ -1,0 +1,32 @@
+from typing import Iterable
+
+import xarray as xr
+
+from starfish.core.types import Features
+from .expression_matrix import ExpressionMatrix
+
+
+def concatenate(expression_matrices: Iterable[ExpressionMatrix]) -> ExpressionMatrix:
+    """Concatenate IntensityTables produced for different fields of view or across imaging rounds
+
+    Expression Matrices are concatenated along the cells axis, and the resulting arrays are stored
+    densely.
+
+    Parameters
+    ----------
+    expression_matrices : Iterable[ExpressionMatrix]
+        iterable (list-like) of expression matrices to combine
+
+    Returns
+    -------
+    ExpressionMatrix :
+        Concatenated expression matrix containing all input cells. Missing gene values are filled
+        with np.NaN
+
+    See Also
+    --------
+    Combine_first: http://xarray.pydata.org/en/stable/combining.html#combine
+
+    """
+    concatenated_matrix: xr.DataArray = xr.concat(list(expression_matrices), Features.CELLS)
+    return ExpressionMatrix(concatenated_matrix)

--- a/starfish/core/expression_matrix/expression_matrix.py
+++ b/starfish/core/expression_matrix/expression_matrix.py
@@ -1,6 +1,7 @@
 import xarray as xr
 
 from starfish.core.util.try_import import try_import
+from starfish.types import Features
 
 
 class ExpressionMatrix(xr.DataArray):
@@ -47,8 +48,8 @@ class ExpressionMatrix(xr.DataArray):
         """
         import loompy
 
-        row_attrs = {k: self['cells'][k].values for k in self['cells'].coords}
-        col_attrs = {k: self['genes'][k].values for k in self['genes'].coords}
+        row_attrs = {k: self[Features.CELLS][k].values for k in self[Features.CELLS].coords}
+        col_attrs = {k: self[Features.GENES][k].values for k in self[Features.GENES].coords}
 
         loompy.create(filename, self.data, row_attrs, col_attrs)
 
@@ -63,8 +64,8 @@ class ExpressionMatrix(xr.DataArray):
         """
         import anndata
 
-        row_attrs = {k: self['cells'][k].values for k in self['cells'].coords}
-        col_attrs = {k: self['genes'][k].values for k in self['genes'].coords}
+        row_attrs = {k: self[Features.CELLS][k].values for k in self[Features.CELLS].coords}
+        col_attrs = {k: self[Features.GENES][k].values for k in self[Features.GENES].coords}
         anndata = anndata.AnnData(self.data, row_attrs, col_attrs)
         anndata.write(filename)
 

--- a/starfish/core/expression_matrix/test/test_concatenate.py
+++ b/starfish/core/expression_matrix/test/test_concatenate.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+from starfish.core.expression_matrix.concatenate import concatenate
+from starfish.core.expression_matrix.expression_matrix import ExpressionMatrix
+from starfish.types import Features
+
+
+def test_concatenate_two_expression_matrices():
+    a_data = np.array(
+        [[0, 1],
+         [1, 0]]
+    )
+    b_data = np.array(
+        [[0],
+         [1]]
+    )
+    dims = [Features.CELLS, Features.GENES]
+    a_coords = [(Features.CELLS, [0, 1]), (Features.GENES, ["x", "y"])]
+    b_coords = [(Features.CELLS, [0, 1]), (Features.GENES, ["x"])]
+
+    a = ExpressionMatrix(a_data, dims=dims, coords=a_coords)
+    b = ExpressionMatrix(b_data, dims=dims, coords=b_coords)
+
+    concatenated = concatenate([a, b])
+
+    expected = np.array(
+        [[0, 1],
+         [1, 0],
+         [0, np.nan],
+         [1, np.nan]]
+    )
+
+    np.testing.assert_equal(concatenated.values, expected)

--- a/starfish/core/intensity_table/concatenate.py
+++ b/starfish/core/intensity_table/concatenate.py
@@ -31,4 +31,5 @@ def concatenate(intensity_tables: Iterable[IntensityTable]) -> IntensityTable:
     Sparse Arrays in xarray: https://github.com/pydata/xarray/issues/1375
     Combine_first: http://xarray.pydata.org/en/stable/combining.html#combine
     """
-    return xr.concat(list(intensity_tables), Features.AXIS)
+    concatenated_intensities: xr.DataArray = xr.concat(list(intensity_tables), Features.AXIS)
+    return IntensityTable(concatenated_intensities)


### PR DESCRIPTION
## Features:
* Add a method to concatenate ExpressionMatrix objects
* Add a test

## Style fixes: 
* Fix constant usage in ExpressionMatrix

## Bug fixes:
* Fix IntensityTable concatenate, which was returning a DataArray instead of an IntensityTable