### PR TITLE
funcs passed to apply and transform can use positional arguments

### DIFF
--- a/starfish/core/imagestack/test/test_apply.py
+++ b/starfish/core/imagestack/test/test_apply.py
@@ -21,6 +21,15 @@ def test_apply():
     assert (output.xarray == 0.5).all()
 
 
+def test_apply_positional():
+    """test that apply correctly applies a simple function across 2d tiles of a Stack.  Unlike
+    test_apply, the parameter is passed in as a positional parameter."""
+    stack = synthetic_stack()
+    assert (stack.xarray == 1).all()
+    output = stack.apply(divide, 2, n_processes=1)
+    assert (output.xarray == 0.5).all()
+
+
 def test_apply_3d():
     """test that apply correctly applies a simple function across 3d volumes of a Stack"""
     stack = synthetic_stack()


### PR DESCRIPTION
With the existing code, funcs passed to apply and transform can only use keyword arguments.  This is unnecessarily limiting, and if we want to support #1446, we need to be able to work with a variety of functions with their own argument calling mechanisms.

