### PR TITLE
Fix docker image build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,6 +43,7 @@ USER starfish
 # Set up the initial conda environment
 COPY --chown=starfish:starfish docker/environment.yml /src/docker/environment.yml
 COPY --chown=starfish:starfish docker/pip-config /src/
+COPY --chown=starfish:starfish docker/condarc /home/starfish/.condarc
 COPY --chown=starfish:starfish REQUIREMENTS* /src/
 WORKDIR /src
 ENV PIP_CONFIG_FILE=/src/pip-config

--- a/docker/condarc
+++ b/docker/condarc
@@ -1,0 +1,2 @@
+pkgs_dirs:
+ - /home/starfish/.conda/pkgs


### PR DESCRIPTION
Newer versions of conda require write access to the [shared package cache](https://support.anaconda.com/hc/en-us/articles/360024035613-Shared-Package-Cache).  Not sure why that was considered a good design choice (would personally make it optional), but this seems to solve the problem by removing the shared cache path from list of package dirs.

Test plan: `make docker` passes.