### PR TITLE
Create a slicedimage Collection factory

### DIFF
--- a/starfish/core/experiment/builder/test/factories/all_purpose.py
+++ b/starfish/core/experiment/builder/test/factories/all_purpose.py
@@ -1,0 +1,128 @@
+from abc import ABCMeta
+from typing import Callable, cast, Collection, Mapping, Sequence, Type, Union
+
+import numpy as np
+import slicedimage
+
+from starfish.core.experiment.builder import (
+    build_irregular_image,
+    FetchedTile,
+    tile_fetcher_factory,
+    TileFetcher,
+    TileIdentifier,
+)
+from starfish.core.types import Axes, Coordinates, CoordinateValue
+
+
+class LocationAwareFetchedTile(FetchedTile, metaclass=ABCMeta):
+    """This is the base class for tiles that are aware of their location in the 5D tensor.
+    """
+    def __init__(
+            self,
+            # these are the arguments passed in as a result of tile_fetcher_factory's
+            # pass_tile_indices parameter.
+            fov_id: int, round_label: int, ch_label: int, zplane_label: int,
+            # these are the arguments we are passing through tile_fetcher_factory.
+            fovs: Sequence[int], rounds: Sequence[int], chs: Sequence[int], zplanes: Sequence[int],
+            tile_height: int, tile_width: int,
+    ) -> None:
+        super().__init__()
+        self.fov_id = fov_id
+        self.round_label = round_label
+        self.ch_label = ch_label
+        self.zplane_label = zplane_label
+        self.fovs = fovs
+        self.rounds = rounds
+        self.chs = chs
+        self.zplanes = zplanes
+        self.tile_height = tile_height
+        self.tile_width = tile_width
+
+
+def _apply_coords_range_fetcher(
+        backing_tile_fetcher: TileFetcher,
+        tile_coordinates_callback: Callable[
+            [TileIdentifier], Mapping[Coordinates, CoordinateValue]],
+) -> TileFetcher:
+    """Given a :py:class:`TileFetcher`, intercept all the returned :py:class:`FetchedTile` instances
+    and replace the coordinates using the coordinates from `tile_coordinates_callback`."""
+    class ModifiedTile(FetchedTile):
+        def __init__(
+                self,
+                backing_tile: FetchedTile,
+                tile_identifier: TileIdentifier,
+                *args, **kwargs
+        ):
+            super().__init__(*args, **kwargs)
+            self.backing_tile = backing_tile
+            self.tile_identifier = tile_identifier
+
+        @property
+        def shape(self) -> Mapping[Axes, int]:
+            return self.backing_tile.shape
+
+        @property
+        def coordinates(self) -> Mapping[Union[str, Coordinates], CoordinateValue]:
+            return cast(
+                Mapping[Union[str, Coordinates], CoordinateValue],
+                tile_coordinates_callback(self.tile_identifier))
+
+        def tile_data(self) -> np.ndarray:
+            return self.backing_tile.tile_data()
+
+    class ModifiedTileFetcher(TileFetcher):
+        def get_tile(self, fov: int, r: int, ch: int, z: int) -> FetchedTile:
+            original_fetched_tile = backing_tile_fetcher.get_tile(fov, r, ch, z)
+            tile_identifier = TileIdentifier(fov, r, ch, z)
+            return ModifiedTile(original_fetched_tile, tile_identifier)
+
+    return ModifiedTileFetcher()
+
+
+def collection_factory(
+        fetched_tile_cls: Type[LocationAwareFetchedTile],
+        tile_identifiers: Collection[TileIdentifier],
+        tile_coordinates_callback: Callable[
+            [TileIdentifier], Mapping[Coordinates, CoordinateValue]],
+        tile_height: int,
+        tile_width: int,
+) -> slicedimage.Collection:
+    """Given a type that implements the :py:class:`LocationAwareFetchedTile` contract, produce a
+    slicedimage Collection with the tiles in `tile_identifiers`.  For a given tile_identifier,
+    retrieve the coordinates by invoking the callback `tile_coordinates_callback`.
+
+    Parameters
+    ----------
+    fetched_tile_cls : Type[LocationAwareFetchedTile]
+        The class of the FetchedTile.
+    tile_identifiers : Collection[TileIdentifier]
+        TileIdentifiers for each of the tiles in the collection.
+    tile_coordinates_callback : Callable[[TileIdentifier], Mapping[Coordinates, CoordinatesValue]]
+        A callable that returns the coordinates for a given tile's TileIdentifier.
+    tile_height : int
+        Height of each tile, in pixels.
+    tile_width : int
+        Width of each tile, in pixels.
+    """
+    all_fov_ids = sorted(set(
+        tile_identifier.fov_id for tile_identifier in tile_identifiers))
+    all_round_labels = sorted(set(
+        tile_identifier.round_id for tile_identifier in tile_identifiers))
+    all_ch_labels = sorted(set(
+        tile_identifier.ch_id for tile_identifier in tile_identifiers))
+    all_zplane_labels = sorted(set(
+        tile_identifier.zplane_id for tile_identifier in tile_identifiers))
+
+    original_tile_fetcher = tile_fetcher_factory(
+        fetched_tile_cls, True,
+        all_fov_ids, all_round_labels, all_ch_labels, all_zplane_labels,
+        tile_height, tile_width,
+    )
+    modified_tile_fetcher = _apply_coords_range_fetcher(
+        original_tile_fetcher, tile_coordinates_callback)
+
+    return build_irregular_image(
+        tile_identifiers,
+        modified_tile_fetcher,
+        default_shape={Axes.Y: tile_height, Axes.X: tile_width}
+    )

