### PR TITLE
[easy] use the xarray property

### DIFF
--- a/starfish/core/image/Filter/element_wise_mult.py
+++ b/starfish/core/image/Filter/element_wise_mult.py
@@ -79,9 +79,9 @@ class ElementWiseMultiply(FilterAlgorithmBase):
             self.run(stack, in_place=True)
             return stack
 
-        stack._data.data.values *= mult_array_aligned
+        stack.xarray.values *= mult_array_aligned
         if self.clip_method == Clip.CLIP:
-            stack._data.data.values = preserve_float_range(stack._data.data.values, rescale=False)
+            stack.xarray.values = preserve_float_range(stack.xarray.values, rescale=False)
         else:
-            stack._data.data.values = preserve_float_range(stack._data.data.values, rescale=True)
+            stack.xarray.values = preserve_float_range(stack.xarray.values, rescale=True)
         return None


### PR DESCRIPTION
Instead of reaching into the private _data field, use the xarray property.

Test plan: `pytest -v -n8  --ff starfish/core/image/Filter/test`

Part of #834