### PR TITLE
Don't waste memory/compute in preserve_float_range

### DIFF
--- a/starfish/core/util/dtype.py
+++ b/starfish/core/util/dtype.py
@@ -3,20 +3,32 @@ from typing import Union
 import numpy as np
 import xarray as xr
 
+
 def preserve_float_range(
         array: Union[xr.DataArray, np.ndarray],
-        rescale: bool=False) -> Union[xr.DataArray, np.ndarray]:
+        rescale: bool = False,
+        preserve_input: bool = False,
+) -> Union[xr.DataArray, np.ndarray]:
     """
     Clips values below zero to zero. If values above one are detected, clips them
     to 1 unless `rescale` is True, in which case the input is scaled by
     the max value and the dynamic range is preserved.
 
+    Input arrays may be modified by this operation if `preserve_input` is False.  There is no
+    guarantee that the input array is returned even if `preserve_input` is True, however.
+
     Parameters
     ----------
     array : Union[xr.DataArray, np.ndarray]
         Array whose values should be in the interval [0, 1] but may not be.
-    rescale: bool
+    rescale : bool
         If true, scale values by the max.
+    preserve_input : bool
+        If True, ensure that we do not modify the input data.  This may either be done by making a
+        copy of the input data or ensuring that the operation does not modify the input array.
+
+        Even if `preserve_input` is True, modifications to the resulting array may modify the input
+        array.
 
     Returns
     -------
@@ -24,19 +36,67 @@ def preserve_float_range(
         Array whose values are in the interval [0, 1].
 
     """
-    array = array.copy()
-
     if isinstance(array, xr.DataArray):
+        # do a shallow copy
+        array = array.copy(deep=False)
         data = array.values
     else:
         data = array
 
-    negative = data < 0
-    if np.any(negative):
-        data[negative] = 0
-    if np.any(data > 1):
-        if rescale:
-            data /= data.max()
-        else:
-            data[data > 1] = 1
-    return array.astype(np.float32)
+    casted = data.astype(np.float32, copy=False)
+    if casted is not data:
+        preserve_input = False
+    data = casted
+
+    if preserve_input or not data.flags['WRITEABLE']:
+        # if we still want a copy, check to see if any modifications would be made.  if so, make a
+        # copy.
+        belowzero = np.any(data < 0)
+        aboveone = np.any(data > 1)
+        if belowzero or aboveone:
+            data = data.copy()
+            _preserve_float_range_in_place(data, rescale and aboveone)
+    else:
+        # we don't want a copy, so we just do it in place.
+        aboveone = np.any(data > 1)
+        _preserve_float_range_in_place(data, rescale and aboveone)
+
+    if isinstance(array, xr.DataArray):
+        if data is not array.values:
+            array.values = data
+    else:
+        array = data
+
+    return array
+
+
+def _preserve_float_range_in_place(
+        array: np.ndarray,
+        rescale: bool = False,
+):
+    """
+    Clips values below zero to zero. If values above one are detected, clips them
+    to 1 unless `rescale` is True, in which case the input is scaled by
+    the max value and the dynamic range is preserved.
+
+    Parameters
+    ----------
+    array : np.ndarray
+        Array whose values should be in the interval [0, 1] but may not be.  This array must be of
+        type np.float32.
+    rescale : bool
+        If true, scale values by the max.
+
+    Returns
+    -------
+    array : np.ndarray
+        Array whose values are in the interval [0, 1].
+
+    """
+    assert array.dtype == np.float32
+
+    array[array < 0] = 0
+    if rescale:
+        array /= array.max()
+    else:
+        array[array > 1] = 1