--- a/starfish/core/experiment/builder/test/factories/unique_tiles.py
+++ b/starfish/core/experiment/builder/test/factories/unique_tiles.py
@@ -1,0 +1,57 @@
+from abc import ABCMeta
+from typing import Mapping
+
+import numpy as np
+from skimage import img_as_float32
+from slicedimage import ImageFormat
+
+from starfish.core.types import Axes
+from .all_purpose import LocationAwareFetchedTile
+
+X_COORDS = 0.01, 0.1
+Y_COORDS = 0.001, 0.01
+Z_COORDS = 0.0001, 0.001
+
+
+def unique_data(
+        fov_id: int, round_label: int, ch_label: int, zplane_label: int,
+        num_fovs: int, num_rounds: int, num_chs: int, num_zplanes: int,
+        tile_height: int, tile_width: int,
+) -> np.ndarray:
+    """Return the data for a given tile."""
+    result = np.empty((tile_height, tile_width), dtype=np.uint32)
+    for row in range(tile_height):
+        base_val = tile_width * (
+            row + tile_height * (
+                zplane_label + num_zplanes * (
+                    ch_label + num_chs * (
+                        round_label + num_rounds * (
+                            fov_id)))))
+
+        result[row:] = np.linspace(base_val, base_val + tile_width, tile_width, False)
+    return img_as_float32(result)
+
+
+class UniqueTiles(LocationAwareFetchedTile, metaclass=ABCMeta):
+    """Tiles where the pixel values are unique per round/ch/z."""
+    @property
+    def format(self) -> ImageFormat:
+        return ImageFormat.TIFF
+
+    @property
+    def shape(self) -> Mapping[Axes, int]:
+        return {Axes.Y: self.tile_height, Axes.X: self.tile_width}
+
+    def tile_data(self) -> np.ndarray:
+        """Return the data for a given tile."""
+        return unique_data(
+            self.fov_id,
+            self.rounds.index(self.round_label),
+            self.chs.index(self.ch_label),
+            self.zplanes.index(self.zplane_label),
+            len(self.fovs),
+            len(self.rounds),
+            len(self.chs),
+            len(self.zplanes),
+            self.tile_height,
+            self.tile_width)

--- a/starfish/core/imagestack/test/factories/__init__.py
+++ b/starfish/core/imagestack/test/factories/__init__.py
@@ -1,4 +1,4 @@
 from .from_codebook import create_imagestack_from_codebook
 from .synthetic_stack import synthetic_stack
-from .unique_tiles import unique_data, unique_tiles_imagestack
+from .unique_tiles import unique_tiles_imagestack
 from .with_coords import imagestack_with_coords_factory

--- a/starfish/core/imagestack/test/factories/all_purpose.py
+++ b/starfish/core/imagestack/test/factories/all_purpose.py
@@ -1,86 +1,13 @@
-from abc import ABCMeta
-from typing import Mapping, Optional, Sequence, Tuple, Type, Union
+from typing import Callable, Collection, Mapping, Optional, Sequence, Tuple, Type
 
