### PR TITLE
[easy] Rename all the algorithm base classes to *Algorithm

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -18,21 +18,15 @@ Creating a new algorithm for an existing `pipeline_component`
 
 For example, to add a new image filter, one would:
 
-1. Create a new python file `new_filter.py` in the `starfish/pipeline/filter/` directory.
+1. Create a new python file `new_filter.py` in the `starfish/core/image/Filter/` directory.
 2. Find the corresponding `AlgorithmBase` for your component.
-   For filters, this is `FilterAlgorithmBase`, which is found in `starfish/pipeline/filter/_base.py`.
+   For filters, this is `FilterAlgorithm`, which is found in `starfish/core/image/Filter/_base.py`.
    Import that base into `new_filter.py`, and have your new algorithm subclass it,
-   e.g. create `class NewFilter(FilterAlgorithmBase)`
+   e.g. create `class NewFilter(FilterAlgorithm)`
 3. Implement all required methods from the base class.
-4. For the command line arguments to mimic the API, the arguments passed to the CLI must exactly
-   match the names of the parameters for `NewFilter.__init__`, after dashes are automatically converted by argparse.
-   For example, `--foo-bar` would convert to `foo_bar` and init must accept such an argument:
-   `NewFilter.__init__(foo_bar, ..., **kwargs)`
-5. `NewFilter.__init__()` must have a `**kwargs` parameter to accept arbitrary CLI args.
 
-That's it! Your `NewFilter` algoritm will automatically register and be available under `starfish filter` in the CLI.
-If at any point something gets confusing, it should be possible to look at existing pipeline components of the same
-category for guidance on implementation.
+That's it! If at any point something gets confusing, it should be possible to look at existing pipeline components of
+the same category for guidance on implementation.
 
 Reporting bugs
 --------------

--- a/docs/source/api/image/index.rst
+++ b/docs/source/api/image/index.rst
@@ -17,7 +17,7 @@ Filtering
 ---------
 
 Filters can be imported using ``starfish.image.Filter``, which registers all classes that subclass
-``FilterAlgorithmBase``:
+``FilterAlgorithm``:
 
 .. code-block:: python
 
@@ -33,7 +33,7 @@ Learn Transform
 ---------------
 
 LearnTransform can be imported using ``starfish.image.LearnTransform``, the subclasses of
-``LearnTransformBase`` are available for transform learning.
+``LearnTransformAlgorithm`` are available for transform learning.
 
 .. code-block:: python
 
@@ -49,7 +49,7 @@ Apply Transform
 ---------------
 
 ApplyTransform can be imported using ``starfish.image.ApplyTransform``, the subclasses of
-``ApplyTransformBase`` are available for transform learning.
+``ApplyTransformAlgorithm`` are available for transform learning.
 
 .. code-block:: python
 
@@ -65,7 +65,7 @@ Segmentation
 ------------
 
 Segmentation can be imported using ``starfish.image.Segment``, which registers all classes that subclass
-``SegmentAlgorithmBase``:
+``SegmentAlgorithm``:
 
 .. code-block:: python
 

--- a/docs/source/api/spots/index.rst
+++ b/docs/source/api/spots/index.rst
@@ -14,7 +14,7 @@ These include :py:class:`starfish.spots.DetectPixels`, which exposes methods tha
 Detecting Pixels
 ----------------
 
-Pixel Detectors can be imported using ``starfish.spots.DetectPixels``, which registers all classes that subclass ``DetectPixelsAlgorithmBase``:
+Pixel Detectors can be imported using ``starfish.spots.DetectPixels``, which registers all classes that subclass ``DetectPixelsAlgorithm``:
 
 .. code-block:: python
 
@@ -29,7 +29,7 @@ Pixel Detectors can be imported using ``starfish.spots.DetectPixels``, which reg
 Detecting Spots
 ---------------
 
-Spot Detectors can be imported using ``starfish.spots.DetectSpots``, which registers all classes that subclass ``DetectSpotsAlgorithmBase``:
+Spot Detectors can be imported using ``starfish.spots.DetectSpots``, which registers all classes that subclass ``DetectSpotsAlgorithm``:
 
 .. code-block:: python
 
