### PR TITLE
[easy] Add FOV-id to unique data generator

### DIFF
--- a/starfish/core/imagestack/test/factories/unique_tiles.py
+++ b/starfish/core/imagestack/test/factories/unique_tiles.py
@@ -16,8 +16,8 @@ Z_COORDS = 0.0001, 0.001
 
 
 def unique_data(
-        round_: int, ch: int, z: int,
-        num_rounds: int, num_chs: int, num_zplanes: int,
+        fov_id: int, round_id: int, ch_id: int, zplane_id: int,
+        num_fovs: int, num_rounds: int, num_chs: int, num_zplanes: int,
         tile_height: int, tile_width: int,
 ) -> np.ndarray:
     """Return the data for a given tile."""
@@ -25,9 +25,10 @@ def unique_data(
     for row in range(tile_height):
         base_val = tile_width * (
             row + tile_height * (
-                z + num_zplanes * (
-                    ch + num_chs * (
-                        round_))))
+                zplane_id + num_zplanes * (
+                    ch_id + num_chs * (
+                        round_id + num_rounds * (
+                            fov_id)))))
 
         result[row:] = np.linspace(base_val, base_val + tile_width, tile_width, False)
     return img_as_float32(result)
@@ -46,15 +47,16 @@ class UniqueTiles(LocationAwareFetchedTile, metaclass=ABCMeta):
     def tile_data(self) -> np.ndarray:
         """Return the data for a given tile."""
         return unique_data(
-            self.rounds.index(self.round),
-            self.chs.index(self.ch),
-            self.zplanes.index(self.zplane),
+            self.fov_id,
+            self.rounds.index(self.round_id),
+            self.chs.index(self.ch_id),
+            self.zplanes.index(self.zplane_id),
+            len(self.fovs),
             len(self.rounds),
             len(self.chs),
             len(self.zplanes),
             self.tile_height,
-            self.tile_width,
-        )
+            self.tile_width)
 
 
 def unique_tiles_imagestack(

--- a/starfish/core/imagestack/test/test_cropped_load.py
+++ b/starfish/core/imagestack/test/test_cropped_load.py
@@ -17,6 +17,7 @@ from ..imagestack import ImageStack
 from ..parser.crop import CropParameters
 
 
+NUM_FOV = 1
 NUM_ROUND = 3
 NUM_CH = 4
 NUM_ZPLANE = 2
@@ -29,7 +30,7 @@ WIDTH = 60
 
 
 def expected_data(round_: int, ch: int, zplane: int):
-    return unique_data(round_, ch, zplane, NUM_ROUND, NUM_CH, NUM_ZPLANE, HEIGHT, WIDTH)
+    return unique_data(0, round_, ch, zplane, NUM_FOV, NUM_ROUND, NUM_CH, NUM_ZPLANE, HEIGHT, WIDTH)
 
 
 def setup_imagestack(crop_parameters: CropParameters) -> ImageStack:

--- a/starfish/core/imagestack/test/test_labeled_indices.py
+++ b/starfish/core/imagestack/test/test_labeled_indices.py
@@ -17,6 +17,7 @@ ZPLANE_LABELS = (3, 4)
 HEIGHT = 2
 WIDTH = 4
 
+NUM_FOV = 1
 NUM_ROUND = len(ROUND_LABELS)
 NUM_CH = len(CH_LABELS)
 NUM_ZPLANE = len(ZPLANE_LABELS)
@@ -24,10 +25,8 @@ NUM_ZPLANE = len(ZPLANE_LABELS)
 
 def expected_data(round_: int, ch: int, zplane: int):
     return unique_data(
-        ROUND_LABELS.index(round_),
-        CH_LABELS.index(ch),
-        ZPLANE_LABELS.index(zplane),
-        NUM_ROUND, NUM_CH, NUM_ZPLANE,
+        0, ROUND_LABELS.index(round_), CH_LABELS.index(ch), ZPLANE_LABELS.index(zplane),
+        NUM_FOV, NUM_ROUND, NUM_CH, NUM_ZPLANE,
         HEIGHT, WIDTH)
 
 


### PR DESCRIPTION
This allows us to generate data that is unique across the entire 6-dimensional tensor.  This helps verify that multi-fov datasets are constructed properly.

Test plan: travis