### PR TITLE
[easy] Create a data type for describing a coordinate value.

### DIFF
--- a/docs/source/_static/data_formatting_examples/format_baristaseq.py
+++ b/docs/source/_static/data_formatting_examples/format_baristaseq.py
@@ -9,7 +9,7 @@ docstring for `format_data`
 
 import os
 import shutil
-from typing import Mapping, Tuple, Union
+from typing import Mapping, Union
 
 import click
 import numpy as np
@@ -18,7 +18,7 @@ from slicedimage import ImageFormat
 
 from starfish.experiment.builder import (FetchedTile, TileFetcher,
                                          write_experiment_json)
-from starfish.types import Axes, Coordinates, Number
+from starfish.types import Axes, Coordinates, CoordinateValue
 
 DEFAULT_TILE_SHAPE = {Axes.Y: 1000, Axes.X: 800}
 
@@ -32,7 +32,7 @@ class BaristaSeqTile(FetchedTile):
         return DEFAULT_TILE_SHAPE
 
     @property
-    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+    def coordinates(self) -> Mapping[Union[str, Coordinates], CoordinateValue]:
         # these are dummy coordinates
         return {
             Coordinates.X: (0.0, 0.0001),

--- a/docs/source/_static/data_formatting_examples/format_imc_data.py
+++ b/docs/source/_static/data_formatting_examples/format_imc_data.py
@@ -6,7 +6,7 @@ The following script converts Imaging Cytof Data in SpaceTx-Format
 """
 import json
 import os
-from typing import List, Mapping, Tuple, Union
+from typing import List, Mapping, Union
 
 import click
 import numpy as np
@@ -14,7 +14,7 @@ from skimage.io import imread
 from slicedimage import ImageFormat
 
 from starfish.experiment.builder import FetchedTile, TileFetcher, write_experiment_json
-from starfish.types import Axes, Coordinates, Features, Number
+from starfish.types import Axes, Coordinates, CoordinateValue, Features
 
 
 class ImagingMassCytometryTile(FetchedTile):
@@ -29,7 +29,7 @@ class ImagingMassCytometryTile(FetchedTile):
         return {Axes.Y: self._tile_data.shape[0], Axes.X: self._tile_data.shape[1]}
 
     @property
-    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+    def coordinates(self) -> Mapping[Union[str, Coordinates], CoordinateValue]:
         # TODO ambrosejcarr: ask about what these coordinates should correspond to.
         return {
             Coordinates.X: (0.0, 0.0001),

--- a/docs/source/_static/data_formatting_examples/format_iss_breast_data.py
+++ b/docs/source/_static/data_formatting_examples/format_iss_breast_data.py
@@ -6,7 +6,7 @@ The following script formats In-Situ Sequencing data in SpaceTx-Format
 """
 import argparse
 import os
-from typing import Mapping, Tuple, Union
+from typing import Mapping, Union
 
 import numpy as np
 import pandas as pd
@@ -15,7 +15,7 @@ from slicedimage import ImageFormat
 
 from starfish.core.util.argparse import FsExistsType
 from starfish.experiment.builder import FetchedTile, TileFetcher, write_experiment_json
-from starfish.types import Axes, Coordinates, Number
+from starfish.types import Axes, Coordinates, CoordinateValue
 
 
 class IssCroppedBreastTile(FetchedTile):
@@ -33,7 +33,7 @@ class IssCroppedBreastTile(FetchedTile):
         return {Axes.Y: 1044, Axes.X: 1390}
 
     @property
-    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+    def coordinates(self) -> Mapping[Union[str, Coordinates], CoordinateValue]:
         return self._coordinates
 
     @staticmethod

--- a/docs/source/_static/data_formatting_examples/format_iss_data.py
+++ b/docs/source/_static/data_formatting_examples/format_iss_data.py
@@ -9,7 +9,7 @@ import io
 import json
 import os
 import zipfile
-from typing import Mapping, Tuple, Union
+from typing import Mapping, Union
 
 import numpy as np
 import requests
@@ -19,7 +19,7 @@ from slicedimage import ImageFormat
 from starfish import Codebook
 from starfish.experiment.builder import FetchedTile, TileFetcher
 from starfish.experiment.builder import write_experiment_json
-from starfish.types import Axes, Coordinates, Features, Number
+from starfish.types import Axes, Coordinates, CoordinateValue, Features
 from starfish.util.argparse import FsExistsType
 
 SHAPE = {Axes.Y: 980, Axes.X: 1330}
@@ -34,7 +34,7 @@ class ISSTile(FetchedTile):
         return SHAPE
 
     @property
-    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+    def coordinates(self) -> Mapping[Union[str, Coordinates], CoordinateValue]:
         # FIXME: (dganguli) please provide proper coordinates here.
         return {
             Coordinates.X: (0.0, 0.0001),

--- a/docs/source/_static/data_formatting_examples/format_merfish_U2OS_data.py
+++ b/docs/source/_static/data_formatting_examples/format_merfish_U2OS_data.py
@@ -8,7 +8,7 @@ import argparse
 import functools
 import json
 import os
-from typing import IO, Mapping, Tuple, Union
+from typing import IO, Mapping, Union
 
 import numpy as np
 import pandas as pd
@@ -17,7 +17,7 @@ from slicedimage import ImageFormat
 
 from starfish.core.util.argparse import FsExistsType
 from starfish.experiment.builder import FetchedTile, TileFetcher, write_experiment_json
-from starfish.types import Axes, Coordinates, Number
+from starfish.types import Axes, Coordinates, CoordinateValue
 
 SHAPE = {Axes.Y: 2048, Axes.X: 2048}
 
@@ -60,7 +60,7 @@ class MERFISHTile(FetchedTile):
         return SHAPE
 
     @property
-    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+    def coordinates(self) -> Mapping[Union[str, Coordinates], CoordinateValue]:
         return self._coordinates
 
     def tile_data(self) -> IO:
@@ -78,7 +78,7 @@ class MERFISHAuxTile(FetchedTile):
         return SHAPE
 
     @property
-    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+    def coordinates(self) -> Mapping[Union[str, Coordinates], CoordinateValue]:
         return self._coordinates
 
     def tile_data(self) -> np.ndarray:

--- a/docs/source/_static/data_formatting_examples/format_osmfish.py
+++ b/docs/source/_static/data_formatting_examples/format_osmfish.py
@@ -9,7 +9,7 @@ import functools
 import json
 import os
 import re
-from typing import Mapping, Tuple, Union
+from typing import Mapping, Union
 
 import click
 import numpy as np
@@ -17,7 +17,7 @@ from slicedimage import ImageFormat
 
 import starfish.util.try_import
 from starfish.experiment.builder import FetchedTile, TileFetcher, write_experiment_json
-from starfish.types import Axes, Coordinates, Features, Number
+from starfish.types import Axes, Coordinates, CoordinateValue, Features
 
 
 # We use this to cache images across tiles.  In the case of the osmFISH data set, volumes are saved
@@ -33,7 +33,7 @@ class osmFISHTile(FetchedTile):
     def __init__(
             self,
             file_path: str,
-            coordinates: Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]],
+            coordinates: Mapping[Union[str, Coordinates], CoordinateValue],
             z: int
     ) -> None:
         """Parser for an osmFISH tile.
@@ -42,7 +42,7 @@ class osmFISHTile(FetchedTile):
         ----------
         file_path : str
             location of the osmFISH tile
-        coordinates : Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]
+        coordinates : Mapping[Union[str, Coordinates], CoordinateValue]
             the coordinates for the selected osmFISH tile, extracted from the metadata
         z : int
             the z-layer for the selected osmFISH tile
@@ -64,7 +64,7 @@ class osmFISHTile(FetchedTile):
         return {Axes.Y: raw_shape[0], Axes.X: raw_shape[1]}
 
     @property
-    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+    def coordinates(self) -> Mapping[Union[str, Coordinates], CoordinateValue]:
         return self._coordinates
 
     def tile_data(self) -> np.ndarray:

--- a/docs/source/_static/data_formatting_examples/format_seqFISH.py
+++ b/docs/source/_static/data_formatting_examples/format_seqFISH.py
@@ -6,7 +6,7 @@ The following script formats SeqFISH data in SpaceTx-Format
 """
 import functools
 import os
