### PR TITLE
Fix the path where we find skip files

### DIFF
--- a/notebooks/subdir.mk
+++ b/notebooks/subdir.mk
@@ -16,7 +16,7 @@ regenerate-ipynb: $(ipynb_regenerate_targets)
 regenerate-py: $(py_regenerate_targets)
 
 $(py_run_targets): %.py :
-	[ -e $*.py.skip ] || $(PYTHON) $(pypath)/$*.py
+	[ -e $(pypath)/$*.py.skip ] || $(PYTHON) $(pypath)/$*.py
 
 $(py_files): %.py :
 	[ -e $*.py.skip ] || $(PYTHON) $*.py


### PR DESCRIPTION
This should unbreak the cronjob.  I think I broke this in #1384.  Whoops!