--- a/starfish/core/util/test/test_dtype.py
+++ b/starfish/core/util/test/test_dtype.py
@@ -1,0 +1,129 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from ..dtype import preserve_float_range
+
+
+def combos(make_xarrays: bool):
+    test_parameters = (
+        # none of these will change the data
+        (
+            np.asarray((0.0, 0.0, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 1.0), dtype=np.float32),
+        ),
+
+        # different dtype.
+        (
+            np.asarray((0.0, 0.0, 1.0), dtype=np.float64),
+            np.asarray((0.0, 0.0, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 1.0), dtype=np.float32),
+        ),
+
+        # some below zero stuff
+        (
+            np.asarray((-1.0, 0.0, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 1.0), dtype=np.float32),
+        ),
+
+        # some above one stuff
+        (
+            np.asarray((0.0, 1.0, 2.0), dtype=np.float32),
+            np.asarray((0.0, 1.0, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.5, 1.0), dtype=np.float32),
+        ),
+
+        # both below zero and above one stuff
+        (
+            np.asarray((-1.0, 0.0, 1.0, 2.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 1.0, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 0.5, 1.0), dtype=np.float32),
+        ),
+
+        # both below zero and above one stuff
+        (
+            np.asarray((-1.0, 0.0, 1.0, 2.0), dtype=np.float64),
+            np.asarray((0.0, 0.0, 1.0, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 0.5, 1.0), dtype=np.float32),
+        ),
+
+        # both below zero and above one stuff
+        (
+            np.asarray((-1, 0, 1, 2), dtype=np.int16),
+            np.asarray((0.0, 0.0, 1.0, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 0.5, 1.0), dtype=np.float32),
+        ),
+    )
+
+    if make_xarrays:
+        return (
+            (xr.DataArray(source),
+             xr.DataArray(expected_clipped_output),
+             xr.DataArray(expected_rescaled_output))
+            for source, expected_clipped_output, expected_rescaled_output in test_parameters
+        )
+    else:
+        return test_parameters
+
+
+@pytest.mark.parametrize(
+    ("_source", "expected_clipped_output", "expected_rescaled_output"),
+    combos(True)
+)
+def test_preserve_range_xarray(
+        _source: xr.DataArray,
+        expected_clipped_output: xr.DataArray,
+        expected_rescaled_output: xr.DataArray,
+):
+    def run(source: xr.DataArray, expected_output: xr.DataArray, rescale: bool):
+        original_data = source.copy(deep=True)
+
+        # compute while trying to preserve the input.  if there is no change to the data, we should
+        # come back with the same block of memory.
+        output_preserve_input = preserve_float_range(source, rescale=rescale, preserve_input=True)
+        assert expected_output.equals(output_preserve_input)
+        assert original_data.equals(source)
+        if source.dtype == np.float32 and expected_output.equals(source):
+            assert output_preserve_input.values is source.values
+
+        # compute it while trying to save memory.
+        output_stingy_memory = preserve_float_range(source, rescale=rescale, preserve_input=False)
+        assert expected_output.equals(output_stingy_memory)
+        if source.dtype == np.float32:
+            assert output_stingy_memory.values is source.values
+
+    run(_source.copy(deep=True), expected_clipped_output, False)
+    run(_source.copy(deep=True), expected_rescaled_output, True)
+
+
+@pytest.mark.parametrize(
+    ("_source", "expected_clipped_output", "expected_rescaled_output"),
+    combos(False)
+)
+def test_preserve_range_ndarray(
+        _source: np.ndarray,
+        expected_clipped_output: np.ndarray,
+        expected_rescaled_output: np.ndarray,
+):
+    def run(source: np.ndarray, expected_output: np.ndarray, rescale: bool):
+        original_data = source.copy()
+
+        # compute while trying to preserve the input.  if there is no change to the data, we should
+        # come back with the same block of memory.
+        output_preserve_input = preserve_float_range(source, rescale=rescale, preserve_input=True)
+        assert np.all(np.equal(expected_output, output_preserve_input))
+        assert np.all(np.equal(original_data, source))
+        if source.dtype == np.float32 and np.all(np.equal(expected_output, source)):
+            # no change
+            assert output_preserve_input is source
+
+        # compute it while trying to save memory.
+        output_stingy_memory = preserve_float_range(source, rescale=rescale, preserve_input=False)
+        assert np.all(np.equal(expected_output, output_stingy_memory))
+        if source.dtype == np.float32:
+            assert output_stingy_memory is source
+
+    run(_source.copy(), expected_clipped_output, False)
+    run(_source.copy(), expected_rescaled_output, True)


### PR DESCRIPTION
There are two flaws with the existing `preserve_float_range` implementation:
1. It wastes memory by copying even when it does not have to.
2. It does extra loops through the array.

This attempts to optimize `preserve_float_range`, while retaining flexibility for the caller to configure the behavior we want.  There is a new parameter, `preserve_input`, which controls whether or not it is important to preserve the input.  When it is true, we will make deliberate effort to preserve the input data, even at the cost of performance.  When it is false, we will overwrite the input data unless we are forced to make a copy (the two reasons that compel us to do so are if the dtype is different and if the input array is immutable).

Test plan: Add new tests to cover all the scenarios, and `make -j fast`