### PR TITLE
Codify the expectation that in-place experiment construction does not rely on TileFetcher data

### DIFF
--- a/starfish/core/experiment/builder/test/inplace_script.py
+++ b/starfish/core/experiment/builder/test/inplace_script.py
@@ -2,10 +2,10 @@ import hashlib
 import os
 import sys
 from pathlib import Path
-from typing import cast, Mapping, Tuple, Union
+from typing import Mapping, Tuple, Union
 
 import numpy as np
-from skimage.io import imread, imsave
+from skimage.io import imsave
 from slicedimage import ImageFormat
 
 from starfish.core.experiment.builder import FetchedTile, TileFetcher, write_experiment_json
@@ -19,7 +19,15 @@ from starfish.core.types import Axes, Coordinates, Number
 SHAPE = {Axes.Y: 500, Axes.X: 1390}
 
 
-class InplaceTile(InplaceFetchedTile):
+def tile_fn(input_dir: Path, prefix: str, fov: int, r: int, ch: int, zplane: int) -> Path:
+    filename = '{}-Z{}-H{}-C{}.tiff'.format(prefix, zplane, r, ch)
+    return input_dir / f"fov_{fov:03}" / filename
+
+
+class ZeroesInplaceTile(InplaceFetchedTile):
+    """These tiles contain all zeroes.  This is irrelevant to the actual experiment construction
+    because we are using in-place mode.  That means we build references to the files already on-disk
+    and any data returned is merely metadata (tile shape, tile coordinates, and tile checksum."""
     def __init__(self, file_path: Path):
         self.file_path = file_path
 
@@ -43,22 +51,21 @@ class InplaceTile(InplaceFetchedTile):
         return hasher.hexdigest()
 
     def tile_data(self) -> np.ndarray:
-        return imread(os.fspath(self.file_path))
+        return np.zeros(shape=(SHAPE[Axes.Y], SHAPE[Axes.X]), dtype=np.float32)
 
     @property
     def filepath(self) -> Path:
         return self.file_path
 
 
-class InplaceFetcher(TileFetcher):
+class ZeroesInplaceFetcher(TileFetcher):
     def __init__(self, input_dir: Path, prefix: str):
         self.input_dir = input_dir
         self.prefix = prefix
 
     def get_tile(self, fov: int, r: int, ch: int, z: int) -> FetchedTile:
-        filename = '{}-Z{}-H{}-C{}.tiff'.format(self.prefix, z, r, ch)
-        file_path = self.input_dir / f"fov_{fov:03}" / filename
-        return InplaceTile(file_path)
+        file_path = tile_fn(self.input_dir, self.prefix, fov, r, ch, z)
+        return ZeroesInplaceTile(file_path)
 
 
 def fov_path_generator(parent_toc_path: Path, toc_name: str) -> Path:
@@ -82,9 +89,9 @@ def format_data(
         tile_format=ImageFormat.TIFF,
         primary_image_dimensions=primary_image_dimensions,
         aux_name_to_dimensions=aux_name_to_dimensions,
-        primary_tile_fetcher=InplaceFetcher(image_dir, FieldOfView.PRIMARY_IMAGES),
+        primary_tile_fetcher=ZeroesInplaceFetcher(image_dir, FieldOfView.PRIMARY_IMAGES),
         aux_tile_fetcher={
-            aux_img_name: InplaceFetcher(image_dir, aux_img_name)
+            aux_img_name: ZeroesInplaceFetcher(image_dir, aux_img_name)
             for aux_img_name in aux_name_to_dimensions.keys()
         },
         postprocess_func=add_codebook,
@@ -95,19 +102,21 @@ def format_data(
 
 
 def write_image(
+        base_path: Path,
+        prefix: str,
         num_fovs: int,
         image_dimensions: Mapping[Union[Axes, str], int],
-        fetcher: InplaceFetcher
 ):
+    """Writes the constituent tiles of an image to disk.  The tiles are made up with random noise.
+    """
     for fov_num in range(num_fovs):
         for r in range(image_dimensions[Axes.ROUND]):
             for ch in range(image_dimensions[Axes.CH]):
                 for zplane in range(image_dimensions[Axes.ZPLANE]):
-                    tile = cast(InplaceFetchedTile, fetcher.get_tile(fov_num, r, ch, zplane))
-                    path = tile.filepath
+                    path = tile_fn(base_path, prefix, fov_num, r, ch, zplane)
                     path.parent.mkdir(parents=True, exist_ok=True)
 
-                    data = np.random.random(size=(SHAPE[Axes.Y], SHAPE[Axes.X]))
+                    data = np.random.random(size=(SHAPE[Axes.Y], SHAPE[Axes.X])).astype(np.float32)
 
                     imsave(os.fspath(path), data, plugin="tifffile")
 
@@ -130,12 +139,10 @@ def write_inplace(path: str, num_fovs: int = 2):
     tmpdir = Path(path)
 
     # write out the image files
-    primary_fetcher = InplaceFetcher(tmpdir, FieldOfView.PRIMARY_IMAGES)
-    write_image(num_fovs, primary_image_dimensions, primary_fetcher)
+    write_image(tmpdir, FieldOfView.PRIMARY_IMAGES, num_fovs, primary_image_dimensions)
 
     for aux_img_name in aux_name_to_dimensions.keys():
-        aux_fetcher = InplaceFetcher(tmpdir, aux_img_name)
-        write_image(num_fovs, aux_name_to_dimensions[aux_img_name], aux_fetcher)
+        write_image(tmpdir, aux_img_name, num_fovs, aux_name_to_dimensions[aux_img_name])
 
     # format the experiment.
     format_data(tmpdir, primary_image_dimensions, aux_name_to_dimensions, num_fovs)


### PR DESCRIPTION
When we construct an experiment in-place, the source data comes from the tiles already on disk.  Therefore, whatever image data we provide the TileFetcher that we pass into `write_experiment_json` should be discarded.  This verifies that the data from the tiles on the disk are what gets constituted into the experiment, and that the data returned by TileFetcher is ignored.

Test plan: passed the test.
Fixes #1388