### PR TITLE
on-demand loading of data.

### DIFF
--- a/starfish/core/image/Filter/reduce.py
+++ b/starfish/core/image/Filter/reduce.py
@@ -180,7 +180,7 @@ class Reduce(FilterAlgorithmBase):
         """
 
         # Apply the reducing function
-        reduced = stack._data.reduce(
+        reduced = stack.xarray.reduce(
             self.func, dim=[Axes(dim).value for dim in self.dims], **self.kwargs)
 
         # Add the reduced dims back and align with the original stack

--- a/starfish/core/image/Filter/zero_by_channel_magnitude.py
+++ b/starfish/core/image/Filter/zero_by_channel_magnitude.py
@@ -61,7 +61,7 @@ class ZeroByChannelMagnitude(FilterAlgorithmBase):
         """
         # The default is False, so even if code requests True require config to be True as well
         verbose = verbose and StarfishConfig().verbose
-        channels_per_round = stack._data.groupby(Axes.ROUND.value)
+        channels_per_round = stack.xarray.groupby(Axes.ROUND.value)
         channels_per_round = tqdm(channels_per_round) if verbose else channels_per_round
 
         if not in_place:

--- a/starfish/core/imagestack/test/test_slicedimage_dtype.py
+++ b/starfish/core/imagestack/test/test_slicedimage_dtype.py
@@ -70,12 +70,13 @@ class CornerDifferentDtype(TileFetcher):
 
 
 def test_multiple_tiles_of_different_kind():
+    stack = synthetic_stack(
+        NUM_ROUND, NUM_CH, NUM_Z,
+        HEIGHT, WIDTH,
+        tile_fetcher=CornerDifferentDtype(np.uint32, np.float32),
+    )
     with pytest.raises(TypeError):
-        synthetic_stack(
-            NUM_ROUND, NUM_CH, NUM_Z,
-            HEIGHT, WIDTH,
-            tile_fetcher=CornerDifferentDtype(np.uint32, np.float32),
-        )
+        stack._ensure_data_loaded()
 
 
 def test_multiple_tiles_of_same_dtype():
@@ -94,12 +95,13 @@ def test_multiple_tiles_of_same_dtype():
 
 
 def test_int_type_promotion():
+    stack = synthetic_stack(
+        NUM_ROUND, NUM_CH, NUM_Z,
+        HEIGHT, WIDTH,
+        tile_fetcher=CornerDifferentDtype(np.int32, np.int8),
+    )
     with warnings.catch_warnings(record=True) as warnings_:
-        stack = synthetic_stack(
-            NUM_ROUND, NUM_CH, NUM_Z,
-            HEIGHT, WIDTH,
-            tile_fetcher=CornerDifferentDtype(np.int32, np.int8),
-        )
+        stack._ensure_data_loaded()
         assert len(warnings_) == 2
         assert issubclass(warnings_[0].category, UserWarning)
         assert issubclass(warnings_[1].category, DataFormatWarning)
@@ -117,12 +119,13 @@ def test_int_type_promotion():
 
 
 def test_uint_type_promotion():
+    stack = synthetic_stack(
+        NUM_ROUND, NUM_CH, NUM_Z,
+        HEIGHT, WIDTH,
+        tile_fetcher=CornerDifferentDtype(np.uint32, np.uint8),
+    )
     with warnings.catch_warnings(record=True) as warnings_:
-        stack = synthetic_stack(
-            NUM_ROUND, NUM_CH, NUM_Z,
-            HEIGHT, WIDTH,
-            tile_fetcher=CornerDifferentDtype(np.uint32, np.uint8),
-        )
+        stack._ensure_data_loaded()
         assert len(warnings_) == 2
         assert issubclass(warnings_[0].category, UserWarning)
         assert issubclass(warnings_[1].category, DataFormatWarning)
@@ -140,12 +143,13 @@ def test_uint_type_promotion():
 
 
 def test_float_type_demotion():
+    stack = synthetic_stack(
+        NUM_ROUND, NUM_CH, NUM_Z,
+        HEIGHT, WIDTH,
+        tile_fetcher=CornerDifferentDtype(np.float64, np.float32),
+    )
     with warnings.catch_warnings(record=True) as warnings_:
-        stack = synthetic_stack(
-            NUM_ROUND, NUM_CH, NUM_Z,
-            HEIGHT, WIDTH,
-            tile_fetcher=CornerDifferentDtype(np.float64, np.float32),
-        )
+        stack._ensure_data_loaded()
         assert len(warnings_) == 2
         assert issubclass(warnings_[0].category, UserWarning)
         assert issubclass(warnings_[1].category, DataFormatWarning)

--- a/starfish/core/multiprocessing/test/test_multiprocessing.py
+++ b/starfish/core/multiprocessing/test/test_multiprocessing.py
@@ -126,7 +126,7 @@ def test_imagestack_deepcopy(nitems: int=10) -> None:
     shape = (nitems, 3, 4, 5, 6)
     dtype = np.float32
     source = np.zeros(shape, dtype=np.float32)
-    imagestack = ImageStack.from_numpy(source)
+    imagestack = ImageStack.from_numpy(source)._ensure_data_loaded()
     imagestack_copy = copy.deepcopy(imagestack)
     _start_process_to_test_shmem(
         array_holder=imagestack_copy._data._backing_mp_array,


### PR DESCRIPTION
The imagestack's xarray is created with coordinates and NaNs for the values.  When someone accesses the `xarray` property, `get_slice()`, `set_slice()` (except when called by the code initializing the data array), `transform()`, `sel()`, or `max_proj()`, the array is initialized with the correct data.

Theoretically, this allows someone to initialize the ImageStack and examine the coordinates without having the tile data read.

Test plan: pass existing tests.