### PR TITLE
Get rid of the check-requirements cron job.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,9 +66,6 @@ jobs:
     - name: Released Notebooks
       if: type = cron and branch =~ /^(master|merge)/
       script: make check-notebooks install-released-notebooks-support run-notebooks
-    - name: Check Requirements
-      if: type = cron and branch =~ /^master$/
-      script: make refresh-all-requirements check-requirements
 cache:
   directories:
   - $HOME/.cache/pip


### PR DESCRIPTION
This will be implemented as a AWS cloudwatch event -> AWS lambda -> travis API push that hits once a week.

This should bring some sanity to our crons.