### PR TITLE
Saxelrod fix element wise

### DIFF
--- a/starfish/core/image/_filter/element_wise_mult.py
+++ b/starfish/core/image/_filter/element_wise_mult.py
@@ -37,6 +37,13 @@ class ElementWiseMultiply(FilterAlgorithmBase):
             raise ValueError("`scale_by_chunk` is not a valid clip_method for ElementWiseMultiply")
         self.clip_method = clip_method
 
+    _DEFAULT_TESTING_PARAMETERS = {
+        "mult_array": xr.DataArray(
+            np.array([[[[[1]]], [[[0.5]]]]]),
+            dims=('r', 'c', 'z', 'y', 'x')
+        )
+    }
+
     def run(
             self,
             stack: ImageStack,

--- a/starfish/core/image/_filter/element_wise_mult.py
+++ b/starfish/core/image/_filter/element_wise_mult.py
@@ -29,20 +29,13 @@ class ElementWiseMultiply(FilterAlgorithmBase):
     """
 
     def __init__(
-        self, mult_array: xr.core.dataarray.DataArray, clip_method: Union[str, Clip] = Clip.CLIP
+        self, mult_array: xr.DataArray, clip_method: Union[str, Clip] = Clip.CLIP
     ) -> None:
 
         self.mult_array = mult_array
         if clip_method == Clip.SCALE_BY_CHUNK:
             raise ValueError("`scale_by_chunk` is not a valid clip_method for ElementWiseMultiply")
         self.clip_method = clip_method
-
-    _DEFAULT_TESTING_PARAMETERS = {
-        "mult_array": xr.DataArray(
-            np.array([[[[[1]]], [[[0.5]]]]]),
-            dims=('r', 'c', 'z', 'y', 'x')
-        )
-    }
 
     def run(
             self,
@@ -78,12 +71,11 @@ class ElementWiseMultiply(FilterAlgorithmBase):
         if not in_place:
             stack = deepcopy(stack)
 
-        # stack._data contains the xarray
-        stack._data *= mult_array_aligned
+        stack._data.data.values *= mult_array_aligned
         if self.clip_method == Clip.CLIP:
-            stack._data = preserve_float_range(stack._data, rescale=False)
+            stack._data.data.values = preserve_float_range(stack._data.data.values, rescale=False)
         else:
-            stack._data = preserve_float_range(stack._data, rescale=True)
+            stack._data.data.values = preserve_float_range(stack._data.data.values, rescale=True)
         return stack
 
     @staticmethod

--- a/starfish/core/image/_filter/test/test_filter.py
+++ b/starfish/core/image/_filter/test/test_filter.py
@@ -1,8 +1,8 @@
 from typing import Tuple, Union
 
 import numpy as np
-import xarray as xr
 import pytest
+import xarray as xr
 
 from starfish.core.image._filter import element_wise_mult, gaussian_high_pass, mean_high_pass
 from starfish.core.imagestack.imagestack import ImageStack
@@ -46,12 +46,10 @@ def test_mean_high_pass(size: Union[Number, Tuple[Number]], is_volume: bool) -> 
 def test_element_wise_mult() -> None:
     image_stack = random_data_image_stack_factory()
     mult_array = xr.DataArray(
-            np.array([[[[[0.5]]]]]),
-            dims=('r', 'c', 'z', 'y', 'x')
-        )
+        np.array([[[[[0.5]]]]]),
+        dims=('r', 'c', 'z', 'y', 'x')
+    )
     ewm = element_wise_mult.ElementWiseMultiply(mult_array)
     multiplied = ewm.run(image_stack, in_place=False)
     assert isinstance(multiplied.xarray, xr.DataArray)
-    assert multiplied.xarray.equals(image_stack.xarray*.5)
-
-
+    assert multiplied.xarray.equals(image_stack.xarray * .5)

--- a/starfish/core/image/_filter/test/test_filter.py
+++ b/starfish/core/image/_filter/test/test_filter.py
@@ -1,9 +1,10 @@
 from typing import Tuple, Union
 
 import numpy as np
+import xarray as xr
 import pytest
 
-from starfish.core.image._filter import gaussian_high_pass, mean_high_pass
+from starfish.core.image._filter import element_wise_mult, gaussian_high_pass, mean_high_pass
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Clip, Number
 
@@ -40,3 +41,16 @@ def test_mean_high_pass(size: Union[Number, Tuple[Number]], is_volume: bool) -> 
     mhp = mean_high_pass.MeanHighPass(size=size, is_volume=is_volume, clip_method=Clip.CLIP)
     result = mhp.run(image_stack)
     assert np.sum(result.xarray) < sum_before
+
+
+def test_element_wise_mult() -> None:
+    image_stack = random_data_image_stack_factory()
+    mult_array = xr.DataArray(
+            np.array([[[[[0.5]]]]]),
+            dims=('r', 'c', 'z', 'y', 'x')
+        )
+    ewm = element_wise_mult.ElementWiseMultiply(mult_array)
+    ewm.run(image_stack, in_place=True)
+    assert isinstance(image_stack.xarray, xr.DataArray)
+
+

--- a/starfish/core/image/_filter/test/test_filter.py
+++ b/starfish/core/image/_filter/test/test_filter.py
@@ -50,7 +50,8 @@ def test_element_wise_mult() -> None:
             dims=('r', 'c', 'z', 'y', 'x')
         )
     ewm = element_wise_mult.ElementWiseMultiply(mult_array)
-    ewm.run(image_stack, in_place=True)
-    assert isinstance(image_stack.xarray, xr.DataArray)
+    multiplied = ewm.run(image_stack, in_place=False)
+    assert isinstance(multiplied.xarray, xr.DataArray)
+    assert multiplied.xarray.equals(image_stack.xarray*.5)
 
 


### PR DESCRIPTION
Fixes #1145. Asserts that element_wise returns an xarray and adds a test