### PR TITLE
Update in-place experiment writing to use the new WriterContract API in slicedimage 4.0.0

### DIFF
--- a/REQUIREMENTS-STRICT.txt
+++ b/REQUIREMENTS-STRICT.txt
@@ -61,7 +61,7 @@ semantic-version==2.6.0
 Send2Trash==1.5.0
 showit==1.1.4
 six==1.12.0
-slicedimage==3.1.2
+slicedimage==4.0.0
 sympy==1.4
 terminado==0.8.2
 testpath==0.4.2

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -10,7 +10,7 @@ scikit-image>=0.14.0
 scikit-learn
 scipy
 showit >= 1.1.4
-slicedimage==3.1.2
+slicedimage==4.0.0
 scikit-learn
 sympy
 tqdm

--- a/starfish/REQUIREMENTS-STRICT.txt
+++ b/starfish/REQUIREMENTS-STRICT.txt
@@ -61,7 +61,7 @@ semantic-version==2.6.0
 Send2Trash==1.5.0
 showit==1.1.4
 six==1.12.0
-slicedimage==3.1.2
+slicedimage==4.0.0
 sympy==1.4
 terminado==0.8.2
 testpath==0.4.2

--- a/starfish/core/experiment/builder/structured_formatter.py
+++ b/starfish/core/experiment/builder/structured_formatter.py
@@ -6,8 +6,6 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import (
-    BinaryIO,
-    Callable,
     cast,
     FrozenSet,
     Mapping,
@@ -20,11 +18,11 @@ from typing import (
 from warnings import warn
 
 import numpy as np
-from slicedimage import ImageFormat, Tile
+from slicedimage import ImageFormat, WriterContract
 
 from starfish.core.types import Axes, Coordinates, CoordinateValue, Number
 from . import TileIdentifier, write_irregular_experiment_json
-from .inplace import enable_inplace_mode, inplace_tile_opener, InplaceFetchedTile
+from .inplace import InplaceFetchedTile, InplaceWriterContract
 from .providers import FetchedTile, TileFetcher
 
 FILENAME_CRE = re.compile(
@@ -130,17 +128,16 @@ def format_structured_dataset(
     }
 
     if in_place:
-        enable_inplace_mode()
-        tile_opener: Optional[Callable[[Path, Tile, str], BinaryIO]] = inplace_tile_opener
+        writer_contract: Optional[WriterContract] = InplaceWriterContract()
     else:
-        tile_opener = None
+        writer_contract = None
 
     write_irregular_experiment_json(
         output_experiment_dir_str,
         tile_format,
         image_tile_identifiers=image_tile_identifiers,
         tile_fetchers=tile_fetchers,
-        tile_opener=tile_opener,
+        writer_contract=writer_contract,
     )
 
 

--- a/starfish/core/experiment/builder/test/inplace_script.py
+++ b/starfish/core/experiment/builder/test/inplace_script.py
@@ -10,7 +10,7 @@ from slicedimage import ImageFormat
 
 from starfish.core.experiment.builder import FetchedTile, TileFetcher, write_experiment_json
 from starfish.core.experiment.builder.inplace import (
-    enable_inplace_mode, inplace_tile_opener, InplaceFetchedTile
+    InplaceFetchedTile, InplaceWriterContract,
 )
 from starfish.core.experiment.experiment import Experiment, FieldOfView
 from starfish.core.types import Axes, Coordinates, CoordinateValue
@@ -80,8 +80,6 @@ def format_data(
         experiment_json_doc['codebook'] = "codebook.json"
         return experiment_json_doc
 
-    enable_inplace_mode()
-
     write_experiment_json(
         path=os.fspath(image_dir),
         fov_count=num_fovs,
@@ -95,8 +93,7 @@ def format_data(
         },
         postprocess_func=add_codebook,
         default_shape=SHAPE,
-        fov_path_generator=fov_path_generator,
-        tile_opener=inplace_tile_opener,
+        writer_contract=InplaceWriterContract(),
     )
 
 


### PR DESCRIPTION
Test plan: in-place experiment writing tests pass.

Note that travis won't succeed until https://github.com/spacetx/slicedimage/pull/109/ is approved and released.