### PR TITLE
downgrade pyparsing

### DIFF
--- a/REQUIREMENTS-STRICT.txt
+++ b/REQUIREMENTS-STRICT.txt
@@ -3,8 +3,8 @@ appnope==0.1.0
 attrs==19.1.0
 backcall==0.1.0
 bleach==3.1.0
-boto3==1.9.192
-botocore==1.12.192
+boto3==1.9.194
+botocore==1.12.194
 certifi==2019.6.16
 chardet==3.0.4
 Click==7.0
@@ -49,7 +49,7 @@ prometheus-client==0.7.1
 prompt-toolkit==2.0.9
 ptyprocess==0.6.0
 Pygments==2.4.2
-pyparsing==2.4.1
+pyparsing==2.4.0
 pyrsistent==0.15.3
 python-dateutil==2.8.0
 pytz==2019.1

--- a/starfish/REQUIREMENTS-STRICT.txt
+++ b/starfish/REQUIREMENTS-STRICT.txt
@@ -3,8 +3,8 @@ appnope==0.1.0
 attrs==19.1.0
 backcall==0.1.0
 bleach==3.1.0
-boto3==1.9.192
-botocore==1.12.192
+boto3==1.9.194
+botocore==1.12.194
 certifi==2019.6.16
 chardet==3.0.4
 Click==7.0
@@ -49,7 +49,7 @@ prometheus-client==0.7.1
 prompt-toolkit==2.0.9
 ptyprocess==0.6.0
 Pygments==2.4.2
-pyparsing==2.4.1
+pyparsing==2.4.0
 pyrsistent==0.15.3
 python-dateutil==2.8.0
 pytz==2019.1


### PR DESCRIPTION
For reasons that are not clear, pyparsing 2.4.1 seems to have been removed.  Following https://github.com/pyparsing/pyparsing/issues/105 to keep an eye on it.