### PR TITLE
don't check frame type when testing decoded spots.

### DIFF
--- a/starfish/core/types/test/test_decoded_spots.py
+++ b/starfish/core/types/test/test_decoded_spots.py
@@ -50,4 +50,4 @@ def test_decoded_spots() -> None:
 
     # load back into memory
     ds2 = DecodedSpots.load_csv(filename)
-    pd.testing.assert_frame_equal(ds.data, ds2.data)
+    pd.testing.assert_frame_equal(ds.data, ds2.data, check_dtype=False)


### PR DESCRIPTION
Generally, it'll all resolve to float32 anyway, but in this test, the autodetected type was int for one column, but was loaded back in as float.  This quirk appears to be specific to Windows, for whatever reason.