### PR TITLE
Remove tile_data from set of methods in-place tile construction needs to implement

### DIFF
--- a/starfish/core/experiment/builder/inplace.py
+++ b/starfish/core/experiment/builder/inplace.py
@@ -15,8 +15,10 @@ import sys
 from pathlib import Path
 from typing import BinaryIO
 
+import numpy as np
 from slicedimage import Tile
 
+from starfish.core.types import Axes
 from .providers import FetchedTile
 
 
@@ -72,3 +74,6 @@ class InplaceFetchedTile(FetchedTile):
     def sha256(self):
         """Returns the sha256 checksum of the source tile."""
         raise NotImplementedError()
+
+    def tile_data(self) -> np.ndarray:
+        return np.zeros(shape=(self.shape[Axes.Y], self.shape[Axes.X]), dtype=np.float32)

--- a/starfish/core/experiment/builder/test/inplace_script.py
+++ b/starfish/core/experiment/builder/test/inplace_script.py
@@ -50,9 +50,6 @@ class ZeroesInplaceTile(InplaceFetchedTile):
             hasher.update(fh.read())
         return hasher.hexdigest()
 
-    def tile_data(self) -> np.ndarray:
-        return np.zeros(shape=(SHAPE[Axes.Y], SHAPE[Axes.X]), dtype=np.float32)
-
     @property
     def filepath(self) -> Path:
         return self.file_path


### PR DESCRIPTION
#1389 codifies the expectation that in-place tile construction does not rely on the data from `tile_data()`.  This removes the requirement that in-place tile construction even needs to implement `tile_data()` by providing a default implementation.

Note that this doesn't preclude someone from implementing `tile_data()` (example: the structured data formatter in #1421) for cases where the TileFetcher can be used inplace or non-inplace.

Test plan: travis