### PR TITLE
Add __slots__ to classes that subclass xr.DataArray

### DIFF
--- a/starfish/core/codebook/codebook.py
+++ b/starfish/core/codebook/codebook.py
@@ -61,6 +61,8 @@ class Codebook(xr.DataArray):
 
     """
 
+    __slots__ = ()
+
     @property
     def code_length(self) -> int:
         """return the length of codes in this codebook"""

--- a/starfish/core/expression_matrix/expression_matrix.py
+++ b/starfish/core/expression_matrix/expression_matrix.py
@@ -27,6 +27,8 @@ class ExpressionMatrix(xr.DataArray):
         load an ExpressionMatrix from netCDF
     """
 
+    __slots__ = ()
+
     def save(self, filename: str) -> None:
         """Save an ExpressionMatrix as a Netcdf File
 

--- a/starfish/core/intensity_table/decoded_intensity_table.py
+++ b/starfish/core/intensity_table/decoded_intensity_table.py
@@ -57,6 +57,8 @@ class DecodedIntensityTable(IntensityTable):
 
         """
 
+    __slots__ = ()
+
     @classmethod
     def from_intensity_table(
             cls,

--- a/starfish/core/intensity_table/intensity_table.py
+++ b/starfish/core/intensity_table/intensity_table.py
@@ -73,6 +73,8 @@ class IntensityTable(xr.DataArray):
           * c         (c) int64 0 1 2
     """
 
+    __slots__ = ()
+
     @staticmethod
     def _build_xarray_coords(
             spot_attributes: SpotAttributes,


### PR DESCRIPTION
The absence of `__slots__` triggers a warning.

Test plan: travis alltest!