### PR TITLE
Fix smFISH notebook.

### DIFF
--- a/notebooks/py/smFISH.py
+++ b/notebooks/py/smFISH.py
@@ -22,7 +22,6 @@
 #
 #The data consist of 45 images from 1 round, 1 channels, and 33 z-planes. Each image is
 #(2048, 2048) (y, x). There are no test data.
-#
 # EPY: END markdown
 
 # EPY: START code
@@ -118,15 +117,13 @@ def processing_pipeline(
         decoded IntensityTable containing spots matched to the genes they are hybridized against
     """
 
-    print("Loading images...")
-    primary_image = experiment[fov_name].get_image(FieldOfView.PRIMARY_IMAGES)
     all_intensities = list()
     codebook = experiment.codebook
-    
-    images = enumerate(experiment[fov_name].iterate_image_type(FieldOfView.PRIMARY_IMAGES))
+
+    print("Loading images...")
+    images = enumerate(experiment[fov_name].get_images(FieldOfView.PRIMARY_IMAGES))
 
     for image_number, primary_image in images:
-
         print(f"Filtering image {image_number}...")
         filter_kwargs = dict(
             in_place=True,

--- a/notebooks/smFISH.ipynb
+++ b/notebooks/smFISH.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,12 +27,12 @@
     "\n",
     "The data consist of 45 images from 1 round, 1 channels, and 33 z-planes. Each image is\n",
     "(2048, 2048) (y, x). There are no test data.\n",
-    "\n"
+    ""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,12 +57,12 @@
     "The 3d smFISH workflow run by the Allen runs a bandpass filter to remove high and low frequency\n",
     "signal and blurs over z with a 1-pixel gaussian to smooth the signal over the z-axis.\n",
     "\n",
-    "low-intensity signal is (stringently) clipped from the images before and after these filters.\n"
+    "low-intensity signal is (stringently) clipped from the images before and after these filters."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,12 +90,12 @@
     "------------------------------\n",
     "Spots are detected using a spot finder based on trackpy's locate method, which identifies\n",
     "local intensity maxima, and spots are matched to the gene they represent by looking them up in a\n",
-    "codebook that records which (round, channel) matches which gene target.\n"
+    "codebook that records which (round, channel) matches which gene target."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,12 +117,12 @@
    "metadata": {},
    "source": [
     "Construct the pipeline\n",
-    "----------------------\n"
+    "----------------------"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,15 +152,13 @@
     "        decoded IntensityTable containing spots matched to the genes they are hybridized against\n",
     "    \"\"\"\n",
     "\n",
-    "    print(\"Loading images...\")\n",
-    "    primary_image = experiment[fov_name].get_image(FieldOfView.PRIMARY_IMAGES)\n",
     "    all_intensities = list()\n",
     "    codebook = experiment.codebook\n",
-    "    \n",
-    "    images = enumerate(experiment[fov_name].iterate_image_type(FieldOfView.PRIMARY_IMAGES))\n",
+    "\n",
+    "    print(\"Loading images...\")\n",
+    "    images = enumerate(experiment[fov_name].get_images(FieldOfView.PRIMARY_IMAGES))\n",
     "\n",
     "    for image_number, primary_image in images:\n",
-    "\n",
     "        print(f\"Filtering image {image_number}...\")\n",
     "        filter_kwargs = dict(\n",
     "            in_place=True,\n",
@@ -196,36 +194,14 @@
    "metadata": {},
    "source": [
     "Load data, run pipeline, display results\n",
-    "----------------------------------------\n"
+    "----------------------------------------"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Loading images...\n",
-      "100%|██████████| 102/102 [00:05<00:00, 16.85it/s]\n",
-      "100%|██████████| 102/102 [00:06<00:00, 15.73it/s]\n",
-      "Filtering image 0...\n",
-      "Applying Clip...\n",
-      "102it [00:02, 34.11it/s]\n",
-      "Applying Bandpass...\n",
-      "102it [00:13,  7.71it/s]\n",
-      "Applying Gaussian Low Pass...\n",
-      "3it [00:00, 68.09it/s]\n",
-      "Applying Clip...\n",
-      "3it [00:00, 63.69it/s]\n",
-      "Calling spots...\n",
-      "Decoding spots...\n",
-      "Processing complete.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "experiment = starfish.data.allen_smFISH(use_test_data=True)\n",
     "\n",


### PR DESCRIPTION
1. `iterate_image_type` is now deprecated.  Use `get_images` instead.
2. Remove extra call to `get_image(..)`.  The output is not used anywhere.

Test plan: python notebooks/py/smFISH.py