### PR TITLE
Support for irregular images in the builder

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,4 +1,5 @@
 click
+dataclasses;python_version<"3.7"
 jsonschema
 matplotlib
 numpy != 1.13.0

--- a/starfish/core/experiment/builder/cli.py
+++ b/starfish/core/experiment/builder/cli.py
@@ -4,7 +4,13 @@ from slicedimage import ImageFormat
 
 from starfish.core.types import Axes
 from starfish.core.util import click
-from . import AUX_IMAGE_NAMES, write_experiment_json
+from . import write_experiment_json
+
+
+AUX_IMAGE_NAMES = {
+    'nuclei',
+    'dots',
+}
 
 
 class StarfishIndex(click.ParamType):

--- a/starfish/core/experiment/builder/test/test_build.py
+++ b/starfish/core/experiment/builder/test/test_build.py
@@ -33,11 +33,11 @@ class TestWithBuildData(unittest.TestCase):
         ],
         [
             "starfish", "validate", "manifest",
-            lambda tempdir, *args, **kwargs: os.sep.join([tempdir, "primary_images.json"])
+            lambda tempdir, *args, **kwargs: os.sep.join([tempdir, "primary.json"])
         ],
         [
             "starfish", "validate", "fov",
-            lambda tempdir, *args, **kwargs: os.sep.join([tempdir, "primary_images-fov_000.json"])
+            lambda tempdir, *args, **kwargs: os.sep.join([tempdir, "primary-fov_000.json"])
         ],
     )
 

--- a/starfish/experiment/builder.py
+++ b/starfish/experiment/builder.py
@@ -1,6 +1,9 @@
 from starfish.core.experiment.builder import (   # noqa: F401
     build_image,
+    build_irregular_image,
     inplace,
+    TileIdentifier,
     write_experiment_json,
+    write_irregular_experiment_json,
 )
 from starfish.core.experiment.builder.providers import FetchedTile, TileFetcher  # noqa: F401


### PR DESCRIPTION
Both `build_image` and `write_experiment_json` get an irregular flavor.  In each case, the irregular case accepts an iterator of `TileCoordinate` objects, which record where the tile is in the 5D tensor.  `build_image` and `write_experiment_json` internally call their irregular flavors because they are very generalized.

#1374 introduced `write_labeled_experiment_json`, and this replaces that operation.  We are not deprecating that API because it never made it into a release; we will simply replace it.

Test plan: travis

Fixes #1322