-import numpy as np
-
-from starfish.core.experiment.builder import (
-    build_image,
-    FetchedTile,
-    tile_fetcher_factory,
-    TileFetcher,
+from starfish.core.experiment.builder import TileIdentifier
+from starfish.core.experiment.builder.test.factories.all_purpose import (
+    collection_factory,
+    LocationAwareFetchedTile,
 )
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.imagestack.parser.crop import CropParameters
-from starfish.core.types import Axes, Coordinates, CoordinateValue, Number
-
-
-class LocationAwareFetchedTile(FetchedTile, metaclass=ABCMeta):
-    """This is the base class for tiles that are aware of their location in the 5D tensor.
-    """
-    def __init__(
-            self,
-            # these are the arguments passed in as a result of tile_fetcher_factory's
-            # pass_tile_indices parameter.
-            fov_id: int, round_id: int, ch_id: int, zplane_id: int,
-            # these are the arguments we are passing through tile_fetcher_factory.
-            fovs: Sequence[int], rounds: Sequence[int], chs: Sequence[int], zplanes: Sequence[int],
-            tile_height: int, tile_width: int,
-    ) -> None:
-        super().__init__()
-        self.fov_id = fov_id
-        self.round_id = round_id
-        self.ch_id = ch_id
-        self.zplane_id = zplane_id
-        self.fovs = fovs
-        self.rounds = rounds
-        self.chs = chs
-        self.zplanes = zplanes
-        self.tile_height = tile_height
-        self.tile_width = tile_width
-
-
-def _apply_coords_range_fetcher(
-        backing_tile_fetcher: TileFetcher,
-        zplanes: Sequence[int],
-        fov_to_xrange: Mapping[int, Tuple[Number, Number]],
-        fov_to_yrange: Mapping[int, Tuple[Number, Number]],
-        zrange: Tuple[Number, Number],
-) -> TileFetcher:
-    """Given a :py:class:`TileFetcher`, intercept all the returned :py:class:`FetchedTile` instances
-    and replace the coordinates.  The range for the x and the y coordinates should be fetched from
-    `fov_to_xrange` and `fov_to_yrange`, respectively, using the fov id.  The z coordinates are
-    uniform across all fields of view."""
-    class ModifiedTile(FetchedTile):
-        def __init__(self, backing_tile: FetchedTile, fov: int, zplane: int, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            self.backing_tile = backing_tile
-            self.fov = fov
-            self.zplane = zplane
-
-        @property
-        def shape(self) -> Mapping[Axes, int]:
-            return self.backing_tile.shape
-
-        @property
-        def coordinates(self) -> Mapping[Union[str, Coordinates], CoordinateValue]:
-            zplane_offset = zplanes.index(self.zplane)
-            zplane_coords = np.linspace(zrange[0], zrange[1], len(zplanes))
-
-            return {
-                Coordinates.X: fov_to_xrange[self.fov],
-                Coordinates.Y: fov_to_yrange[self.fov],
-                Coordinates.Z: zplane_coords[zplane_offset],
-            }
-
-        def tile_data(self) -> np.ndarray:
-            return self.backing_tile.tile_data()
-
-    class ModifiedTileFetcher(TileFetcher):
-        def get_tile(self, fov: int, r: int, ch: int, z: int) -> FetchedTile:
-            original_fetched_tile = backing_tile_fetcher.get_tile(fov, r, ch, z)
-            return ModifiedTile(original_fetched_tile, fov, z)
-
-    return ModifiedTileFetcher()
+from starfish.core.types import Coordinates, CoordinateValue, Number
 
 
 def imagestack_factory(
@@ -121,20 +48,35 @@ def imagestack_factory(
     crop_parameters : Optional[CropParameters]
         The crop parameters to apply during ImageStack construction.
     """
-    original_tile_fetcher = tile_fetcher_factory(
-        fetched_tile_cls, True,
-        range(1), round_labels, ch_labels, zplane_labels,
-        tile_height, tile_width,
-    )
-    modified_tile_fetcher = _apply_coords_range_fetcher(
-        original_tile_fetcher, zplane_labels, {0: xrange}, {0: yrange}, zrange)
+    tile_identifiers: Collection[TileIdentifier] = [
+        TileIdentifier(0, round_label, ch_label, zplane_label)
+        for round_label in round_labels
+        for ch_label in ch_labels
+        for zplane_label in zplane_labels
+    ]
 
-    collection = build_image(
-        range(1),
-        round_labels,
-        ch_labels,
-        zplane_labels,
-        modified_tile_fetcher,
+    def make_tile_coordinate_callback(
+            all_zplane_labels: Sequence[int]
+    ) -> Callable[[TileIdentifier], Mapping[Coordinates, CoordinateValue]]:
+        def tile_coordinate_callback(
+                tile_identifier: TileIdentifier
+        ) -> Mapping[Coordinates, CoordinateValue]:
+            zplane_offset = all_zplane_labels.index(tile_identifier.zplane_id)
+            return {
+                Coordinates.X: xrange,
+                Coordinates.Y: yrange,
+                Coordinates.Z: zrange[zplane_offset],
+            }
+
+        return tile_coordinate_callback
+
+    collection = collection_factory(
+        fetched_tile_cls,
+        tile_identifiers,
+        make_tile_coordinate_callback(
+            sorted(set(tile_identifier.zplane_id for tile_identifier in tile_identifiers))),
+        tile_height,
+        tile_width,
     )
     tileset = list(collection.all_tilesets())[0][1]
 

--- a/starfish/core/imagestack/test/factories/unique_tiles.py
+++ b/starfish/core/imagestack/test/factories/unique_tiles.py
@@ -1,62 +1,13 @@
-from abc import ABCMeta
-from typing import Mapping, Optional, Sequence
+from typing import Optional, Sequence
 
-import numpy as np
-from skimage import img_as_float32
-from slicedimage import ImageFormat
-
+from starfish.core.experiment.builder.test.factories.unique_tiles import UniqueTiles
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.imagestack.parser.crop import CropParameters
-from starfish.core.types import Axes
-from .all_purpose import imagestack_factory, LocationAwareFetchedTile
+from .all_purpose import imagestack_factory
 
 X_COORDS = 0.01, 0.1
 Y_COORDS = 0.001, 0.01
 Z_COORDS = 0.0001, 0.001
-
-
-def unique_data(
-        fov_id: int, round_id: int, ch_id: int, zplane_id: int,
-        num_fovs: int, num_rounds: int, num_chs: int, num_zplanes: int,
-        tile_height: int, tile_width: int,
-) -> np.ndarray:
-    """Return the data for a given tile."""
-    result = np.empty((tile_height, tile_width), dtype=np.uint32)
-    for row in range(tile_height):
-        base_val = tile_width * (
-            row + tile_height * (
-                zplane_id + num_zplanes * (
-                    ch_id + num_chs * (
-                        round_id + num_rounds * (
-                            fov_id)))))
-
-        result[row:] = np.linspace(base_val, base_val + tile_width, tile_width, False)
-    return img_as_float32(result)
-
-
-class UniqueTiles(LocationAwareFetchedTile, metaclass=ABCMeta):
-    """Tiles where the pixel values are unique per round/ch/z."""
-    @property
-    def format(self) -> ImageFormat:
-        return ImageFormat.TIFF
-
-    @property
-    def shape(self) -> Mapping[Axes, int]:
-        return {Axes.Y: self.tile_height, Axes.X: self.tile_width}
-
-    def tile_data(self) -> np.ndarray:
-        """Return the data for a given tile."""
-        return unique_data(
-            self.fov_id,
-            self.rounds.index(self.round_id),
-            self.chs.index(self.ch_id),
-            self.zplanes.index(self.zplane_id),
-            len(self.fovs),
-            len(self.rounds),
-            len(self.chs),
-            len(self.zplanes),
-            self.tile_height,
-            self.tile_width)
 
 
 def unique_tiles_imagestack(

--- a/starfish/core/imagestack/test/test_cropped_load.py
+++ b/starfish/core/imagestack/test/test_cropped_load.py
@@ -4,9 +4,10 @@ TileSet.
 """
 import numpy as np
 
+from starfish.core.experiment.builder.test.factories.unique_tiles import unique_data
 from starfish.core.types import Axes
 from .factories.unique_tiles import (
-    unique_data, unique_tiles_imagestack, X_COORDS, Y_COORDS, Z_COORDS,
+    unique_tiles_imagestack, X_COORDS, Y_COORDS, Z_COORDS,
 )
 from .imagestack_test_utils import (
     recalculate_physical_coordinate_range,

--- a/starfish/core/imagestack/test/test_labeled_indices.py
+++ b/starfish/core/imagestack/test/test_labeled_indices.py
@@ -4,9 +4,10 @@ on such an ImageStack work.
 """
 import numpy as np
 
+from starfish.core.experiment.builder.test.factories.unique_tiles import unique_data
 from starfish.types import Axes
 from .factories.unique_tiles import (
-    unique_data, unique_tiles_imagestack, X_COORDS, Y_COORDS, Z_COORDS,
+    unique_tiles_imagestack, X_COORDS, Y_COORDS, Z_COORDS,
 )
 from .imagestack_test_utils import verify_physical_coordinates, verify_stack_data
 from ..imagestack import ImageStack


### PR DESCRIPTION
Currently, we have an ImageStack factory that takes a set of parameters, builds a slicedimage Collection, and then parses that yield the requested ImageStack.

It turns out that building a slicedimage Collection is quite useful if we want to write just a set of tiles and build up the json metadata around it.

This PR extracts the logic that builds the slicedimage Collection, extends it to support multi-FOV collections, and puts it in a separate place.  Then we adapt the ImageStack factory to utilize the slicedimage Collection factory.

Test plan: `pytest -v -n4 starfish/core/imagestack/test`
Depends on #1402, #1403 