-from typing import Mapping, Tuple, Union
+from typing import Mapping, Union
 
 import click
 import numpy as np
@@ -16,7 +16,7 @@ from slicedimage import ImageFormat
 
 from starfish import Codebook
 from starfish.experiment.builder import FetchedTile, TileFetcher, write_experiment_json
-from starfish.types import Axes, Coordinates, Features, Number
+from starfish.types import Axes, Coordinates, CoordinateValue, Features
 
 
 # We use this to cache images across tiles.  In the case of the osmFISH data set, volumes are saved
@@ -31,7 +31,7 @@ class SeqFISHTile(FetchedTile):
     def __init__(
             self,
             file_path: str,
-            coordinates: Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]],
+            coordinates: Mapping[Union[str, Coordinates], CoordinateValue],
             zplane: int,
             ch: int,
     ):
@@ -53,7 +53,7 @@ class SeqFISHTile(FetchedTile):
         return {Axes.Y: raw_shape[0], Axes.X: raw_shape[1]}
 
     @property
-    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+    def coordinates(self) -> Mapping[Union[str, Coordinates], CoordinateValue]:
         """Stores coordinate information passed from the TileFetcher"""
         return self._coordinates
 
@@ -74,7 +74,7 @@ class SeqFISHTileFetcher(TileFetcher):
         self.input_dir = input_dir
 
     @property
