### PR TITLE
Fix mypy + xarray errors

### DIFF
--- a/REQUIREMENTS-STRICT.txt
+++ b/REQUIREMENTS-STRICT.txt
@@ -3,8 +3,8 @@ appnope==0.1.0
 attrs==19.1.0
 backcall==0.1.0
 bleach==3.1.0
-boto3==1.9.228
-botocore==1.12.228
+boto3==1.9.231
+botocore==1.12.231
 certifi==2019.9.11
 chardet==3.0.4
 Click==7.0
@@ -26,7 +26,7 @@ Jinja2==2.10.1
 jmespath==0.9.4
 joblib==0.13.2
 jsonschema==3.0.2
-jupyter-client==5.3.2
+jupyter-client==5.3.3
 jupyter-core==4.5.0
 kiwisolver==1.1.0
 MarkupSafe==1.1.1
@@ -38,7 +38,7 @@ nbformat==4.4.0
 networkx==2.3
 notebook==6.0.1
 numpy==1.17.2
-packaging==19.1
+packaging==19.2
 pandas==0.25.1
 pandocfilters==1.4.2
 parso==0.5.1
@@ -72,7 +72,7 @@ terminado==0.8.2
 testpath==0.4.2
 tifffile==2019.7.26
 tornado==6.0.3
-tqdm==4.35.0
+tqdm==4.36.1
 trackpy==0.4.1
 traitlets==4.3.2
 urllib3==1.25.3
@@ -80,4 +80,4 @@ validators==0.14.0
 wcwidth==0.1.7
 webencodings==0.5.1
 widgetsnbextension==3.5.1
-xarray==0.12.3
+xarray==0.13.0

--- a/starfish/REQUIREMENTS-STRICT.txt
+++ b/starfish/REQUIREMENTS-STRICT.txt
@@ -3,8 +3,8 @@ appnope==0.1.0
 attrs==19.1.0
 backcall==0.1.0
 bleach==3.1.0
-boto3==1.9.228
-botocore==1.12.228
+boto3==1.9.231
+botocore==1.12.231
 certifi==2019.9.11
 chardet==3.0.4
 Click==7.0
@@ -26,7 +26,7 @@ Jinja2==2.10.1
 jmespath==0.9.4
 joblib==0.13.2
 jsonschema==3.0.2
-jupyter-client==5.3.2
+jupyter-client==5.3.3
 jupyter-core==4.5.0
 kiwisolver==1.1.0
 MarkupSafe==1.1.1
@@ -38,7 +38,7 @@ nbformat==4.4.0
 networkx==2.3
 notebook==6.0.1
 numpy==1.17.2
-packaging==19.1
+packaging==19.2
 pandas==0.25.1
 pandocfilters==1.4.2
 parso==0.5.1
@@ -72,7 +72,7 @@ terminado==0.8.2
 testpath==0.4.2
 tifffile==2019.7.26
 tornado==6.0.3
-tqdm==4.35.0
+tqdm==4.36.1
 trackpy==0.4.1
 traitlets==4.3.2
 urllib3==1.25.3
@@ -80,4 +80,4 @@ validators==0.14.0
 wcwidth==0.1.7
 webencodings==0.5.1
 widgetsnbextension==3.5.1
-xarray==0.12.3
+xarray==0.13.0

--- a/starfish/core/codebook/codebook.py
+++ b/starfish/core/codebook/codebook.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, TypeVar, Union
 
 import numpy as np
 import pandas as pd
@@ -20,6 +20,9 @@ from starfish.core.intensity_table.decoded_intensity_table import DecodedIntensi
 from starfish.core.intensity_table.intensity_table import IntensityTable
 from starfish.core.spacetx_format.util import CodebookValidator
 from starfish.core.types import Axes, Features, Number
+
+
+NormalizedFeaturesArgtype = TypeVar("NormalizedFeaturesArgtype", "Codebook", IntensityTable)
 
 
 class Codebook(xr.DataArray):
