### PR TITLE
Bring existing deprecated methods in compliance with deprecation policy.

### DIFF
--- a/starfish/core/experiment/builder/__init__.py
+++ b/starfish/core/experiment/builder/__init__.py
@@ -236,16 +236,18 @@ def write_irregular_experiment_json(
         Generates the path for a FOV's json file.  If one is not provided, the default generates
         the FOV's json file at the same level as the top-level json file for an image.    If this is
         not provided, a reasonable default will be provided.  If this is provided, writer_contract
-        should not be provided.
+        should not be provided.  This parameter is deprecated and `writer_contract` should be used
+        instead.
     tile_opener : Optional[Callable[[Path, Tile, str], BinaryIO]]
         Callable that gets invoked with the following arguments: 1. the directory of the experiment
         that is being constructed, 2. the tile that is being written, and 3. the file extension
         that the tile should be written with.  The callable is expected to return an open file
         handle.  If this is not provided, a reasonable default will be provided.  If this is
-        provided, writer_contract should not be provided.
+        provided, `writer_contract` should not be provided.  This parameter is deprecated and
+        `writer_contract` should be used instead.
     writer_contract : Optional[WriterContract]
         Contract for specifying how the slicedimage image is to be laid out.  If this is provided,
-        fov_path_generator and tile_opener should not be provided.
+        `fov_path_generator` and `tile_opener` should not be provided.
     """
     if postprocess_func is None:
         postprocess_func = lambda doc: doc

--- a/starfish/core/experiment/builder/inplace.py
+++ b/starfish/core/experiment/builder/inplace.py
@@ -33,6 +33,11 @@ class InplaceWriterContract(WriterContract):
 
 
 def enable_inplace_mode():
+    """
+    .. deprecated:: 0.1.4
+        This method is no longer necessary.  Call `write_experiment_json` with
+        `writer_contract=InplaceWriterContract()`.
+    """
     warnings.warn("`enable_inplace_mode()` is no longer necessary.", DeprecationWarning)
 
 

--- a/starfish/core/experiment/experiment.py
+++ b/starfish/core/experiment/experiment.py
@@ -101,11 +101,19 @@ class FieldOfView:
         return set(self._images.keys())
 
     def show_aligned_image_groups(self) -> None:
+        """
+        .. deprecated:: 0.1.4
+            Use `FieldOfView.get_images()` to retrieve all the aligned image groups.
+        """
         raise DeprecationWarning("This method has been deprecated. Aligned groups are now parsed "
                                  "as a part of, FieldOfView.get_images() and are determined by the "
                                  "selected axes provided to the method.")
 
     def iterate_image_type(self, image_type: str) -> Iterator[ImageStack]:
+        """
+        .. deprecated:: 0.1.4
+            Use `FieldOfView.get_images()` to retrieve all the aligned image groups.
+        """
         raise DeprecationWarning("This method has been deprecated. Instead use "
                                  "FieldOfView.get_images(image_type)")
 

--- a/starfish/core/image/Filter/max_proj.py
+++ b/starfish/core/image/Filter/max_proj.py
@@ -10,6 +10,9 @@ class MaxProject(FilterAlgorithmBase):
     """
     Creates a maximum projection over one or more axis of the image tensor
 
+    .. deprecated:: 0.1.2
+        Use `Filter.Reduce(func='max')` instead.
+
     Parameters
     ----------
     dims : Axes


### PR DESCRIPTION
Add a ..deprecated:: docstring.  This will serve as a helpful example next time someone wants to deprecate something.

Part of #1508