### PR TITLE
Fix dimension ordering on Codebook and IntensityTable

### DIFF
--- a/starfish/core/codebook/test/test_approximate_nearest_code.py
+++ b/starfish/core/codebook/test/test_approximate_nearest_code.py
@@ -16,12 +16,12 @@ def test_simple_intensities_find_correct_nearest_code():
     data = np.array(
         [[[0, 0.5],
           [0.5, 0]],
-         [[0, 0.5],
-          [0, 0.5]],
-         [[0.5, 0],
-          [0.5, 0]],
          [[0, 0],
-          [0.5, 0.5]]]
+          [0.5, 0.5]],
+         [[0.5, 0.5],
+          [0, 0]],
+         [[0, 0.5],
+          [0, 0.5]]]
     )
     intensities = intensity_table_factory(data=data)
     codebook = codebook_factory()

--- a/starfish/core/codebook/test/test_from_code_array.py
+++ b/starfish/core/codebook/test/test_from_code_array.py
@@ -44,10 +44,10 @@ def assert_sizes(codebook, check_values=True):
         return
 
     # codebook should have 4 "on" combinations
-    expected_values = np.zeros((2, 3, 2))
+    expected_values = np.zeros((2, 2, 3))
     expected_values[0, 0, 0] = 1
     expected_values[0, 1, 1] = 1
-    expected_values[1, 2, 0] = 1
+    expected_values[1, 0, 2] = 1
     expected_values[1, 1, 1] = 1
 
     assert np.array_equal(codebook.values, expected_values)
@@ -129,7 +129,7 @@ def test_from_code_array_throws_exception_when_data_is_improperly_formatted():
 def test_empty_codebook():
     code_array: List = codebook_array_factory()
     targets = [x[Features.TARGET] for x in code_array]
-    codebook = Codebook.zeros(targets, n_channel=3, n_round=2)
+    codebook = Codebook.zeros(targets, n_round=2, n_channel=3)
     assert_sizes(codebook, False)
 
 def test_create_codebook():
@@ -137,12 +137,12 @@ def test_create_codebook():
     targets = [x[Features.TARGET] for x in code_array]
 
     # Loop performed by from_code_array
-    data = np.zeros((2, 3, 2), dtype=np.uint8)
+    data = np.zeros((2, 2, 3), dtype=np.uint8)
     for i, code_dict in enumerate(code_array):
         for bit in code_dict[Features.CODEWORD]:
             ch = int(bit[Axes.CH])
             r = int(bit[Axes.ROUND])
-            data[i, ch, r] = int(bit[Features.CODE_VALUE])
+            data[i, r, ch] = int(bit[Features.CODE_VALUE])
 
-    codebook = Codebook.from_numpy(targets, n_channel=3, n_round=2, data=data)
+    codebook = Codebook.from_numpy(targets, n_round=2, n_channel=3, data=data)
     assert_sizes(codebook)