@@ -419,9 +422,9 @@ class Codebook(xr.DataArray):
 
     @staticmethod
     def _normalize_features(
-            array: Union["Codebook", IntensityTable],
+            array: NormalizedFeaturesArgtype,
             norm_order: int,
-    ) -> Tuple[Union["Codebook", IntensityTable], np.ndarray]:
+    ) -> Tuple[NormalizedFeaturesArgtype, np.ndarray]:
         """Unit normalize each feature of array
 
         Parameters

--- a/starfish/core/expression_matrix/expression_matrix.py
+++ b/starfish/core/expression_matrix/expression_matrix.py
@@ -70,7 +70,7 @@ class ExpressionMatrix(xr.DataArray):
         anndata.write(filename)
 
     @classmethod
-    def load(cls, filename: str) -> "ExpressionMatrix":
+    def load(cls, filename: str) -> "ExpressionMatrix":  # type: ignore
         """load an ExpressionMatrix from Netcdf
 
         Parameters

--- a/starfish/core/image/Filter/reduce.py
+++ b/starfish/core/image/Filter/reduce.py
@@ -203,7 +203,7 @@ class Reduce(FilterAlgorithm):
                 assert coord.value not in reduced.coords
                 physical_coords[coord] = [np.average(stack._data.coords[coord.value])]
             else:
-                physical_coords[coord] = reduced.coords[coord.value]
+                physical_coords[coord] = cast(Sequence[Number], reduced.coords[coord.value])
         reduced_stack = ImageStack.from_numpy(reduced.values, coordinates=physical_coords)
 
         return reduced_stack

--- a/starfish/core/imagestack/indexing_utils.py
+++ b/starfish/core/imagestack/indexing_utils.py
@@ -1,4 +1,4 @@
-from typing import Dict, Mapping, MutableMapping, Tuple, Union
+from typing import Dict, Hashable, Mapping, MutableMapping, Tuple, Union
 
 import numpy as np
 import xarray as xr
@@ -8,7 +8,7 @@ from starfish.core.types import Axes, Coordinates, CoordinateValue
 
 
 def convert_to_selector(
-        indexers: Mapping[Axes, Union[int, slice, tuple]]) -> Mapping[str, Union[int, slice]]:
+        indexers: Mapping[Axes, Union[int, slice, tuple]]) -> Mapping[Hashable, Union[int, slice]]:
     """Converts a mapping of Axis to int, slice, or tuple to a mapping of str to int or slice.  The
     latter format is required for standard xarray indexing methods.
 
@@ -18,7 +18,7 @@ def convert_to_selector(
             A dictionary of dim:index where index is the value or range to index the dimension
 
     """