@@ -44,7 +44,7 @@ Spot Detectors can be imported using ``starfish.spots.DetectSpots``, which regis
 Decoding
 --------
 
-Decoders can be imported using ``starfish.spots.Decode``, which registers all classes that subclass ``DecodeAlgorithmBase``:
+Decoders can be imported using ``starfish.spots.Decode``, which registers all classes that subclass ``DecodeAlgorithm``:
 
 .. code-block:: python
 
@@ -59,7 +59,7 @@ Decoders can be imported using ``starfish.spots.Decode``, which registers all cl
 Target Assignment
 -----------------
 
-Target Assignment can be imported using ``starfish.spots.AssignTargets``, which registers all classes that subclass ``AssignTargetsAlgorithmBase``:
+Target Assignment can be imported using ``starfish.spots.AssignTargets``, which registers all classes that subclass ``AssignTargetsAlgorithm``:
 
 .. code-block:: python
 

--- a/docs/source/contributing/index.rst
+++ b/docs/source/contributing/index.rst
@@ -20,21 +20,15 @@ Creating a new algorithm for an existing `pipeline_component`
 
 For example, to add a new image filter, one would:
 
-1. Create a new python file `new_filter.py` in the `starfish/pipeline/filter/` directory.
+1. Create a new python file `new_filter.py` in the `starfish/core/image/Filter/` directory.
 2. Find the corresponding `AlgorithmBase` for your component.
-   For filters, this is `FilterAlgorithmBase`, which is found in `starfish/pipeline/filter/_base.py`.
+   For filters, this is `FilterAlgorithm`, which is found in `starfish/core/image/Filter/_base.py`.
    Import that base into `new_filter.py`, and have your new algorithm subclass it,
-   e.g. create `class NewFilter(FilterAlgorithmBase)`
+   e.g. create `class NewFilter(FilterAlgorithm)`
 3. Implement all required methods from the base class.
-4. For the command line arguments to mimic the API, the arguments passed to the CLI must exactly
-   match the names of the parameters for `NewFilter.__init__`, after dashes are automatically converted by argparse.
-   For example, `--foo-bar` would convert to `foo_bar` and init must accept such an argument:
-   `NewFilter.__init__(foo_bar, ..., **kwargs)`
-5. `NewFilter.__init__()` must have a `**kwargs` parameter to accept arbitrary CLI args.
 
-That's it! Your `NewFilter` algoritm will automatically register and be available under `starfish filter` in the CLI.
-If at any point something gets confusing, it should be possible to look at existing pipeline components of the same
-category for guidance on implementation.
+That's it! If at any point something gets confusing, it should be possible to look at existing pipeline components of
+the same category for guidance on implementation.
 
 Reporting bugs
 --------------

--- a/starfish/core/image/Filter/__init__.py
+++ b/starfish/core/image/Filter/__init__.py
@@ -1,4 +1,4 @@
-from ._base import FilterAlgorithmBase
+from ._base import FilterAlgorithm
 from .bandpass import Bandpass
 from .clip import Clip
 from .clip_percentile_to_zero import ClipPercentileToZero
@@ -21,6 +21,6 @@ from .zero_by_channel_magnitude import ZeroByChannelMagnitude
 all_filters = {
     filter_name: filter_cls
     for filter_name, filter_cls in locals().items()
-    if isinstance(filter_cls, type) and FilterAlgorithmBase in filter_cls.__mro__
+    if isinstance(filter_cls, type) and FilterAlgorithm in filter_cls.__mro__
 }
 __all__ = list(all_filters.keys())

--- a/starfish/core/image/Filter/_base.py
+++ b/starfish/core/image/Filter/_base.py
@@ -5,7 +5,7 @@ from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.pipeline.algorithmbase import AlgorithmBase
 
 
-class FilterAlgorithmBase(metaclass=AlgorithmBase):
+class FilterAlgorithm(metaclass=AlgorithmBase):
 
     @abstractmethod
     def run(self, stack: ImageStack, *args) -> Optional[ImageStack]:

