### PR TITLE
only call initializer if it's present

### DIFF
--- a/starfish/core/multiprocessing/pool.py
+++ b/starfish/core/multiprocessing/pool.py
@@ -22,13 +22,15 @@ class Pool:
 
     def map(self, func, iterable, chunksize=None):
         if self.pool is None:
-            self.initializer(*self.initargs)
+            if self.initializer is not None:
+                self.initializer(*self.initargs)
             return map(func, iterable)
         return self.pool.map(func, iterable, chunksize)
 
     def imap(self, func, iterable, chunksize=1):
         if self.pool is None:
-            self.initializer(*self.initargs)
+            if self.initializer is not None:
+                self.initializer(*self.initargs)
             return map(func, iterable)
         return self.pool.imap(func, iterable, chunksize)
 


### PR DESCRIPTION
In our implementation of multiprocessing, we do not actually leverage python's `multiprocessing` module if n_processes=1 or if the OS is NT.  In that case, we call all the code in the current process, current thread.  Part of that involves calling the `multiprocessing.Pool`'s initializer.  However, that is an optional argument, and we don't want to call it if it's not present.