-    return_dict: MutableMapping[str, Union[int, slice]] = {
+    return_dict: MutableMapping[Hashable, Union[int, slice]] = {
         ind.value: slice(None, None) for ind in Axes}
     for key, value in indexers.items():
         if isinstance(value, tuple):
@@ -63,7 +63,7 @@ def convert_coords_to_indices(
 
 
 def index_keep_dimensions(data: xr.DataArray,
-                          indexers: Mapping[str, Union[int, slice]],
+                          indexers: Mapping[Hashable, Union[int, slice]],
                           by_pos: bool=False
                           ) -> xr.DataArray:
     """Takes an xarray and key to index it. Indexes then adds back in lost dimensions"""

--- a/starfish/core/intensity_table/intensity_table.py
+++ b/starfish/core/intensity_table/intensity_table.py
@@ -1,6 +1,6 @@
 from itertools import product
 from json import loads
-from typing import Dict, List, Optional, Sequence, Union
+from typing import Dict, Hashable, List, Optional, Sequence, Union
 
 import numpy as np
 import pandas as pd
@@ -72,7 +72,7 @@ class IntensityTable(xr.DataArray):
             spot_attributes: SpotAttributes,
             channel_values: Sequence[int],
             round_values: Sequence[int]
-    ) -> Dict[str, np.ndarray]:
+    ) -> Dict[Hashable, np.ndarray]:
         """build coordinates for intensity-table"""
         coordinates = {
             k: (Features.AXIS, spot_attributes.data[k].values)
@@ -205,7 +205,7 @@ class IntensityTable(xr.DataArray):
         """Returns True if this table's features have physical-space loci."""
         return Coordinates.X in self.coords and Coordinates.Y in self.coords
 
-    def to_netcdf(self, filename: str) -> None:
+    def to_netcdf(self, filename: str) -> None:  # type: ignore
         """
         Save an IntensityTable as a Netcdf File.
 

--- a/starfish/core/intensity_table/intensity_table_coordinates.py
+++ b/starfish/core/intensity_table/intensity_table_coordinates.py
@@ -1,3 +1,5 @@
+from typing import Callable
+
 import numpy as np
 import xarray as xr
 
@@ -37,6 +39,7 @@ def transfer_physical_coords_from_imagestack_to_intensity_table(
         intensity_table_pixel_offsets: np.ndarray = intensity_table[axis].values
 
         # can't interpolate if the axis size == 1, so just select in that case.
+        coordinate_fetcher: Callable
         if len(imagestack_pixels) == 1:
             coordinate_fetcher = imagestack_pixels.sel
         else:

--- a/starfish/core/segmentation_mask.py
+++ b/starfish/core/segmentation_mask.py
@@ -1,6 +1,6 @@
 import io
 import tarfile
-from typing import Dict, List, Optional, Sequence, Tuple, Union
+from typing import cast, Dict, Hashable, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import xarray as xr
@@ -143,7 +143,7 @@ class SegmentationMaskCollection:
 
         masks: List[xr.DataArray] = []
 
-        coords: Dict[str, Union[list, Tuple[str, Sequence]]]
+        coords: Dict[Hashable, Union[list, Tuple[str, Sequence]]]
 
         # for each region (and its properties):
         for label, prop in enumerate(props):
@@ -249,7 +249,7 @@ class SegmentationMaskCollection:
         """
         with tarfile.open(path, 'w:gz') as t:
             for i, mask in enumerate(self._masks):
-                data = mask.to_netcdf()
+                data = cast(bytes, mask.to_netcdf())
                 with io.BytesIO(data) as buff:
                     info = tarfile.TarInfo(name=str(i) + '.nc')
                     info.size = len(data)

--- a/starfish/core/spots/AssignTargets/label.py
+++ b/starfish/core/spots/AssignTargets/label.py
@@ -44,7 +44,7 @@ class Label(AssignTargetsAlgorithm):
                 drop=True
             )
 
-            in_mask = mask.sel_points(y=in_bbox.y, x=in_bbox.x)
+            in_mask = mask.sel(y=in_bbox.y, x=in_bbox.x)
             spot_ids = in_bbox[Features.SPOT_ID][in_mask.values]
             decoded_intensities[Features.CELL_ID].loc[spot_ids] = mask.name
 

--- a/starfish/core/spots/DetectPixels/combine_adjacent_features.py
+++ b/starfish/core/spots/DetectPixels/combine_adjacent_features.py
@@ -1,7 +1,7 @@
 import warnings
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
-from typing import Dict, List, NamedTuple, Optional, Tuple
+from typing import cast, Dict, List, NamedTuple, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -140,7 +140,7 @@ class CombineAdjacentFeatures:
 
         int_targets = target_map.targets_as_int(intensities[Features.TARGET].values)
         if mask_filtered_features:
-            fails_filters = np.where(~intensities[Features.PASSES_THRESHOLDS])[0]
+            fails_filters = np.where(~intensities[Features.PASSES_THRESHOLDS])[0]  # type: ignore
             int_targets[fails_filters] = 0
 
         decoded_image: np.ndarray = int_targets.reshape((max_z, max_y, max_x))
