### PR TITLE
[easy] remove nan code, fix baristaSeq notebook

### DIFF
--- a/notebooks/BaristaSeq.ipynb
+++ b/notebooks/BaristaSeq.ipynb
@@ -454,7 +454,7 @@
     "    *np.unique(pixel_decoded['target'], return_counts=True)[::-1]\n",
     ")\n",
     "\n",
-    "print(pixel_decoded_gene_counts.sort_values(ascending=False).drop(\"nan\")[:20])"
+    "print(pixel_decoded_gene_counts.sort_values(ascending=False)[:20])"
    ]
   }
  ],

--- a/notebooks/py/BaristaSeq.py
+++ b/notebooks/py/BaristaSeq.py
@@ -329,5 +329,5 @@ pixel_decoded_gene_counts = pd.Series(
     *np.unique(pixel_decoded['target'], return_counts=True)[::-1]
 )
 
-print(pixel_decoded_gene_counts.sort_values(ascending=False).drop("nan")[:20])
+print(pixel_decoded_gene_counts.sort_values(ascending=False)[:20])
 # EPY: END code


### PR DESCRIPTION
#1255 removed 'nan's from pixel decoding so the drop('nan') is no longer needed. 