### PR TITLE
Relax the constraint that AssignTargets operates on DecodedIntensityTables

### DIFF
--- a/starfish/core/spots/AssignTargets/_base.py
+++ b/starfish/core/spots/AssignTargets/_base.py
@@ -2,7 +2,7 @@ from abc import abstractmethod
 
 import numpy as np
 
-from starfish.core.intensity_table.decoded_intensity_table import DecodedIntensityTable
+from starfish.core.intensity_table.intensity_table import IntensityTable
 from starfish.core.pipeline.algorithmbase import AlgorithmBase
 
 
@@ -16,9 +16,9 @@ class AssignTargetsAlgorithm(metaclass=AlgorithmBase):
     def run(
             self,
             label_image: np.ndarray,
-            decoded_intensity_table: DecodedIntensityTable,
+            decoded_intensity_table: IntensityTable,
             verbose: bool=False,
             in_place: bool=False,
-    ) -> DecodedIntensityTable:
+    ) -> IntensityTable:
         """Performs target (e.g. gene) assignment given the spots and the regions."""
         raise NotImplementedError()

--- a/starfish/core/spots/AssignTargets/label.py
+++ b/starfish/core/spots/AssignTargets/label.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from starfish.core.intensity_table.decoded_intensity_table import DecodedIntensityTable
+from starfish.core.intensity_table.intensity_table import IntensityTable
 from starfish.core.segmentation_mask import SegmentationMaskCollection
 from starfish.core.types import Features
 from ._base import AssignTargetsAlgorithm
@@ -21,49 +21,49 @@ class Label(AssignTargetsAlgorithm):
     @staticmethod
     def _assign(
         masks: SegmentationMaskCollection,
-        decoded_intensities: DecodedIntensityTable,
+        intensities: IntensityTable,
         in_place: bool,
-    ) -> DecodedIntensityTable:
+    ) -> IntensityTable:
 
         cell_ids = (
             Features.AXIS,
-            np.full(decoded_intensities.sizes[Features.AXIS], fill_value='nan', dtype='<U8')
+            np.full(intensities.sizes[Features.AXIS], fill_value='nan', dtype='<U8')
         )
 
-        decoded_intensities[Features.CELL_ID] = cell_ids
+        intensities[Features.CELL_ID] = cell_ids
 
         for mask in masks:
             y_min, y_max = float(mask.y.min()), float(mask.y.max())
             x_min, x_max = float(mask.x.min()), float(mask.x.max())
 
-            in_bbox = decoded_intensities.where(
-                (decoded_intensities.y >= y_min)
-                & (decoded_intensities.y <= y_max)
-                & (decoded_intensities.x >= x_min)
-                & (decoded_intensities.x <= x_max),
+            in_bbox = intensities.where(
+                (intensities.y >= y_min)
+                & (intensities.y <= y_max)
+                & (intensities.x >= x_min)
+                & (intensities.x <= x_max),
                 drop=True
             )
 
             in_mask = mask.sel(y=in_bbox.y, x=in_bbox.x)
             spot_ids = in_bbox[Features.SPOT_ID][in_mask.values]
-            decoded_intensities[Features.CELL_ID].loc[spot_ids] = mask.name
+            intensities[Features.CELL_ID].loc[spot_ids] = mask.name
 
-        return decoded_intensities
+        return intensities
 
     def run(
             self,
             masks: SegmentationMaskCollection,
-            decoded_intensity_table: DecodedIntensityTable,
+            intensity_table: IntensityTable,
             verbose: bool = False,
             in_place: bool = False,
-    ) -> DecodedIntensityTable:
+    ) -> IntensityTable:
         """Extract cell ids for features in IntensityTable from a segmentation label image
 
         Parameters
         ----------
         masks : SegmentationMaskCollection
             binary masks segmenting each cell
-        decoded_intensity_table : IntensityTable
+        intensity_table : IntensityTable
             spot information
         in_place : bool
             if True, process ImageStack in-place, otherwise return a new stack
@@ -77,4 +77,4 @@ class Label(AssignTargetsAlgorithm):
             cells will be assigned zero.
 
         """
-        return self._assign(masks, decoded_intensity_table, in_place=in_place)
+        return self._assign(masks, intensity_table, in_place=in_place)


### PR DESCRIPTION
Upon review, I was probably too hasty in landing #1565.  :(

It doesn't appear that assigning targets has any requirement that the spots are decoded, so I'm putting this up for review.