--- a/starfish/core/codebook/test/test_metric_decode.py
+++ b/starfish/core/codebook/test/test_metric_decode.py
@@ -66,10 +66,10 @@ def test_metric_decode():
     match
     """
     data = np.array(
-        [[[0, 3],  # this code is decoded "right"
-          [4, 0]],
-         [[0, 0.4],  # this code should be filtered based on magnitude
-          [0, 0.3]],
+        [[[0, 4],  # this code is decoded "right"
+          [3, 0]],
+         [[0, 0],  # this code should be filtered based on magnitude
+          [0.4, 0.3]],
          [[30, 0],  # this code should be filtered based on distance
           [0, 40]]]
     )

--- a/starfish/core/codebook/test/test_per_round_max_decode.py
+++ b/starfish/core/codebook/test/test_per_round_max_decode.py
@@ -24,8 +24,8 @@ def intensity_table_factory(data: np.ndarray=np.array([[[0, 3], [4, 0]]])) -> In
     spot_attributes = SpotAttributes(spot_attributes_data)
     intensity_table = IntensityTable.from_spot_data(
         data, spot_attributes,
-        ch_values=np.arange(data.shape[1]),
-        round_values=np.arange(data.shape[2]),
+        round_values=np.arange(data.shape[1]),
+        ch_values=np.arange(data.shape[2]),
     )
     return intensity_table
 
@@ -54,14 +54,17 @@ def codebook_factory() -> Codebook:
     return Codebook.from_code_array(codebook_array)
 
 
-def test_intensity_tables_with_different_nubmers_of_codes_or_channels_throw_value_error():
+def test_intensity_tables_with_different_numbers_of_codes_or_channels_throw_value_error():
     """
     The test passes a 3-round and 1-round IntensityTable to a 2-round codebook. Both should
     raise a ValueError.
     """
     data = np.array(
-        [[[4, 3, 1],
-          [4, 0, 2]]]
+        [[[4, 4],
+          [3, 0],
+          [1, 2],
+          ]
+         ]
     )
     codebook = codebook_factory()
     intensities = intensity_table_factory(data)

--- a/starfish/core/intensity_table/test/test_concatenate.py
+++ b/starfish/core/intensity_table/test/test_concatenate.py
@@ -43,7 +43,7 @@ def test_intensity_table_concatenation():
 
     # slice out z in addition to reduce the total feature number by 1/2
     i4 = intensities.where(np.logical_and(intensities.r == 0, intensities.z == 1), drop=True)
-    expected_shape = (i1.shape[0] + i4.shape[0], 3, 1)
+    expected_shape = (i1.shape[0] + i4.shape[0], 1, 3)
     result = concatenate([i1, i4])
 
     assert expected_shape == result.shape

--- a/starfish/core/intensity_table/test/test_empty_intensity_table.py
+++ b/starfish/core/intensity_table/test/test_empty_intensity_table.py
@@ -29,8 +29,8 @@ def test_intensity_table_can_be_created_from_spot_attributes():
 
     intensities = IntensityTable.zeros(
         spot_attributes,
+        round_labels=np.arange(3),
         ch_labels=np.arange(1),
-        round_labels=np.arange(3)
     )
 
     assert intensities.sizes[Axes.CH] == 1

--- a/starfish/core/intensity_table/test/test_stack_intensity_table_reshaping.py
+++ b/starfish/core/intensity_table/test/test_stack_intensity_table_reshaping.py
@@ -42,7 +42,7 @@ def pixel_intensities_to_imagestack(
     # reverses the process used to produce the intensity table in to_pixel_intensities
     data = intensities.values.reshape([
         *image_shape,
-        intensities.sizes[Axes.CH],
-        intensities.sizes[Axes.ROUND]])
-    data = data.transpose(4, 3, 0, 1, 2)
+        intensities.sizes[Axes.ROUND],
+        intensities.sizes[Axes.CH]])
+    data = data.transpose(3, 4, 0, 1, 2)
     return ImageStack.from_numpy(data)

--- a/starfish/core/intensity_table/test/test_synthetic_intensities.py
+++ b/starfish/core/intensity_table/test/test_synthetic_intensities.py
@@ -40,9 +40,7 @@ def test_synthetic_intensity_generation():
     assert np.all(intensities[Axes.X.value] <= width)
 
     # both codes should match GENE_B
-    assert np.array_equal(
-        np.where(intensities.values),
-        [[0, 0, 1, 1],  # two each in feature 0 & 1
-         [1, 2, 1, 2],  # one each in channel 1 & 2
-         [1, 0, 1, 0]],  # channel 1 matches round 1, channel 2 matches round zero
-    )
+    gene_b_intensities = codebook.sel(target="GENE_B")
+    for feature_id in range(intensities.sizes[Features.AXIS]):
+        feature_intensities = intensities[{Features.AXIS: feature_id}]
+        assert np.array_equal(gene_b_intensities.values, feature_intensities.values)

--- a/starfish/core/spots/DetectPixels/combine_adjacent_features.py
+++ b/starfish/core/spots/DetectPixels/combine_adjacent_features.py
@@ -153,7 +153,7 @@ class CombineAdjacentFeatures:
     ) -> IntensityTable:
         """
         For all pixels that contribute to a connected component, calculate the mean value for
-        each (ch, round), producing an average "trace" of a feature across the imaging experiment
+        each (round, ch), producing an average "trace" of a feature across the imaging experiment
 
         Parameters
         ----------
@@ -179,7 +179,7 @@ class CombineAdjacentFeatures:
         # faster-alternative-to-perform-pandas-groupby-operation
 
         # stack intensities