@@ -170,7 +170,6 @@ class CombineAdjacentFeatures:
 
         """
 
-        import xarray as xr
         pixel_labels = label_image.reshape(-1)
 
         # Use a pandas groupby approach-based approach, because it is much faster than xarray
@@ -200,7 +199,7 @@ class CombineAdjacentFeatures:
         grouped = distances.groupby(level=0)
         pd_mean_distances = grouped.mean()
 
-        pd_xarray = xr.DataArray(
+        pd_xarray = IntensityTable(
             pd_mean_pixel_traces,
             dims=(Features.AXIS, 'traces'),
             coords=dict(
@@ -217,7 +216,7 @@ class CombineAdjacentFeatures:
         except KeyError:
             pass
 
-        return mean_pixel_traces
+        return cast(IntensityTable, mean_pixel_traces)
 
     @staticmethod
     def _single_spot_attributes(

--- a/starfish/core/spots/DetectSpots/_base.py
+++ b/starfish/core/spots/DetectSpots/_base.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Any, Callable, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Optional, Tuple, Union
 
 import numpy as np
 import xarray as xr
@@ -92,7 +92,9 @@ class DetectSpotsAlgorithm(metaclass=AlgorithmBase):
         raise NotImplementedError()
 
     @staticmethod
-    def _get_measurement_function(measurement_type: str) -> Callable[[Sequence], Number]:
+    def _get_measurement_function(
+            measurement_type: str
+    ) -> Callable[[Union[np.ndarray, xr.DataArray]], Number]:
         try:
             measurement_function = getattr(np, measurement_type)
         except AttributeError:

--- a/starfish/core/spots/DetectSpots/detect.py
+++ b/starfish/core/spots/DetectSpots/detect.py
@@ -16,7 +16,7 @@ from starfish.core.types import Axes, Features, Number, SpotAttributes
 def measure_spot_intensity(
         image: Union[np.ndarray, xr.DataArray],
         spots: SpotAttributes,
-        measurement_function: Callable[[Sequence], Number],
+        measurement_function: Callable[[Union[np.ndarray, xr.DataArray]], Number],
         radius_is_gyration: bool=False,
 ) -> pd.Series:
     """measure the intensity of each spot in spots in the corresponding image
@@ -27,7 +27,7 @@ def measure_spot_intensity(
         3-d volume in which to measure intensities
     spots : pd.DataFrame
         SpotAttributes table containing coordinates and radii of spots
-    measurement_function : Callable[[Sequence], Number])
+    measurement_function : Callable[[Union[np.ndarray, xr.DataArray]], Number])
         Function to apply over the spot volumes to identify the intensity (e.g. max, mean, ...)
     radius_is_gyration : bool
         if True, indicates that the radius corresponds to radius of gyration, which is a function of
