### PR TITLE
Fix autodoc'ing for Filter

### DIFF
--- a/docs/source/api/image/index.rst
+++ b/docs/source/api/image/index.rst
@@ -23,7 +23,7 @@ Filters can be imported using ``starfish.image.Filter``, which registers all cla
 
     from starfish.image import Filter
 
-.. autoclass:: starfish.image.Filter
+.. automodule:: starfish.image.Filter
    :members:
 
 

--- a/starfish/core/image/Filter/__init__.py
+++ b/starfish/core/image/Filter/__init__.py
@@ -1,3 +1,4 @@
+from ._base import FilterAlgorithmBase
 from .bandpass import Bandpass
 from .clip import Clip
 from .clip_percentile_to_zero import ClipPercentileToZero
@@ -14,3 +15,11 @@ from .reduce import Reduce
 from .richardson_lucy_deconvolution import DeconvolvePSF
 from .white_tophat import WhiteTophat
 from .zero_by_channel_magnitude import ZeroByChannelMagnitude
+
+# autodoc's automodule directive only captures the modules explicitly listed in __all__.
+all_filters = {
+    filter_name: filter_cls
+    for filter_name, filter_cls in locals().items()
+    if isinstance(filter_cls, type) and FilterAlgorithmBase in filter_cls.__mro__
+}
+__all__ = list(all_filters.keys())


### PR DESCRIPTION
automodule [itself isn't sufficient](https://stackoverflow.com/questions/30856279/how-to-use-sphinx-automodule-and-exposed-functions-in-init).  It needs the __all__ variable to be correctly set to automodule.

Fixes #1509