### PR TITLE
Add map/reduce methods to ImageStack

### DIFF
--- a/starfish/core/image/Filter/reduce.py
+++ b/starfish/core/image/Filter/reduce.py
@@ -2,7 +2,6 @@ from typing import (
     cast,
     Iterable,
     MutableMapping,
-    Optional,
     Sequence,
     Union
 )
@@ -97,7 +96,7 @@ class Reduce(FilterAlgorithm):
             self,
             stack: ImageStack,
             *args,
-    ) -> Optional[ImageStack]:
+    ) -> ImageStack:
         """Performs the dimension reduction with the specifed function
 
         Parameters
@@ -108,8 +107,7 @@ class Reduce(FilterAlgorithm):
         Returns
         -------
         ImageStack :
-            If in-place is False, return the results of filter as a new stack. Otherwise return the
-            original stack.
+            Return the results of filter as a new stack.
 
         """
 

--- a/starfish/core/imagestack/imagestack.py
+++ b/starfish/core/imagestack/imagestack.py
@@ -11,6 +11,7 @@ from typing import (
     Any,
     Callable,
     Hashable,
+    Iterable,
     Iterator,
     List,
     Mapping,
@@ -50,6 +51,7 @@ from starfish.core.types import (
     Clip,
     Coordinates,
     CoordinateValue,
+    FunctionSource,
     Number,
     STARFISH_EXTRAS_KEY
 )
@@ -1175,3 +1177,50 @@ class ImageStack:
     def _squeezed_numpy(self, *dims: Axes):
         """return this ImageStack's data as a squeezed numpy array"""
         return self.xarray.squeeze(tuple(dim.value for dim in dims)).values
+
+    def reduce(
+            self,
+            dims: Iterable[Union[Axes, str]],
+            func: str,
+            module: FunctionSource = FunctionSource.np,
+            clip_method: Clip = Clip.CLIP,
+            *args,
+            **kwargs) -> "ImageStack":
+        """
+        Reduces the dimensionality of the ImageStack and returns a new ImageStack with the result.
+        This is a shortcut for :py:class:`starfish.image.Filter.Reduce`.
+
+        See Also
+        --------
+        starfish.image.Filter.Reduce
+        """
+        from starfish.core.image import Filter
+
+        reducer = Filter.Reduce(dims, func, module, clip_method, **kwargs)
+        return reducer.run(self, *args)
+
+    def map(
+            self,
+            func: str,
+            module: FunctionSource = FunctionSource.np,
+            in_place: bool = False,
+            group_by: Optional[Set[Union[Axes, str]]] = None,
+            clip_method: Clip = Clip.CLIP,
+            *args,
+            **kwargs) -> Optional["ImageStack"]:
+        """
+        Maps the contents of the ImageStack to produce another image.  This can be done in-place or
+        can produce a new ImageStack.  This is a shortcut for
+        :py:class:`starfish.image.Filter.Map`.
+
+        See Also
+        --------
+        starfish.image.Filter.Map
+        """
+        from starfish.core.image import Filter
+
+        mapper = Filter.Map(
+            func, *args,
+            module=module, in_place=in_place, group_by=group_by, clip_method=clip_method,
+            **kwargs)
+        return mapper.run(self, *args)

--- a/starfish/core/imagestack/test/test_max_proj.py
+++ b/starfish/core/imagestack/test/test_max_proj.py
@@ -14,7 +14,7 @@ def test_max_projection_preserves_dtype():
     array = np.ones((2, 2, 2), dtype=original_dtype)
     image = ImageStack.from_numpy(array.reshape((1, 1, 2, 2, 2)))
 
-    max_projection = image.max_proj(Axes.CH, Axes.ROUND, Axes.ZPLANE)
+    max_projection = image.reduce((Axes.CH, Axes.ROUND, Axes.ZPLANE), "max")
     assert max_projection.xarray.dtype == original_dtype
 
 
@@ -26,7 +26,7 @@ Z_COORDS = 1, 3
 def test_max_projection_preserves_coordinates():
     e = data.ISS(use_test_data=True)
     nuclei = e.fov().get_image('nuclei')
-    nuclei_proj = nuclei.max_proj(Axes.ROUND, Axes.CH, Axes.ZPLANE)
+    nuclei_proj = nuclei.reduce((Axes.CH, Axes.ROUND, Axes.ZPLANE), "max")
     # Since this data already has only 1 round, 1 ch, 1 zplane
     # let's just assert that the max_proj operation didn't change anything
     assert nuclei.xarray.equals(nuclei_proj.xarray)
@@ -44,6 +44,6 @@ def test_max_projection_preserves_coordinates():
 
     stack = imagestack_with_coords_factory(stack_shape, physical_coords)
 
-    stack_proj = stack.max_proj(Axes.ROUND, Axes.CH, Axes.ZPLANE)
+    stack_proj = stack.reduce((Axes.CH, Axes.ROUND, Axes.ZPLANE), "max")
     expected_z = np.average(Z_COORDS)
     verify_physical_coordinates(stack_proj, X_COORDS, Y_COORDS, expected_z)


### PR DESCRIPTION
This is syntactic sugar to simplify single map / reduce operations.  Right now, we would need to instantiate the filter and then run it against the stack, e.g.,

```
max_projector = Filter.Reduce((Axes.CH, Axes.ROUND, Axes.ZPLANE))
max_projected = max_projector.run(stack)
```

With this, it simplifies to:

```
max_projected = stack.reduce((Axes.CH, Axes.ROUND, Axes.ZPLANE), "max")
```

Test plan: Converted imagestack/test/test_max_proj.py to use this idiom.
Depends on #1540 