-        stacked = intensities.stack(traces=(Axes.CH.value, Axes.ROUND.value))
+        stacked = intensities.stack(traces=(Axes.ROUND.value, Axes.CH.value))
 
         # drop into pandas to use their faster groupby
         traces: pd.DataFrame = pd.DataFrame(

--- a/starfish/core/spots/DetectPixels/test/test_calculate_mean_pixel_traces.py
+++ b/starfish/core/spots/DetectPixels/test/test_calculate_mean_pixel_traces.py
@@ -61,19 +61,15 @@ def test_calculate_mean_pixel_traces():
     # evaluate the mean pixel traces, we have 4 different spot ids
     assert np.unique(label_image).shape[0] == mean_pixel_traces.shape[0]
 
-    # there should be two channels and 1 round
+    # there should be one round and two channels
     assert np.array_equal(intensity_table.shape[1:], mean_pixel_traces.shape[1:])
 
     # values can be calculated from the simple example, and should match the mean pixel traces
     expected_values = np.array(
-        [[[.25],
-          [.15]],
-         [[.25],
-          [.2]],
-         [[.15],
-          [.25]],
-         [[.2],
-          [.25]]],
+        [[[.25, .15]],
+         [[.25, .2]],
+         [[.15, .25]],
+         [[.2, .25]]],
         dtype=np.float32
     )
     assert np.allclose(expected_values, mean_pixel_traces.values)

--- a/starfish/core/spots/DetectSpots/detect.py
+++ b/starfish/core/spots/DetectSpots/detect.py
@@ -100,8 +100,8 @@ def measure_spot_intensities(
     # construct the empty intensity table
     intensity_table = IntensityTable.zeros(
         spot_attributes=spot_attributes,
-        ch_labels=ch_labels,
         round_labels=round_labels,
+        ch_labels=ch_labels,
     )
 
     # if no spots were detected, return the empty IntensityTable
@@ -150,7 +150,7 @@ def concatenate_spot_attributes_to_intensities(
     features_coordinates = all_spots.drop(['spot_id', 'intensity'], axis=1)
 
     intensity_table = IntensityTable.zeros(
-        SpotAttributes(features_coordinates), ch_values, round_values,
+        SpotAttributes(features_coordinates), round_values, ch_values,
     )
 
     i = 0

--- a/starfish/core/spots/DetectSpots/test/test_synthetic_data.py
+++ b/starfish/core/spots/DetectSpots/test/test_synthetic_data.py
@@ -37,11 +37,11 @@ def test_round_trip_synthetic_data():
     # applying the gaussian blur to the intensities causes them to be reduced in magnitude, so
     # they won't be the same size, but they should be in the same place, and decode the same
     # way
-    spot1, ch1, round1 = np.where(intensities.values)
-    spot2, ch2, round2 = np.where(calculated_intensities.values)
+    spot1, round1, ch1 = np.where(intensities.values)
+    spot2, round2, ch2 = np.where(calculated_intensities.values)
     assert np.array_equal(spot1, spot2)
-    assert np.array_equal(ch1, ch2)
     assert np.array_equal(round1, round2)
+    assert np.array_equal(ch1, ch2)
     assert len(decoded_intensities.coords[Features.TARGET]) == 1
 
 

--- a/starfish/core/test/factories.py
+++ b/starfish/core/test/factories.py
@@ -206,8 +206,8 @@ class SyntheticData:
         # at the end of the function
         intensities.values = img_as_uint(intensities)
 
-        for ch, round_ in product(*(range(s) for s in intensities.shape[1:])):
-            spots = intensities[:, ch, round_]
+        for round_, ch in product(*(range(s) for s in intensities.shape[1:])):
+            spots = intensities[{Axes.ROUND.value: round_, Axes.CH.value: ch}]
 
             # numpy deprecated casting a specific way of casting floats that is triggered in xarray
             with warnings.catch_warnings():

--- a/starfish/core/test/test_synthetic_spot_creation.py
+++ b/starfish/core/test/test_synthetic_spot_creation.py
@@ -20,7 +20,7 @@ def test_synthetic_spot_creation_produces_an_imagestack_with_correct_spot_locati
 
     codebook, true_intensities, image = synthetic_spot_pass_through_stack()
 
-    g, c, r = np.where(true_intensities.values)
+    g, r, c = np.where(true_intensities.values)
 
     x = np.empty_like(g)
     y = np.empty_like(g)


### PR DESCRIPTION
These two seem to think that 'c' precedes 'r', which is different from the rest of the codebase.
