### PR TITLE
import SegmentationMaskCollection in main starfish

### DIFF
--- a/starfish/__init__.py
+++ b/starfish/__init__.py
@@ -18,4 +18,5 @@ from .core.experiment.experiment import Experiment, FieldOfView
 from .core.expression_matrix.expression_matrix import ExpressionMatrix
 from .core.imagestack.imagestack import ImageStack
 from .core.intensity_table.intensity_table import IntensityTable
+from .core.segmentation_mask import SegmentationMaskCollection
 from .core.starfish import starfish


### PR DESCRIPTION
Adds an import statement so that `SegmentationMaskCollection` is findable in the root `starfish` module, like our other objects. 