### PR TITLE
3.) SeqFish/StarMap/LocalBlobSearch

### DIFF
--- a/notebooks/STARmap.ipynb
+++ b/notebooks/STARmap.ipynb
@@ -36,7 +36,7 @@
     "import starfish\n",
     "from starfish import IntensityTable\n",
     "import starfish.data\n",
-    "from starfish.types import Axes\n",
+    "from starfish.types import Axes, TraceBuildingStrategies\n",
     "from starfish.util.plot import (\n",
     "    diagnose_registration, imshow_plane, intensity_histogram\n",
     ")\n",
@@ -136,7 +136,7 @@
    "source": [
     "ch_z_max_projector = starfish.image.Filter.Reduce((Axes.CH, Axes.ZPLANE), func=\"max\")\n",
     "projection = ch_r_max_projector.run(stack)\n",
-    "reference_image = projection.sel({Axes.ROUND: 1})\n",
+    "reference_image = projection.sel({Axes.ROUND: 0})\n",
     "\n",
     "ltt = starfish.image.LearnTransform.Translation(\n",
     "    reference_stack=reference_image,\n",
@@ -302,16 +302,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lsbd = starfish.spots.DetectSpots.LocalSearchBlobDetector(\n",
+    "bd = starfish.spots.FindSpots.BlobDetector(\n",
     "    min_sigma=1,\n",
     "    max_sigma=8,\n",
     "    num_sigma=10,\n",
     "    threshold=np.percentile(np.ravel(stack.xarray.values), 95),\n",
-    "    exclude_border=2,\n",
-    "    anchor_round=0,\n",
-    "    search_radius=10,\n",
-    ")\n",
-    "intensities = lsbd.run(scaled, n_processes=8)"
+    "    exclude_border=2)\n",
+    "\n",
+    "spots = bd.run(scaled)"
    ]
   },
   {
@@ -331,7 +329,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "decoded = experiment.codebook.decode_per_round_max(IntensityTable(intensities.fillna(0)))\n",
+    "decoder = starfish.spots.DecodeSpots.PerRoundMaxChannel(\n",
+    "    codebook=experiment.codebook,\n",
+    "    anchor_round=0,\n",
+    "    search_radius=10,\n",
+    "    trace_building_strategy=TraceBuildingStrategies.NEAREST_NEIGHBOR)\n",
+    "\n",
+    "decoded = decoder.run(spots=spots)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "decode_mask = decoded['target'] != 'nan'\n",
     "\n",
     "# %gui qt\n",

--- a/notebooks/SeqFISH.ipynb
+++ b/notebooks/SeqFISH.ipynb
@@ -28,8 +28,7 @@
     "\n",
     "import starfish\n",
     "import starfish.data\n",
-    "from starfish.spots import DetectSpots\n",
-    "from starfish.types import Axes"
+    "from starfish.types import Axes, TraceBuildingStrategies"
    ]
   },
   {
@@ -196,15 +195,19 @@
    "source": [
     "threshold = 0.5\n",
     "\n",
-    "lsbd = starfish.spots.DetectSpots.LocalSearchBlobDetector(\n",
+    "bd = starfish.spots.FindSpots.BlobDetector(\n",
     "    min_sigma=(1.5, 1.5, 1.5),\n",
     "    max_sigma=(8, 8, 8),\n",
     "    num_sigma=10,\n",
-    "    threshold=threshold,\n",
-    "    search_radius=7\n",
-    ")\n",
-    "intensities = lsbd.run(clipped)\n",
-    "decoded = exp.codebook.decode_per_round_max(intensities.fillna(0))"
+    "    threshold=threshold)\n",
+    "\n",
+    "spots = bd.run(clipped)\n",
+    "decoder = starfish.spots.DecodeSpots.PerRoundMaxChannel(\n",
+    "    codebook=exp.codebook,\n",
+    "    search_radius=7,\n",
+    "    trace_building_strategy=TraceBuildingStrategies.NEAREST_NEIGHBOR)\n",
+    "\n",
+    "decoded = decoder.run(spots=spots)"
    ]
   },
   {
@@ -213,7 +216,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "starfish.display(clipped, intensities)"
+    "starfish.display(clipped, decoded)"
    ]
   },
   {

--- a/notebooks/py/SeqFISH.py
+++ b/notebooks/py/SeqFISH.py
@@ -23,8 +23,7 @@ from tqdm import tqdm
 
 import starfish
 import starfish.data
-from starfish.spots import DetectSpots
-from starfish.types import Axes
+from starfish.types import Axes, TraceBuildingStrategies
 # EPY: END code
 
 # EPY: START markdown
@@ -117,19 +116,23 @@ starfish.display(clipped)
 # EPY: START code
 threshold = 0.5
 
-lsbd = starfish.spots.DetectSpots.LocalSearchBlobDetector(
+bd = starfish.spots.FindSpots.BlobDetector(
     min_sigma=(1.5, 1.5, 1.5),
     max_sigma=(8, 8, 8),
     num_sigma=10,
-    threshold=threshold,
-    search_radius=7
-)
-intensities = lsbd.run(clipped)
-decoded = exp.codebook.decode_per_round_max(intensities.fillna(0))
+    threshold=threshold)
+
+spots = bd.run(clipped)
+decoder = starfish.spots.DecodeSpots.PerRoundMaxChannel(
+    codebook=exp.codebook,
+    search_radius=7,
+    trace_building_strategy=TraceBuildingStrategies.NEAREST_NEIGHBOR)
+
+decoded = decoder.run(spots=spots)
 # EPY: END code
 
 # EPY: START code
-starfish.display(clipped, intensities)
+starfish.display(clipped, decoded)
 # EPY: END code
 
 # EPY: START markdown

--- a/starfish/core/spots/DecodeSpots/per_round_max_channel_decoder.py
+++ b/starfish/core/spots/DecodeSpots/per_round_max_channel_decoder.py
@@ -1,9 +1,11 @@
+from typing import Callable, Optional
+
 from starfish.core.codebook.codebook import Codebook
 from starfish.core.intensity_table.decoded_intensity_table import DecodedIntensityTable
 from starfish.core.intensity_table.intensity_table_coordinates import \
     transfer_physical_coords_to_intensity_table
-from starfish.core.spots.DecodeSpots.trace_builders import build_spot_traces_exact_match
-from starfish.core.types import SpotFindingResults
+from starfish.core.spots.DecodeSpots.trace_builders import TRACE_BUILDERS
+from starfish.core.types import SpotFindingResults, TraceBuildingStrategies
 from ._base import DecodeSpotsAlgorithm
 
 
@@ -20,11 +22,28 @@ class PerRoundMaxChannel(DecodeSpotsAlgorithm):
     ----------
     codebook : Codebook
         Contains codes to decode IntensityTable
-
+    trace_building_strategy: TraceBuildingStrategies
+        Defines the strategy for building spot traces to decode across rounds and chs of spot
+        finding results.
+    search_radius : Optional[int]
+        Only applicable if trace_building_strategy is TraceBuildingStrategies.NEAREST_NEIGHBORS.
+        Number of pixels over which to search for spots in other rounds and channels.
+    anchor_round : Optional[int]
+        Only applicable if trace_building_strategy is TraceBuildingStrategies.NEAREST_NEIGHBORS.
+        The imaging round against which other rounds will be checked for spots in the same
+        approximate pixel location.
     """
 
-    def __init__(self, codebook: Codebook):
+    def __init__(
+            self,
+            codebook: Codebook,
+            trace_building_strategy: TraceBuildingStrategies = TraceBuildingStrategies.EXACT_MATCH,
+            anchor_round: Optional[int]=1,
+            search_radius: Optional[int]=3):
         self.codebook = codebook
+        self.trace_builder: Callable = TRACE_BUILDERS[trace_building_strategy]
+        self.anchor_round = anchor_round
+        self.search_radius = search_radius
 
     def run(self, spots: SpotFindingResults, *args) -> DecodedIntensityTable:
         """Decode spots by selecting the max-valued channel in each sequencing round
@@ -40,6 +59,8 @@ class PerRoundMaxChannel(DecodeSpotsAlgorithm):
             IntensityTable decoded and appended with Features.TARGET and Features.QUALITY values.
 
         """
-        intensities = build_spot_traces_exact_match(spots)
+        intensities = self.trace_builder(spot_results=spots,
+                                         anchor_round=self.anchor_round,
+                                         search_radius=self.search_radius)
         transfer_physical_coords_to_intensity_table(intensity_table=intensities, spots=spots)
         return self.codebook.decode_per_round_max(intensities)

--- a/starfish/core/spots/DecodeSpots/test/test_nearest_neighbor_trace_builder.py
+++ b/starfish/core/spots/DecodeSpots/test/test_nearest_neighbor_trace_builder.py
@@ -1,0 +1,167 @@
+import numpy as np
+from scipy.ndimage.filters import gaussian_filter
+
+from starfish import ImageStack
+from starfish.core.spots.DecodeSpots.trace_builders import build_traces_nearest_neighbors
+from starfish.core.spots.FindSpots import BlobDetector
+from starfish.core.types import Axes
+
+
+def traversing_code() -> ImageStack:
+    """this code walks in a sequential direction, and should only be detectable from some anchors"""
+    img = np.zeros((3, 2, 20, 50, 50), dtype=np.float32)
+
+    # code 1
+    img[0, 0, 5, 35, 35] = 10
+    img[1, 1, 5, 32, 32] = 10
+    img[2, 0, 5, 29, 29] = 10
+
+    # blur points
+    gaussian_filter(img, (0, 0, 0.5, 1.5, 1.5), output=img)
+
+    return ImageStack.from_numpy(img)
+
+
+def multiple_possible_neighbors() -> ImageStack:
+    """this image is intended to be tested with anchor_round in {0, 1}, last round has more spots"""
+    img = np.zeros((3, 2, 20, 50, 50), dtype=np.float32)
+
+    # round 1
+    img[0, 0, 5, 20, 40] = 10
+    img[0, 0, 5, 40, 20] = 10
+
+    # round 2
+    img[1, 1, 5, 20, 40] = 10
+    img[1, 1, 5, 40, 20] = 10
+
+    # round 3
+    img[2, 0, 5, 20, 40] = 10
+    img[2, 0, 5, 35, 35] = 10
+    img[2, 0, 5, 40, 20] = 10
+
+    # blur points
+    gaussian_filter(img, (0, 0, 0.5, 1.5, 1.5), output=img)
+
+    return ImageStack.from_numpy(img)
+
+
+def jitter_code() -> ImageStack:
+    """this code has some minor jitter <= 3px at the most distant point"""
+    img = np.zeros((3, 2, 20, 50, 50), dtype=np.float32)
+
+    # code 1
+    img[0, 0, 5, 35, 35] = 10
+    img[1, 1, 5, 34, 35] = 10
+    img[2, 0, 6, 35, 33] = 10
+
+    # blur points
+    gaussian_filter(img, (0, 0, 0.5, 1.5, 1.5), output=img)
+
+    return ImageStack.from_numpy(img)
+
+
+def two_perfect_codes() -> ImageStack:
+    """this code has no jitter"""
+    img = np.zeros((3, 2, 20, 50, 50), dtype=np.float32)
+
+    # code 1
+    img[0, 0, 5, 20, 35] = 10
+    img[1, 1, 5, 20, 35] = 10
+    img[2, 0, 5, 20, 35] = 10
+
+    # code 1
+    img[0, 0, 5, 40, 45] = 10
+    img[1, 1, 5, 40, 45] = 10
+    img[2, 0, 5, 40, 45] = 10
+
+    # blur points
+    gaussian_filter(img, (0, 0, 0.5, 1.5, 1.5), output=img)
+
+    return ImageStack.from_numpy(img)
+
+
+def blob_detector():
+    return BlobDetector(min_sigma=1, max_sigma=4, num_sigma=30, threshold=.1)
+
+
+def test_local_search_blob_detector_two_codes():
+    stack = two_perfect_codes()
+    bd = blob_detector()
+    spot_results = bd.run(stack)
+
+    intensity_table = build_traces_nearest_neighbors(spot_results=spot_results, anchor_round=1,
+                                                     search_radius=1)
+
+    assert intensity_table.shape == (2, 2, 3)
+    assert np.all(intensity_table[0][Axes.X.value] == 45)
+    assert np.all(intensity_table[0][Axes.Y.value] == 40)
+    assert np.all(intensity_table[0][Axes.ZPLANE.value] == 5)
+
+
+def test_local_search_blob_detector_jitter_code():
+    stack = jitter_code()
+
+    bd = blob_detector()
+    spot_results = bd.run(stack)
+    intensity_table = build_traces_nearest_neighbors(spot_results=spot_results, anchor_round=1,
+                                                     search_radius=3)
+
+    assert intensity_table.shape == (1, 2, 3)
+    f, c, r = np.where(~intensity_table.isnull())
+    assert np.all(f == np.array([0, 0, 0]))
+    assert np.all(c == np.array([0, 0, 1]))
+    assert np.all(r == np.array([0, 2, 1]))
+
+    # test again with smaller search radius
+    bd = BlobDetector(min_sigma=1, max_sigma=4, num_sigma=30, threshold=.1)
+    per_tile_spot_results = bd.run(stack)
+
+    intensity_table = build_traces_nearest_neighbors(spot_results=per_tile_spot_results,
+                                                     anchor_round=0,
+                                                     search_radius=1)
+
+    assert intensity_table.shape == (1, 2, 3)
+    f, c, r = np.where(~intensity_table.isnull())
+    assert np.all(f == 0)
+    assert np.all(c == 0)
+    assert np.all(r == 0)
+
+
+def test_local_search_blob_detector_traversing_code():
+    stack = traversing_code()
+
+    bd = blob_detector()
+    spot_results = bd.run(stack)
+    intensity_table = build_traces_nearest_neighbors(spot_results=spot_results, anchor_round=0,
+                                                     search_radius=5)
+
+    assert intensity_table.shape == (1, 2, 3)
+    f, c, r = np.where(~intensity_table.isnull())
+    assert np.all(f == np.array([0, 0]))
+    assert np.all(c == np.array([0, 1]))
+    assert np.all(r == np.array([0, 1]))
+
+    bd = blob_detector()
+    spot_results = bd.run(stack)
+    intensity_table = build_traces_nearest_neighbors(spot_results=spot_results, anchor_round=1,
+                                                     search_radius=5)
+
+    f, c, r = np.where(~intensity_table.isnull())
+    assert np.all(f == np.array([0, 0, 0]))
+    assert np.all(c == np.array([0, 0, 1]))
+    assert np.all(r == np.array([0, 2, 1]))
+
+
+def test_local_search_blob_detector_multiple_neighbors():
+    stack = multiple_possible_neighbors()
+
+    bd = blob_detector()
+    spot_results = bd.run(stack)
+    intensity_table = build_traces_nearest_neighbors(spot_results=spot_results, anchor_round=0,
+                                                     search_radius=4)
+
+    assert intensity_table.shape == (2, 2, 3)
+    f, c, r = np.where(~intensity_table.isnull())
+    assert np.all(intensity_table[Axes.ZPLANE.value] == (5, 5))
+    assert np.all(intensity_table[Axes.Y.value] == (40, 20))
+    assert np.all(intensity_table[Axes.X.value] == (20, 40))

--- a/starfish/core/spots/DecodeSpots/trace_builders.py
+++ b/starfish/core/spots/DecodeSpots/trace_builders.py
@@ -1,8 +1,11 @@
+from typing import Callable, Mapping
+
 from starfish.core.intensity_table.intensity_table import IntensityTable
-from starfish.core.types import Axes, Features, SpotFindingResults
+from starfish.core.types import Axes, Features, SpotFindingResults, TraceBuildingStrategies
+from .util import _build_intensity_table, _match_spots, _merge_spots_by_round
 
 
-def build_spot_traces_exact_match(spot_results: SpotFindingResults) -> IntensityTable:
+def build_spot_traces_exact_match(spot_results: SpotFindingResults, **kwargs) -> IntensityTable:
     """
     Combines spots found in matching x/y positions across rounds and channels of
     an ImageStack into traces represented as an IntensityTable.
@@ -10,7 +13,7 @@ def build_spot_traces_exact_match(spot_results: SpotFindingResults) -> Intensity
     Parameters
     -----------
     spot_results: SpotFindingResults
-        Spots found accrss rounds/channels of an ImageStack
+        Spots found across rounds/channels of an ImageStack
     """
     # create IntensityTable with same x/y/z info accross all r/ch
     spot_attributes = list(spot_results.values())[0]
@@ -25,3 +28,42 @@ def build_spot_traces_exact_match(spot_results: SpotFindingResults) -> Intensity
         value = 0 if value.empty else value
         intensity_table.loc[dict(c=c, r=r)] = value
     return intensity_table
+
+
+def build_traces_nearest_neighbors(spot_results: SpotFindingResults, anchor_round: int=1,
+                                   search_radius: int=3):
+    """
+    Combine spots found across round and channels of an ImageStack using a nearest neighbors
+    strategy
+
+    Parameters
+    -----------
+    spot_results : SpotFindingResults
+        Spots found across rounds/channels of an ImageStack
+    anchor_round : int
+        The imaging round against which other rounds will be checked for spots in the same
+        approximate pixel location.
+    search_radius : int
+        Number of pixels over which to search for spots in other rounds and channels.
+
+    """
+    per_round_spot_results = _merge_spots_by_round(spot_results)
+
+    distances, indices = _match_spots(
+        per_round_spot_results,
+        anchor_round=anchor_round
+    )
+    intensity_table = _build_intensity_table(
+        per_round_spot_results, distances, indices,
+        rounds=spot_results.round_labels,
+        channels=spot_results.ch_labels,
+        search_radius=search_radius,
+        anchor_round=anchor_round
+    )
+    return intensity_table
+
+
+TRACE_BUILDERS: Mapping[TraceBuildingStrategies, Callable] = {
+    TraceBuildingStrategies.EXACT_MATCH: build_spot_traces_exact_match,
+    TraceBuildingStrategies.NEAREST_NEIGHBOR: build_traces_nearest_neighbors
+}

--- a/starfish/core/spots/DecodeSpots/util.py
+++ b/starfish/core/spots/DecodeSpots/util.py
@@ -1,0 +1,158 @@
+from collections import defaultdict
+from typing import Any, Dict, Hashable, List, Mapping, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+from sklearn.neighbors import NearestNeighbors
+
+from starfish.core.intensity_table.intensity_table import IntensityTable
+from starfish.core.types import Axes, Features, SpotFindingResults
+
+
+def _match_spots(
+    round_dataframes: Dict[int, pd.DataFrame], anchor_round: int
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """ For each spot in anchor round, find the closest spot within search_radius in all rounds.
+
+    Parameters
+    ----------
+    round_dataframes : Dict[int, pd.DataFrame]
+        Output from _merge_spots_by_round, contains mapping of image volumes from each round to
+        all the spots detected in them.
+    anchor_round : int
+        The imaging round to seed the local search from.
+
+    Returns
+    -------
+    pd.DataFrame
+        Spots x rounds dataframe containing the distances to the nearest spot. np.nan if
+        no spot is detected within search radius
+    """
+    reference_df = round_dataframes[anchor_round]
+    reference_coordinates = reference_df[[Axes.ZPLANE, Axes.Y, Axes.X]]
+
+    dist = pd.DataFrame(
+        data=np.zeros((reference_df.shape[0], len(round_dataframes)), dtype=float),
+        columns=list(round_dataframes.keys())
+    )
+    ind = pd.DataFrame(
+        data=np.zeros((reference_df.shape[0], len(round_dataframes)), dtype=np.int32),
+        columns=list(round_dataframes.keys())
+    )
+
+    # fill data for anchor round; every spot is a perfect match to itself.
+    ind[anchor_round] = np.arange(reference_df.shape[0], dtype=np.int32)
+
+    # get spots matching across rounds
+    for r in sorted(set(round_dataframes.keys()) - {anchor_round, }):
+        query_df = round_dataframes[r]
+        query_coordinates = query_df[[Axes.ZPLANE, Axes.Y, Axes.X]]
+        nn = NearestNeighbors(n_neighbors=1)
+        nn.fit(query_coordinates)
+        distances, indices = nn.kneighbors(reference_coordinates)
+        dist[r] = distances
+        ind[r] = indices
+
+    return dist, ind
+
+
+def _build_intensity_table(
+    round_dataframes: Dict[int, pd.DataFrame],
+    dist: pd.DataFrame,
+    ind: pd.DataFrame,
+    channels: Sequence[int],
+    rounds: Sequence[int],
+    search_radius: int,
+    anchor_round: int,
+) -> IntensityTable:
+    """Construct an intensity table from the results of a local search over detected spots
+
+    Parameters
+    ----------
+    round_dataframes : Dict[int, pd.DataFrame]
+        Output from _merge_spots_by_round, contains mapping of image volumes from each round to
+        all the spots detected in them.
+    dist, ind : pd.DataFrame
+        Output from _match_spots, contains distances and indices to the nearest spot for each
+        spot in anchor_round.
+    channels, rounds : Sequence[int]
+        Channels and rounds present in the ImageStack from which spots were detected.
+    search_radius : int
+        The maximum (euclidean) distance in pixels for a spot to be considered matching in
+        a round subsequent to the anchor round.
+    anchor_round : int
+        The imaging round to seed the local search from.
+
+    """
+
+    anchor_df = round_dataframes[anchor_round]
+
+    # create empty IntensityTable filled with np.nan
+    data = np.full((dist.shape[0], len(channels), len(rounds)), fill_value=np.nan)
+    dims = (Features.AXIS, Axes.CH.value, Axes.ROUND.value)
+    coords: Mapping[Hashable, Tuple[str, Any]] = {
+        Features.SPOT_RADIUS: (Features.AXIS, anchor_df[Features.SPOT_RADIUS]),
+        Axes.ZPLANE.value: (Features.AXIS, anchor_df[Axes.ZPLANE]),
+        Axes.Y.value: (Features.AXIS, anchor_df[Axes.Y]),
+        Axes.X.value: (Features.AXIS, anchor_df[Axes.X]),
+        Axes.ROUND.value: (Axes.ROUND.value, rounds),
+        Axes.CH.value: (Axes.CH.value, channels)
+    }
+    intensity_table = IntensityTable(data=data, dims=dims, coords=coords)
+
+    # fill IntensityTable
+    for r in rounds:
+        # get intensity data and indices
+        spot_indices = ind[r]
+        intensity_data = round_dataframes[r].loc[spot_indices, Features.INTENSITY]
+        channel_index = round_dataframes[r].loc[spot_indices, Axes.CH]
+        round_index = np.full(ind.shape[0], fill_value=r, dtype=int)
+        feature_index = np.arange(ind.shape[0], dtype=int)
+
+        # mask spots that are outside the search radius
+        mask = np.asarray(dist[r] < search_radius)  # indices need not match
+        feature_index = feature_index[mask]
+        channel_index = channel_index[mask]
+        round_index = round_index[mask]
+        intensity_data = intensity_data[mask]
+
+        # need numpy indexing to set values in vectorized manner
+        intensity_table.values[feature_index, channel_index, round_index] = intensity_data
+
+    return intensity_table
+
+
+def _merge_spots_by_round(
+    spot_results: SpotFindingResults
+) -> Dict[int, pd.DataFrame]:
+    """Merge DataFrames containing spots from different channels into one DataFrame per round.
+
+    Parameters
+    ----------
+    spot_results : Dict[Tuple[int, int], pd.DataFrame]
+        Output of _find_spots. Dictionary mapping (round, channel) volumes to the spots detected
+        in them.
+
+    Returns
+    -------
+    Dict[int, pd.DataFrame]
+        Dictionary mapping round volumes to the spots detected in them. Contains an additional
+        column labeled by Axes.CH which identifies the channel in which a given spot was
+        detected.
+
+    """
+
+    # add channel information to each table and add it to round_data
+    round_data: Mapping[int, List] = defaultdict(list)
+    for (r, c), df in spot_results.items():
+        df = df.data
+        df[Axes.CH.value] = np.full(df.shape[0], c)
+        round_data[r].append(df)
+
+    # create one dataframe per round
+    round_dataframes = {
+        k: pd.concat(v, axis=0).reset_index().drop('index', axis=1)
+        for k, v in round_data.items()
+    }
+
+    return round_dataframes

--- a/starfish/core/spots/DetectSpots/local_search_blob_detector.py
+++ b/starfish/core/spots/DetectSpots/local_search_blob_detector.py
@@ -408,6 +408,12 @@ class LocalSearchBlobDetector(DetectSpotsAlgorithm):
             Contains detected coded spots.
 
         """
+        DeprecationWarning("Starfish is embarking on a SpotFinding data structures refactor"
+                           "(See https://github.com/spacetx/starfish/issues/1514) This version of "
+                           "LocalSearchBlobDetector will soon be deleted. To find and decode your"
+                           " spots please instead use FindSpots.BlobDetector then "
+                           "DecodeSpots.PerRoundMaxChannel with the parameter "
+                           "TraceBuildingStrategies.NEAREST_NEIGHBOR. See example in STARmap.py")
 
         if blobs_image is not None:
             raise ValueError(

--- a/starfish/core/spots/FindSpots/blob.py
+++ b/starfish/core/spots/FindSpots/blob.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Optional, Union
+from typing import Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -60,8 +60,8 @@ class BlobDetector(FindSpotsAlgorithm):
 
     def __init__(
             self,
-            min_sigma: Number,
-            max_sigma: Number,
+            min_sigma: Union[Number, Tuple[Number, ...]],
+            max_sigma: Union[Number, Tuple[Number, ...]],
             num_sigma: int,
             threshold: Number,
             overlap: float = 0.5,
@@ -102,28 +102,37 @@ class BlobDetector(FindSpotsAlgorithm):
 
         fitted_blobs_array: np.ndarray = self.detector_method(
             data_image,
-            self.min_sigma,
-            self.max_sigma,
-            self.num_sigma,
-            self.threshold,
-            self.overlap
+            min_sigma=self.min_sigma,
+            max_sigma=self.max_sigma,
+            threshold=self.threshold,
+            exclude_border=self.exclude_border,
+            overlap=self.overlap,
+            num_sigma=self.num_sigma
         )
 
         if fitted_blobs_array.shape[0] == 0:
             return SpotAttributes.empty(extra_fields=[Features.INTENSITY, Features.SPOT_ID])
 
-        # create the SpotAttributes Table
-        columns = [Axes.ZPLANE.value, Axes.Y.value, Axes.X.value, Features.SPOT_RADIUS]
-        fitted_blobs = pd.DataFrame(data=fitted_blobs_array, columns=columns)
+        # measure intensities
+        z_inds = fitted_blobs_array[:, 0].astype(int)
+        y_inds = fitted_blobs_array[:, 1].astype(int)
+        x_inds = fitted_blobs_array[:, 2].astype(int)
+        radius = np.round(fitted_blobs_array[:, 3] * np.sqrt(3))
+        data_image = data_image.values if isinstance(data_image, xr.DataArray) else data_image
+        intensities = data_image[tuple([z_inds, y_inds, x_inds])]
 
-        # convert standard deviation of gaussian kernel used to identify spot to radius of spot
-        converted_radius = np.round(fitted_blobs[Features.SPOT_RADIUS] * np.sqrt(3))
-        fitted_blobs[Features.SPOT_RADIUS] = converted_radius
-
-        # convert the array to int so it can be used to index
-        spots = SpotAttributes(fitted_blobs)
+        # construct dataframe
+        spot_data = pd.DataFrame(
+            data={
+                Features.INTENSITY: intensities,
+                Axes.ZPLANE.value: z_inds,
+                Axes.Y.value: y_inds,
+                Axes.X.value: x_inds,
+                Features.SPOT_RADIUS: radius,
+            }
+        )
+        spots = SpotAttributes(spot_data)
         spots.data[Features.SPOT_ID] = np.arange(spots.data.shape[0])
-
         return spots
 
     def run(

--- a/starfish/core/types/__init__.py
+++ b/starfish/core/types/__init__.py
@@ -11,6 +11,7 @@ from ._constants import (
     PHYSICAL_COORDINATE_DIMENSION,
     PhysicalCoordinateTypes,
     STARFISH_EXTRAS_KEY,
+    TraceBuildingStrategies,
     TransformType
 )
 from ._decoded_spots import DecodedSpots

--- a/starfish/core/types/_constants.py
+++ b/starfish/core/types/_constants.py
@@ -104,3 +104,11 @@ class TransformType(AugmentedEnum):
     currently supported transform types
     """
     SIMILARITY = 'similarity'
+
+
+class TraceBuildingStrategies(AugmentedEnum):
+    """
+    currently support spot trace building strategies
+    """
+    EXACT_MATCH = 'exact_match'
+    NEAREST_NEIGHBOR = 'nearest_neighbor'

--- a/starfish/core/types/_spot_finding_results.py
+++ b/starfish/core/types/_spot_finding_results.py
@@ -30,8 +30,8 @@ class SpotFindingResults:
         """
         spot_attributes_list = spot_attributes_list or []
         self._results: MutableMapping[Tuple, SpotAttributes] = {
-            indices: spots
-            for indices, spots in spot_attributes_list
+            tuple(indices[i] for i in AXES_ORDER): spots
+            for spots, indices in spot_attributes_list
         }
         self.physical_coord_ranges: Mapping[Hashable, xr.DataArray] = {
             Axes.X.value: imagestack_coords[Coordinates.X.value],
@@ -68,6 +68,12 @@ class SpotFindingResults:
         """
         round_ch_index = tuple(indices[i] for i in AXES_ORDER)
         return self._results[round_ch_index]
+
+    def items(self):
+        """
+        Return iterator for Spot finding results
+        """
+        return self._results.items()
 
     def keys(self):
         """

--- a/starfish/types.py
+++ b/starfish/types.py
@@ -11,6 +11,7 @@ from starfish.core.types import (  # noqa: F401
     PHYSICAL_COORDINATE_DIMENSION,
     PhysicalCoordinateTypes,
     STARFISH_EXTRAS_KEY,
+    TraceBuildingStrategies,
     TransformType,
 )
 from starfish.core.types import CoordinateValue, Number  # noqa: F401


### PR DESCRIPTION
Both STARmap and current Seqfish currently use LocalSearchBlobDetector. This refactor eliminates the need for a separate LocalSearchBlobDetector class and instead both assays now use the regular BlobDetector and the PerRoundMaxChannel with a trace building strategy of 'nearest neighbors'. A lot of the changes here are mostly just moving code that already existed in LocalSearchBlobDetector and a few changes to make BlobDetector work for both ISS and STARmap.

depends on: #1518 #1517