-    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+    def coordinates(self) -> Mapping[Union[str, Coordinates], CoordinateValue]:
         """Returns dummy coordinates for this single-FoV TileFetcher"""
         return {
             Coordinates.X: (0., 1.),

--- a/starfish/core/experiment/builder/defaultproviders.py
+++ b/starfish/core/experiment/builder/defaultproviders.py
@@ -2,14 +2,14 @@
 This module implements default providers of data to the experiment builders.
 """
 
-from typing import Mapping, Tuple, Type, Union
+from typing import Mapping, Type, Union
 
 import numpy as np
 from slicedimage import (
     ImageFormat,
 )
 
-from starfish.core.types import Axes, Coordinates, Number
+from starfish.core.types import Axes, Coordinates, CoordinateValue
 from .providers import FetchedTile, TileFetcher
 
 
@@ -23,7 +23,7 @@ class RandomNoiseTile(FetchedTile):
         return {Axes.Y: 1536, Axes.X: 1024}
 
     @property
-    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+    def coordinates(self) -> Mapping[Union[str, Coordinates], CoordinateValue]:
         return {
             Coordinates.X: (0.0, 0.0001),
             Coordinates.Y: (0.0, 0.0001),
@@ -53,7 +53,7 @@ class OnesTile(FetchedTile):
         return self._shape
 
     @property
-    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+    def coordinates(self) -> Mapping[Union[str, Coordinates], CoordinateValue]:
         return {
             Coordinates.X: (0.0, 0.0001),
             Coordinates.Y: (0.0, 0.0001),

--- a/starfish/core/experiment/builder/providers.py
+++ b/starfish/core/experiment/builder/providers.py
@@ -2,11 +2,11 @@
 This module describes the contracts to provide data to the experiment builder.
 """
 
-from typing import Mapping, Tuple, Union
+from typing import Mapping, Union
 
 import numpy as np
 
-from starfish.core.types import Axes, Coordinates, Number
+from starfish.core.types import Axes, Coordinates, CoordinateValue
 
 
 class FetchedTile:
@@ -28,12 +28,12 @@ class FetchedTile:
         raise NotImplementedError()
 
     @property
-    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+    def coordinates(self) -> Mapping[Union[str, Coordinates], CoordinateValue]:
         """Return the tile's coordinates in the global coordinate space..
 
         Returns
         -------
-        Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]
+        Mapping[Union[str, Coordinates], CoordinateValue]
             Maps from a coordinate type (e.g. 'x', 'y', or 'z') to its value or range.
         """
         raise NotImplementedError()

--- a/starfish/core/experiment/builder/test/inplace_script.py
+++ b/starfish/core/experiment/builder/test/inplace_script.py
@@ -2,7 +2,7 @@ import hashlib
 import os
 import sys
 from pathlib import Path
-from typing import Mapping, Tuple, Union
+from typing import Mapping, Union
 
 import numpy as np
 from skimage.io import imsave
@@ -13,7 +13,7 @@ from starfish.core.experiment.builder.inplace import (
     enable_inplace_mode, inplace_tile_opener, InplaceFetchedTile
 )
 from starfish.core.experiment.experiment import Experiment, FieldOfView
-from starfish.core.types import Axes, Coordinates, Number
+from starfish.core.types import Axes, Coordinates, CoordinateValue
 
 
 SHAPE = {Axes.Y: 500, Axes.X: 1390}
@@ -36,7 +36,7 @@ class ZeroesInplaceTile(InplaceFetchedTile):
         return SHAPE
 
     @property
-    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+    def coordinates(self) -> Mapping[Union[str, Coordinates], CoordinateValue]:
         return {
             Coordinates.X: (0.0, 0.0001),
             Coordinates.Y: (0.0, 0.0001),

--- a/starfish/core/imagestack/imagestack.py
+++ b/starfish/core/imagestack/imagestack.py
@@ -48,6 +48,7 @@ from starfish.core.types import (
     Axes,
     Clip,
     Coordinates,
+    CoordinateValue,
     LOG,
     Number,
     STARFISH_EXTRAS_KEY
@@ -421,14 +422,14 @@ class ImageStack:
         return stack
 
     def sel_by_physical_coords(
-            self, indexers: Mapping[Coordinates, Union[Number, Tuple[Number, Number]]]):
+            self, indexers: Mapping[Coordinates, CoordinateValue]):
         """
         Given a dictionary mapping the coordinate name to either a value or a range represented as a
         tuple, return an Imagestack with each the Coordinate dimension indexed accordingly.
 
         Parameters
         ----------
-        indexers : Mapping[Coordinates, Union[Number, Tuple[Number, Number]]]:
+        indexers : Mapping[Coordinates, CoordinateValue]:
             A dictionary of coord:index where index is the value or range to index the coordinate
             dimension.
 

--- a/starfish/core/imagestack/indexing_utils.py
+++ b/starfish/core/imagestack/indexing_utils.py
@@ -4,7 +4,7 @@ import numpy as np
 import xarray as xr
 from xarray.core.utils import is_scalar
 
-from starfish.core.types import Axes, Coordinates, Number
+from starfish.core.types import Axes, Coordinates, CoordinateValue
 
 
 def convert_to_selector(
@@ -28,9 +28,10 @@ def convert_to_selector(
     return return_dict
 
 
-def convert_coords_to_indices(array: xr.DataArray,
-                              indexers: Mapping[Coordinates, Union[Number, Tuple[Number, Number]]]
-                              ) -> Dict[Axes, Union[int, Tuple[Number, Number]]]:
+def convert_coords_to_indices(
+        array: xr.DataArray,
+        indexers: Mapping[Coordinates, CoordinateValue],
+) -> Dict[Axes, Union[int, Tuple[int, int]]]:
     """
     Convert mapping of physical coordinates to value or range to mapping of corresponding Axes and
     positional coordinates.
@@ -39,16 +40,16 @@ def convert_coords_to_indices(array: xr.DataArray,
     ----------
     array : xr.DataArray
         The xarray with both physical and positional coordinates.
-    indexers: Mapping[Coordinates, Union[Number, Tuple[Number, Number]]]
+    indexers: Mapping[Coordinates, CoordinateValue]
         Mapping of physical coordinates to value or range
 
     Returns
     -------
-    Mapping[Axes, Union[int, Tuple[Number, Number]]]:
+    Mapping[Axes, Union[int, Tuple[int, int]]]:
         Mapping of Axes and positional indices that correspond to the given physical indices.
 
     """
-    axes_indexers: Dict[Axes, Union[int, Tuple[Number, Number]]] = dict()
+    axes_indexers: Dict[Axes, Union[int, Tuple[int, int]]] = dict()
     if Coordinates.X in indexers:
         idx_x = find_nearest(array[Coordinates.X.value], indexers[Coordinates.X])
         axes_indexers[Axes.X] = idx_x
@@ -97,7 +98,7 @@ def index_keep_dimensions(data: xr.DataArray,
 
 
 def find_nearest(array: xr.DataArray,
-                 value: Union[Number, Tuple[Number, Number]]
+                 value: CoordinateValue
                  ) -> Union[int, Tuple[int, int]]:
     """
     Given an xarray and value or tuple range return the indices of the closest corresponding
@@ -108,7 +109,7 @@ def find_nearest(array: xr.DataArray,
     array: xr.DataArray
         The array to do lookups in.
 
-    value : Union[Number, Tuple[Number, Number]]
+    value : CoordinateValue
         The value or values to lookup.
 
     Returns

--- a/starfish/core/imagestack/test/factories/all_purpose.py
+++ b/starfish/core/imagestack/test/factories/all_purpose.py
@@ -11,7 +11,7 @@ from starfish.core.experiment.builder import (
 )
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.imagestack.parser.crop import CropParameters
-from starfish.core.types import Axes, Coordinates, Number
+from starfish.core.types import Axes, Coordinates, CoordinateValue, Number
 
 
 class LocationAwareFetchedTile(FetchedTile, metaclass=ABCMeta):
@@ -58,8 +58,7 @@ def _apply_coords_range_fetcher(
             return self.backing_tile.shape
 
         @property
-        def coordinates(self) -> Mapping[Union[str, Coordinates],
-                                         Union[Number, Tuple[Number, Number]]]:
+        def coordinates(self) -> Mapping[Union[str, Coordinates], CoordinateValue]:
             zplane_offset = zplanes.index(self.zplane)
             zplane_coords = np.linspace(zrange[0], zrange[1], len(zplanes))
 

--- a/starfish/core/imagestack/test/test_coordinates.py
+++ b/starfish/core/imagestack/test/test_coordinates.py
@@ -4,7 +4,7 @@ import numpy as np
 from slicedimage import ImageFormat
 
 from starfish.core.experiment.builder import FetchedTile, tile_fetcher_factory
-from starfish.types import Axes, Coordinates, Number
+from starfish.types import Axes, Coordinates, CoordinateValue
 from .factories import synthetic_stack
 from .imagestack_test_utils import verify_physical_coordinates
 from ..physical_coordinates import _get_physical_coordinates_of_z_plane
@@ -45,7 +45,7 @@ class AlignedTiles(FetchedTile):
         return {Axes.Y: HEIGHT, Axes.X: WIDTH}
 
     @property
-    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+    def coordinates(self) -> Mapping[Union[str, Coordinates], CoordinateValue]:
         return {
             Coordinates.X: X_COORDS,
             Coordinates.Y: Y_COORDS,
@@ -91,7 +91,7 @@ class ScalarTiles(FetchedTile):
         return {Axes.Y: HEIGHT, Axes.X: WIDTH}
 
     @property
-    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+    def coordinates(self) -> Mapping[Union[str, Coordinates], CoordinateValue]:
         return {
             Coordinates.X: X_COORDS[0],
             Coordinates.Y: Y_COORDS[0],
@@ -117,7 +117,7 @@ class OffsettedTiles(FetchedTile):
         return {Axes.Y: HEIGHT, Axes.X: WIDTH}
 
     @property
-    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+    def coordinates(self) -> Mapping[Union[str, Coordinates], CoordinateValue]:
         return {
             Coordinates.X: round_to_x(self._round),
             Coordinates.Y: round_to_y(self._round),

--- a/starfish/core/imagestack/test/test_slicedimage_dtype.py
+++ b/starfish/core/imagestack/test/test_slicedimage_dtype.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Mapping, Tuple, Union
+from typing import Mapping, Union
 
 import numpy as np
 import pytest
@@ -8,7 +8,7 @@ from slicedimage import ImageFormat
 
 from starfish.core.errors import DataFormatWarning
 from starfish.core.experiment.builder import FetchedTile, TileFetcher
-from starfish.core.types import Axes, Coordinates, Number
+from starfish.core.types import Axes, Coordinates, CoordinateValue
 from .factories import synthetic_stack
 
 NUM_ROUND = 2
@@ -28,7 +28,7 @@ class OnesTilesByDtype(FetchedTile):
         return {Axes.Y: HEIGHT, Axes.X: WIDTH}
 
     @property
-    def coordinates(self) -> Mapping[Union[str, Coordinates], Union[Number, Tuple[Number, Number]]]:
+    def coordinates(self) -> Mapping[Union[str, Coordinates], CoordinateValue]:
         return {
             Coordinates.X: (0.0, 0.0001),
             Coordinates.Y: (0.0, 0.0001),

--- a/starfish/core/types/__init__.py
+++ b/starfish/core/types/__init__.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Tuple, Union
 
 from ._constants import (
     Axes,
@@ -17,3 +17,4 @@ from ._decoded_spots import DecodedSpots
 from ._spot_attributes import SpotAttributes
 
 Number = Union[int, float]
+CoordinateValue = Union[Number, Tuple[Number, Number]]

--- a/starfish/types.py
+++ b/starfish/types.py
@@ -12,4 +12,4 @@ from starfish.core.types import (  # noqa: F401
     STARFISH_EXTRAS_KEY,
     TransformType,
 )
-from starfish.core.types import Number  # noqa: F401
+from starfish.core.types import CoordinateValue, Number  # noqa: F401


### PR DESCRIPTION
It is either a scalar or a range.

Also ninja'ed in the fix for `convert_coords_to_indices` to return a Union[int, Tuple[int, int]], as indexers must be integers.

Test plan: travis