--- a/starfish/core/image/Filter/bandpass.py
+++ b/starfish/core/image/Filter/bandpass.py
@@ -7,11 +7,11 @@ from trackpy import bandpass
 
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Clip, Number
-from ._base import FilterAlgorithmBase
+from ._base import FilterAlgorithm
 from .util import determine_axes_to_group_by
 
 
-class Bandpass(FilterAlgorithmBase):
+class Bandpass(FilterAlgorithm):
     """
     Convolve with a Gaussian to remove short-wavelength noise and subtract out long-wavelength
     variations, retaining features of intermediate scale. This implementation relies on

--- a/starfish/core/image/Filter/call_bases.py
+++ b/starfish/core/image/Filter/call_bases.py
@@ -6,10 +6,10 @@ import xarray as xr
 
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.types import Axes
-from ._base import FilterAlgorithmBase
+from ._base import FilterAlgorithm
 
 
-class CallBases(FilterAlgorithmBase):
+class CallBases(FilterAlgorithm):
     """
     The CallBases filter determines the nucleotide present in each pixel of each
     (round, channel). The pixel values in the resulting image are the base quality

--- a/starfish/core/image/Filter/clip.py
+++ b/starfish/core/image/Filter/clip.py
@@ -5,11 +5,11 @@ import numpy as np
 import xarray as xr
 
 from starfish.core.imagestack.imagestack import ImageStack
-from ._base import FilterAlgorithmBase
+from ._base import FilterAlgorithm
 from .util import determine_axes_to_group_by
 
 
-class Clip(FilterAlgorithmBase):
+class Clip(FilterAlgorithm):
     """
     Image clipping filter that clips values below a minimum percentile and above a maximum
     percentile.

--- a/starfish/core/image/Filter/clip_percentile_to_zero.py
+++ b/starfish/core/image/Filter/clip_percentile_to_zero.py
@@ -5,11 +5,11 @@ import numpy as np
 import xarray as xr
 
 from starfish.core.imagestack.imagestack import ImageStack
-from ._base import FilterAlgorithmBase
+from ._base import FilterAlgorithm
 from .util import determine_axes_to_group_by
 
 
-class ClipPercentileToZero(FilterAlgorithmBase):
+class ClipPercentileToZero(FilterAlgorithm):
     """
     Image clipping filter that clips values below a minimum percentile and
     above a maximum percentile, and follows up by subtracting the minimum

--- a/starfish/core/image/Filter/clip_value_to_zero.py
+++ b/starfish/core/image/Filter/clip_value_to_zero.py
@@ -6,11 +6,11 @@ import xarray as xr
 
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Number
-from ._base import FilterAlgorithmBase
+from ._base import FilterAlgorithm
 from .util import determine_axes_to_group_by
 
 
-class ClipValueToZero(FilterAlgorithmBase):
+class ClipValueToZero(FilterAlgorithm):
     """
     Image clipping filter that clips values below a minimum value and above a
     maximum value. The filter then subtracts the minimum value from the

--- a/starfish/core/image/Filter/element_wise_mult.py
+++ b/starfish/core/image/Filter/element_wise_mult.py
@@ -7,10 +7,10 @@ import xarray as xr
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Clip
 from starfish.core.util.dtype import preserve_float_range
-from ._base import FilterAlgorithmBase
+from ._base import FilterAlgorithm
 
 
-class ElementWiseMultiply(FilterAlgorithmBase):
+class ElementWiseMultiply(FilterAlgorithm):
     """
     Perform element-wise multiplication on the image tensor. This is useful for
     performing operations such as image normalization or field flatness correction

--- a/starfish/core/image/Filter/gaussian_high_pass.py
+++ b/starfish/core/image/Filter/gaussian_high_pass.py
@@ -8,14 +8,14 @@ from starfish.core.image.Filter.gaussian_low_pass import GaussianLowPass
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Clip, Number
 from starfish.core.util.dtype import preserve_float_range
