### PR TITLE
[easy] Fix the types for verify_physical_coordinates

### DIFF
--- a/starfish/core/imagestack/test/imagestack_test_utils.py
+++ b/starfish/core/imagestack/test/imagestack_test_utils.py
@@ -21,11 +21,13 @@ def verify_stack_data(
     return tile_data, axes
 
 
-def verify_physical_coordinates(stack: ImageStack,
-                                expected_x_coordinates: Tuple[float, float],
-                                expected_y_coordinates: Tuple[float, float],
-                                expected_z_coordinates: Tuple[float, float],
-                                zplane: Optional[int] = None) -> None:
+def verify_physical_coordinates(
+        stack: ImageStack,
+        expected_x_coordinates: Tuple[Number, Number],
+        expected_y_coordinates: Tuple[Number, Number],
+        expected_z_coordinates: Union[Number, Tuple[Number, Number]],
+        zplane: Optional[int] = None,
+) -> None:
     """Given an imagestack and a set of coordinate min/max values verify that the physical
     coordinates on the stack match the expected range of values for each coord dimension.
     """


### PR DESCRIPTION
x/y coordinates has to be a range (i.e., Tuple[Number, Number]).
z can either be any of a range (Tuple[Number, Number], or a single scalar Number, when `zplane` is provided.

Test plan: travis