### PR TITLE
Don't fill a new ImageStack with NaN

### DIFF
--- a/starfish/core/imagestack/imagestack.py
+++ b/starfish/core/imagestack/imagestack.py
@@ -129,7 +129,6 @@ class ImageStack:
 
         # now that we know the tile data type (kind and size), we can allocate the data array.
         np_array = np.empty(shape=data_shape, dtype=np.float32)
-        np_array.fill(np.nan)
         data = xr.DataArray(
             np_array,
             dims=data_dimensions,


### PR DESCRIPTION
We've used this codepath enough that it's reasonably safe to assume that it'll work.  This avoids the allocation of memory until the data is actually filled in.

Test plan: travis.