-from ._base import FilterAlgorithmBase
+from ._base import FilterAlgorithm
 from .util import (
     determine_axes_to_group_by,
     validate_and_broadcast_kernel_size,
 )
 
 
-class GaussianHighPass(FilterAlgorithmBase):
+class GaussianHighPass(FilterAlgorithm):
     """
     Applies a Gaussian high pass filter to the ImageStack. This is useful to remove cellular
     autofluorescence, which is typically low frequency.

--- a/starfish/core/image/Filter/gaussian_low_pass.py
+++ b/starfish/core/image/Filter/gaussian_low_pass.py
@@ -8,14 +8,14 @@ from skimage.filters import gaussian
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Clip, Number
 from starfish.core.util.dtype import preserve_float_range
-from ._base import FilterAlgorithmBase
+from ._base import FilterAlgorithm
 from .util import (
     determine_axes_to_group_by,
     validate_and_broadcast_kernel_size,
 )
 
 
-class GaussianLowPass(FilterAlgorithmBase):
+class GaussianLowPass(FilterAlgorithm):
     """
     Multi-dimensional low-pass gaussian filter. This filter blurs image data, and can be
     useful to apply prior to pixel decoding or watershed segmentation to spread intensity across

--- a/starfish/core/image/Filter/laplace.py
+++ b/starfish/core/image/Filter/laplace.py
@@ -6,7 +6,7 @@ import numpy as np
 import xarray as xr
 from scipy.ndimage import gaussian_laplace
 