@@ -67,7 +67,7 @@ def measure_spot_intensity(
 def measure_spot_intensities(
         data_image: ImageStack,
         spot_attributes: SpotAttributes,
-        measurement_function: Callable[[Sequence], Number],
+        measurement_function: Callable[[Union[np.ndarray, xr.DataArray]], Number],
         radius_is_gyration: bool=False,
 ) -> IntensityTable:
     """given spots found from a reference image, find those spots across a data_image
@@ -78,7 +78,7 @@ def measure_spot_intensities(
         ImageStack containing multiple volumes for which spots' intensities must be calculated
     spot_attributes : pd.Dataframe
         Locations and radii of spots
-    measurement_function : Callable[[Sequence], Number])
+    measurement_function : Callable[[Union[np.ndarray, xr.DataArray]], Number])
         Function to apply over the spot volumes to identify the intensity (e.g. max, mean, ...)
     radius_is_gyration : bool
         if True, indicates that the radius corresponds to radius of gyration, which is a function of
@@ -168,7 +168,7 @@ def detect_spots(data_stack: ImageStack,
                  spot_finding_kwargs: Dict = None,
                  reference_image: Optional[ImageStack] = None,
                  reference_image_max_projection_axes: Optional[Tuple[Axes, ...]] = None,
-                 measurement_function: Callable[[Sequence], Number] = np.max,
+                 measurement_function: Callable[[Union[np.ndarray, xr.DataArray]], Number] = np.max,
                  radius_is_gyration: bool = False,
                  n_processes: Optional[int] = None) -> IntensityTable:
     """Apply a spot_finding_method to a ImageStack
@@ -187,7 +187,7 @@ def detect_spots(data_stack: ImageStack,
         filling in the values in the IntensityTable
     reference_image_max_projection_axes : Tuple[Axes]
         Generate the reference image by max-projecting reference_image across these axes.
-    measurement_function : Callable[[Sequence], Number]
+    measurement_function : Callable[[Union[np.ndarray, xr.DataArray]], Number]
         the function to apply over the spot area to extract the intensity value (default 'np.max')
     radius_is_gyration : bool
         if True, indicates that the radius corresponds to radius of gyration, which is a function of

--- a/starfish/core/spots/DetectSpots/local_search_blob_detector.py
+++ b/starfish/core/spots/DetectSpots/local_search_blob_detector.py
@@ -7,7 +7,7 @@ See: https://github.com/spacetx/starfish/issues/1005
 """
 
 from collections import defaultdict
-from typing import Dict, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Hashable, List, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -344,7 +344,7 @@ class LocalSearchBlobDetector(DetectSpotsAlgorithm):
         # create empty IntensityTable filled with np.nan
         data = np.full((dist.shape[0], len(channels), len(rounds)), fill_value=np.nan)
         dims = (Features.AXIS, Axes.CH.value, Axes.ROUND.value)
-        coords = {
+        coords: Mapping[Hashable, Tuple[str, Any]] = {
             Features.SPOT_RADIUS: (Features.AXIS, anchor_df[Features.SPOT_RADIUS]),
             Axes.ZPLANE.value: (Features.AXIS, anchor_df[Axes.ZPLANE]),
             Axes.Y.value: (Features.AXIS, anchor_df[Axes.Y]),

--- a/starfish/core/util/dtype.py
+++ b/starfish/core/util/dtype.py
@@ -1,14 +1,17 @@
-from typing import Union
+from typing import TypeVar
 
 import numpy as np
 import xarray as xr
 
 
+PreserveFloatRangeType = TypeVar("PreserveFloatRangeType", xr.DataArray, np.ndarray)
+
+
 def preserve_float_range(
-        array: Union[xr.DataArray, np.ndarray],
+        array: PreserveFloatRangeType,
         rescale: bool = False,
         preserve_input: bool = False,
-) -> Union[xr.DataArray, np.ndarray]:
+) -> PreserveFloatRangeType:
     """
     Clips values below zero to zero. If values above one are detected, clips them
     to 1 unless `rescale` is True, in which case the input is scaled by

--- a/starfish/util/plot.py
+++ b/starfish/util/plot.py
@@ -9,7 +9,7 @@ for their plotting needs, as the interactive viewer is better able to handle the
 that starfish needs.
 """
 import itertools
-from typing import Any, Mapping, Optional, Union
+from typing import Any, cast, Mapping, Optional, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -150,7 +150,7 @@ def overlay_spot_calls(
         intensity_keys = (Axes.ROUND, Axes.CH, Axes.ZPLANE)
         intensity_sel = {x.value: sel[x] for x in intensity_keys if x in sel}
         if intensity_sel:
-            intensities = intensities.sel(intensity_sel)
+            intensities = cast(IntensityTable, intensities.sel(intensity_sel))
 
     imshow_kwargs = imshow_kwargs if imshow_kwargs else {}
     scatter_kwargs = scatter_kwargs if scatter_kwargs else {}


### PR DESCRIPTION
xarray 0.13.0 now has type annotations, which breaks a bunch of things.  This attempts to fix the issues.

It appears that xr.DataArray no longer acts like a Sequence[Number], so a bunch of things need to be casted.  It's probable that we should create a new type annotation for array-like objects (i.e., Union[Sequence, xr.DataArray, np.ndarray]).

Depends on #1561 

Test plan: travis.  https://travis-ci.com/spacetx/starfish/builds/128278048 has the errors from upgrading xarray to 0.13.0.