### PR TITLE
Make regionprops available per mask

### DIFF
--- a/starfish/core/segmentation_mask/test/test_segmentation_mask.py
+++ b/starfish/core/segmentation_mask/test/test_segmentation_mask.py
@@ -138,3 +138,9 @@ def test_save_load():
             assert np.array_equal(m, m2)
     finally:
         os.remove(path)
+
+    # ensure that the regionprops are equal
+    for ix in range(len(masks)):
+        original_props = masks.mask_regionprops(ix)
+        recalculated_props = masks.mask_regionprops(ix)
+        assert original_props == recalculated_props


### PR DESCRIPTION
regionprops are useful to characterize and filter segmented cells.  This PR changes what we store for mask data to be a tuple of binary mask and regionprops.  If we construct a mask collection from a labeled image, we retain the region props that are automatically calculated as a part of this conversion process.  If we construct a mask collection from what's stored on disk, we will calculate the regionprops when requested.

Test plan: Save to disk a mask collection generated from a labeled image, and after loading it from disk, verify that the region props of the two mask collections match.

Part of #1497