-from starfish.core.image.Filter._base import FilterAlgorithmBase
+from starfish.core.image.Filter._base import FilterAlgorithm
 from starfish.core.image.Filter.util import (
     determine_axes_to_group_by,
     validate_and_broadcast_kernel_size,
@@ -15,7 +15,7 @@ from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Clip, Number
 
 
-class Laplace(FilterAlgorithmBase):
+class Laplace(FilterAlgorithm):
     """
     Multi-dimensional Gaussian-Laplacian filter used to enhance dots against background
 

--- a/starfish/core/image/Filter/linear_unmixing.py
+++ b/starfish/core/image/Filter/linear_unmixing.py
@@ -6,10 +6,10 @@ import xarray as xr
 
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Axes, Clip
-from ._base import FilterAlgorithmBase
+from ._base import FilterAlgorithm
 
 
-class LinearUnmixing(FilterAlgorithmBase):
+class LinearUnmixing(FilterAlgorithm):
     """
     LinearUnmixing enables the user to correct fluorescent bleed by subtracting fractions of the
     intensities of other channels from each channel in the ImageStack.

--- a/starfish/core/image/Filter/map.py
+++ b/starfish/core/image/Filter/map.py
@@ -11,10 +11,10 @@ from typing import (
 
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Axes, Clip
-from ._base import FilterAlgorithmBase
+from ._base import FilterAlgorithm
 
 
-class Map(FilterAlgorithmBase):
+class Map(FilterAlgorithm):
     """
     Map from input to output by applying a specified function to the input.  The output must have
     the same shape as the input.

--- a/starfish/core/image/Filter/match_histograms.py
+++ b/starfish/core/image/Filter/match_histograms.py
@@ -8,10 +8,10 @@ from starfish.core.compat import match_histograms
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Axes
 from starfish.core.util import enum
-from ._base import FilterAlgorithmBase
+from ._base import FilterAlgorithm
 
 
-class MatchHistograms(FilterAlgorithmBase):
+class MatchHistograms(FilterAlgorithm):
     """
     Normalize data by matching distributions of each tile or volume to a reference volume
 

--- a/starfish/core/image/Filter/max_proj.py
+++ b/starfish/core/image/Filter/max_proj.py
@@ -3,10 +3,10 @@ from typing import Iterable, Optional, Union
 
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Axes
-from ._base import FilterAlgorithmBase
+from ._base import FilterAlgorithm
 
 
-class MaxProject(FilterAlgorithmBase):
+class MaxProject(FilterAlgorithm):
     """
     Creates a maximum projection over one or more axis of the image tensor
 

--- a/starfish/core/image/Filter/mean_high_pass.py
+++ b/starfish/core/image/Filter/mean_high_pass.py
@@ -8,13 +8,13 @@ from scipy.ndimage.filters import uniform_filter
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Clip, Number
 from starfish.core.util.dtype import preserve_float_range
-from ._base import FilterAlgorithmBase
+from ._base import FilterAlgorithm
 from .util import (
     determine_axes_to_group_by, validate_and_broadcast_kernel_size
 )
 
 
-class MeanHighPass(FilterAlgorithmBase):
+class MeanHighPass(FilterAlgorithm):
     """
     The mean high pass filter reduces low spatial frequency features by subtracting a
     mean filtered image from the original image. The mean filter smooths an image by replacing

--- a/starfish/core/image/Filter/reduce.py
+++ b/starfish/core/image/Filter/reduce.py
@@ -16,10 +16,10 @@ import numpy as np
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Axes, Clip, Coordinates, Number
 from starfish.core.util.dtype import preserve_float_range
-from ._base import FilterAlgorithmBase
+from ._base import FilterAlgorithm
 
 
-class Reduce(FilterAlgorithmBase):
+class Reduce(FilterAlgorithm):
     """
     Reduces the cardinality of one or more axes to 1 by applying a function across those axes.
 

--- a/starfish/core/image/Filter/richardson_lucy_deconvolution.py
+++ b/starfish/core/image/Filter/richardson_lucy_deconvolution.py
@@ -7,14 +7,14 @@ from scipy.signal import convolve, fftconvolve
 
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Clip, Number
-from ._base import FilterAlgorithmBase
+from ._base import FilterAlgorithm
 from .util import (
     determine_axes_to_group_by,
     gaussian_kernel,
 )
 
 
-class DeconvolvePSF(FilterAlgorithmBase):
+class DeconvolvePSF(FilterAlgorithm):
     """
     Deconvolve a point spread function from the image. The point spread function is assumed to be
     an isotropic Gaussian, with a user specified standard deviation, sigma.

--- a/starfish/core/image/Filter/white_tophat.py
+++ b/starfish/core/image/Filter/white_tophat.py
@@ -6,11 +6,11 @@ from skimage.morphology import ball, disk, white_tophat
 
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Clip
-from ._base import FilterAlgorithmBase
+from ._base import FilterAlgorithm
 from .util import determine_axes_to_group_by
 
 
-class WhiteTophat(FilterAlgorithmBase):
+class WhiteTophat(FilterAlgorithm):
     """
     Performs "white top hat" filtering of an image to enhance spots. White top hat filtering
     finds spots that are both smaller and brighter than their surroundings by subtracting an

--- a/starfish/core/image/Filter/zero_by_channel_magnitude.py
+++ b/starfish/core/image/Filter/zero_by_channel_magnitude.py
@@ -7,10 +7,10 @@ from tqdm import tqdm
 from starfish.core.config import StarfishConfig
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Axes
-from ._base import FilterAlgorithmBase
+from ._base import FilterAlgorithm
 
 
-class ZeroByChannelMagnitude(FilterAlgorithmBase):
+class ZeroByChannelMagnitude(FilterAlgorithm):
     """
     For assays in which we expect codewords to have explicit zero values,
     e.g., DARTFISH, this filter allows for the explicit zeroing

--- a/starfish/core/image/Segment/_base.py
+++ b/starfish/core/image/Segment/_base.py
@@ -5,7 +5,7 @@ from starfish.core.pipeline.algorithmbase import AlgorithmBase
 from starfish.core.segmentation_mask import SegmentationMaskCollection
 
 
-class SegmentAlgorithmBase(metaclass=AlgorithmBase):
+class SegmentAlgorithm(metaclass=AlgorithmBase):
 
     @abstractmethod
     def run(

--- a/starfish/core/image/Segment/watershed.py
+++ b/starfish/core/image/Segment/watershed.py
@@ -11,10 +11,10 @@ from starfish.core.image.Filter.util import bin_open, bin_thresh
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.segmentation_mask import SegmentationMaskCollection
 from starfish.core.types import Axes, Coordinates, Number
-from ._base import SegmentAlgorithmBase
+from ._base import SegmentAlgorithm
 
 
-class Watershed(SegmentAlgorithmBase):
+class Watershed(SegmentAlgorithm):
     """
     Implements watershed segmentation of cells.
 

--- a/starfish/core/image/_registration/ApplyTransform/_base.py
+++ b/starfish/core/image/_registration/ApplyTransform/_base.py
@@ -5,7 +5,7 @@ from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.pipeline.algorithmbase import AlgorithmBase
 
 
-class ApplyTransformBase(metaclass=AlgorithmBase):
+class ApplyTransformAlgorithm(metaclass=AlgorithmBase):
 
     @abstractmethod
     def run(self, stack, transforms_list, *args) -> Optional[ImageStack]:

--- a/starfish/core/image/_registration/ApplyTransform/warp.py
+++ b/starfish/core/image/_registration/ApplyTransform/warp.py
@@ -8,13 +8,13 @@ from skimage.transform._geometric import GeometricTransform
 from tqdm import tqdm
 
 from starfish.core.config import StarfishConfig
-from starfish.core.image._registration.ApplyTransform._base import ApplyTransformBase
+from starfish.core.image._registration.ApplyTransform._base import ApplyTransformAlgorithm
 from starfish.core.image._registration.transforms_list import TransformsList
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Axes
 
 
-class Warp(ApplyTransformBase):
+class Warp(ApplyTransformAlgorithm):
     """
     Applies a list of geometric transformations to an ImageStack using
     :py:func:skimage.transform.warp

--- a/starfish/core/image/_registration/LearnTransform/_base.py
+++ b/starfish/core/image/_registration/LearnTransform/_base.py
@@ -4,7 +4,7 @@ from starfish.core.image._registration.transforms_list import TransformsList
 from starfish.core.pipeline.algorithmbase import AlgorithmBase
 
 
-class LearnTransformBase(metaclass=AlgorithmBase):
+class LearnTransformAlgorithm(metaclass=AlgorithmBase):
 
     @abstractmethod
     def run(self, stack, *args) -> TransformsList:

--- a/starfish/core/image/_registration/LearnTransform/translation.py
+++ b/starfish/core/image/_registration/LearnTransform/translation.py
@@ -5,10 +5,10 @@ from skimage.transform._geometric import SimilarityTransform
 from starfish.core.image._registration.transforms_list import TransformsList
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Axes, TransformType
-from ._base import LearnTransformBase
+from ._base import LearnTransformAlgorithm
 
 
-class Translation(LearnTransformBase):
+class Translation(LearnTransformAlgorithm):
     """
     Iterate over the given axes of an ImageStack and learn the translation transform
     based off the reference_stack passed into :py:class:`Translation`'s constructor.

--- a/starfish/core/spots/Decode/_base.py
+++ b/starfish/core/spots/Decode/_base.py
@@ -4,7 +4,7 @@ from starfish.core.intensity_table.intensity_table import IntensityTable
 from starfish.core.pipeline.algorithmbase import AlgorithmBase
 
 
-class DecodeAlgorithmBase(metaclass=AlgorithmBase):
+class DecodeAlgorithm(metaclass=AlgorithmBase):
 
     @abstractmethod
     def run(self, intensities: IntensityTable, *args):

--- a/starfish/core/spots/Decode/metric_decoder.py
+++ b/starfish/core/spots/Decode/metric_decoder.py
@@ -1,11 +1,11 @@
 from starfish.core.codebook.codebook import Codebook
 from starfish.core.intensity_table.intensity_table import IntensityTable
 from starfish.core.types import Number
-from ._base import DecodeAlgorithmBase
+from ._base import DecodeAlgorithm
 
 
 # TODO ambrosejcarr add tests
-class MetricDistance(DecodeAlgorithmBase):
+class MetricDistance(DecodeAlgorithm):
     """
     Normalizes both the magnitudes of the codes and the spot intensities, then decodes spots by
     assigning each spot to the closest code, measured by the provided metric.

--- a/starfish/core/spots/Decode/per_round_max_channel_decoder.py
+++ b/starfish/core/spots/Decode/per_round_max_channel_decoder.py
@@ -1,9 +1,9 @@
 from starfish.core.codebook.codebook import Codebook
 from starfish.core.intensity_table.intensity_table import IntensityTable
-from ._base import DecodeAlgorithmBase
+from ._base import DecodeAlgorithm
 
 
-class PerRoundMaxChannel(DecodeAlgorithmBase):
+class PerRoundMaxChannel(DecodeAlgorithm):
     """
     Decode spots by selecting the max-valued channel in each sequencing round.
 

--- a/starfish/core/spots/DetectPixels/_base.py
+++ b/starfish/core/spots/DetectPixels/_base.py
@@ -10,7 +10,7 @@ from starfish.core.types import Number
 from .combine_adjacent_features import ConnectedComponentDecodingResult
 
 
-class DetectPixelsAlgorithmBase(metaclass=AlgorithmBase):
+class DetectPixelsAlgorithm(metaclass=AlgorithmBase):
 
     @abstractmethod
     def run(

--- a/starfish/core/spots/DetectPixels/pixel_spot_decoder.py
+++ b/starfish/core/spots/DetectPixels/pixel_spot_decoder.py
@@ -6,11 +6,11 @@ from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.intensity_table.intensity_table import IntensityTable
 from starfish.core.intensity_table.intensity_table_coordinates import \
     transfer_physical_coords_from_imagestack_to_intensity_table
-from ._base import DetectPixelsAlgorithmBase
+from ._base import DetectPixelsAlgorithm
 from .combine_adjacent_features import CombineAdjacentFeatures, ConnectedComponentDecodingResult
 
 
-class PixelSpotDecoder(DetectPixelsAlgorithmBase):
+class PixelSpotDecoder(DetectPixelsAlgorithm):
     """Decode an image by first coding each pixel, then combining the results into spots
 
     Parameters

--- a/starfish/core/spots/DetectSpots/_base.py
+++ b/starfish/core/spots/DetectSpots/_base.py
@@ -10,7 +10,7 @@ from starfish.core.pipeline.algorithmbase import AlgorithmBase
 from starfish.core.types import Axes, Number, SpotAttributes
 
 
-class DetectSpotsAlgorithmBase(metaclass=AlgorithmBase):
+class DetectSpotsAlgorithm(metaclass=AlgorithmBase):
     """
     Starfish spot detectors use a variety of means to detect bright spots against
     dark backgrounds. Starfish's spot detectors each have different strengths and weaknesses.

--- a/starfish/core/spots/DetectSpots/blob.py
+++ b/starfish/core/spots/DetectSpots/blob.py
@@ -8,7 +8,7 @@ from skimage.feature import blob_dog, blob_doh, blob_log
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.intensity_table.intensity_table import IntensityTable
 from starfish.core.types import Axes, Features, Number, SpotAttributes
-from ._base import DetectSpotsAlgorithmBase
+from ._base import DetectSpotsAlgorithm
 from .detect import detect_spots, measure_spot_intensity
 
 blob_detectors = {
@@ -18,7 +18,7 @@ blob_detectors = {
 }
 
 
-class BlobDetector(DetectSpotsAlgorithmBase):
+class BlobDetector(DetectSpotsAlgorithm):
     """
     Multi-dimensional gaussian spot detector
 

--- a/starfish/core/spots/DetectSpots/local_max_peak_finder.py
+++ b/starfish/core/spots/DetectSpots/local_max_peak_finder.py
@@ -13,7 +13,7 @@ from starfish.core.config import StarfishConfig
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.intensity_table.intensity_table import IntensityTable
 from starfish.core.types import Axes, Features, Number, SpotAttributes
-from ._base import DetectSpotsAlgorithmBase
+from ._base import DetectSpotsAlgorithm
 from .detect import detect_spots
 
 
@@ -22,7 +22,7 @@ from .detect import detect_spots
 # spot finder confusing. One would expect to have access to the private parameters
 # however, they are lost due to the memory-space forking induced by multi-processing.
 
-class LocalMaxPeakFinder(DetectSpotsAlgorithmBase):
+class LocalMaxPeakFinder(DetectSpotsAlgorithm):
     """
     2-dimensional local-max peak finder that wraps skimage.feature.peak_local_max
 

--- a/starfish/core/spots/DetectSpots/local_search_blob_detector.py
+++ b/starfish/core/spots/DetectSpots/local_search_blob_detector.py
@@ -21,7 +21,7 @@ from starfish.core.intensity_table.intensity_table import IntensityTable
 from starfish.core.intensity_table.intensity_table_coordinates import \
     transfer_physical_coords_from_imagestack_to_intensity_table
 from starfish.core.types import Axes, Features, Number, SpotAttributes
-from ._base import DetectSpotsAlgorithmBase
+from ._base import DetectSpotsAlgorithm
 
 blob_detectors = {
     'blob_dog': blob_dog,
@@ -29,7 +29,7 @@ blob_detectors = {
 }
 
 
-class LocalSearchBlobDetector(DetectSpotsAlgorithmBase):
+class LocalSearchBlobDetector(DetectSpotsAlgorithm):
     """
     Multi-dimensional gaussian spot detector.
 

--- a/starfish/core/spots/DetectSpots/test/test_spot_detection.py
+++ b/starfish/core/spots/DetectSpots/test/test_spot_detection.py
@@ -9,7 +9,7 @@ from starfish.core.test.factories import (
     two_spot_sparse_coded_data_factory,
 )
 from starfish.types import Axes, Features
-from .._base import DetectSpotsAlgorithmBase
+from .._base import DetectSpotsAlgorithm
 from ..blob import BlobDetector
 from ..detect import detect_spots
 from ..local_max_peak_finder import LocalMaxPeakFinder
@@ -74,7 +74,7 @@ test_parameters = (
 @pytest.mark.parametrize(*test_parameters)
 def test_spot_detection_with_reference_image(
         data_stack: ImageStack,
-        spot_detector: DetectSpotsAlgorithmBase,
+        spot_detector: DetectSpotsAlgorithm,
         radius_is_gyration: bool,
         max_intensity: float,
 ):
@@ -106,7 +106,7 @@ def test_spot_detection_with_reference_image(
 @pytest.mark.parametrize(*test_parameters)
 def test_spot_detection_with_reference_image_from_max_projection(
         data_stack: ImageStack,
-        spot_detector: DetectSpotsAlgorithmBase,
+        spot_detector: DetectSpotsAlgorithm,
         radius_is_gyration: bool,
         max_intensity: float,
 ):
@@ -135,7 +135,7 @@ def test_spot_detection_with_reference_image_from_max_projection(
 @pytest.mark.parametrize(*test_parameters)
 def test_spot_finding_no_reference_image(
         data_stack: ImageStack,
-        spot_detector: DetectSpotsAlgorithmBase,
+        spot_detector: DetectSpotsAlgorithm,
         radius_is_gyration: bool,
         max_intensity: float,
 ):

--- a/starfish/core/spots/DetectSpots/trackpy_local_max_peak_finder.py
+++ b/starfish/core/spots/DetectSpots/trackpy_local_max_peak_finder.py
@@ -8,11 +8,11 @@ from trackpy import locate
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.intensity_table.intensity_table import IntensityTable
 from starfish.core.types import Axes, SpotAttributes
-from ._base import DetectSpotsAlgorithmBase
+from ._base import DetectSpotsAlgorithm
 from .detect import detect_spots
 
 
-class TrackpyLocalMaxPeakFinder(DetectSpotsAlgorithmBase):
+class TrackpyLocalMaxPeakFinder(DetectSpotsAlgorithm):
     """
     Find spots using a local max peak finding algorithm
 


### PR DESCRIPTION
There were some that were *AlgorithmBase.  There were some that were *Base.  This unifies them all to *Algorithm.

Also fixed some stale docs.