### PR TITLE
10.) Formalizing the ability to return extra info from spot finding 

### DIFF
--- a/starfish/core/spots/DecodeSpots/util.py
+++ b/starfish/core/spots/DecodeSpots/util.py
@@ -145,7 +145,7 @@ def _merge_spots_by_round(
     # add channel information to each table and add it to round_data
     round_data: Mapping[int, List] = defaultdict(list)
     for (r, c), df in spot_results.items():
-        df = df.data
+        df = df.spot_attrs.data
         df[Axes.CH.value] = np.full(df.shape[0], c)
         round_data[r].append(df)
 

--- a/starfish/core/spots/FindSpots/trackpy_local_max_peak_finder.py
+++ b/starfish/core/spots/FindSpots/trackpy_local_max_peak_finder.py
@@ -9,7 +9,7 @@ from trackpy import locate
 from starfish.core.image.Filter.util import determine_axes_to_group_by
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.spots.FindSpots import spot_finding_utils
-from starfish.core.types import Axes, SpotAttributes, SpotFindingResults
+from starfish.core.types import Axes, PerImageSliceSpotResults, SpotAttributes, SpotFindingResults
 from ._base import FindSpotsAlgorithm
 
 
@@ -92,7 +92,8 @@ class TrackpyLocalMaxPeakFinder(FindSpotsAlgorithm):
         self.verbose = verbose
         self.radius_is_gyration = radius_is_gyration
 
-    def image_to_spots(self, data_image: Union[np.ndarray, xr.DataArray]) -> SpotAttributes:
+    def image_to_spots(self, data_image: Union[np.ndarray, xr.DataArray]
+                       ) -> PerImageSliceSpotResults:
         """
 
         Parameters
@@ -102,8 +103,9 @@ class TrackpyLocalMaxPeakFinder(FindSpotsAlgorithm):
 
         Returns
         -------
-        SpotAttributes :
-            spot attributes table for all detected spots
+        PerImageSpotResults :
+            includes a SpotAttributes DataFrame of metadata containing the coordinates, intensity
+            and radius of each spot, as well as any extra information collected during spot finding.
 
         """
         data_image = np.asarray(data_image)
@@ -140,7 +142,7 @@ class TrackpyLocalMaxPeakFinder(FindSpotsAlgorithm):
             attributes.columns = new_colnames
 
         attributes['spot_id'] = np.arange(attributes.shape[0])
-        return SpotAttributes(attributes)
+        return PerImageSliceSpotResults(spot_attrs=SpotAttributes(attributes), extras=None)
 
     def run(
             self,

--- a/starfish/core/types/__init__.py
+++ b/starfish/core/types/__init__.py
@@ -17,7 +17,7 @@ from ._constants import (
 from ._decoded_spots import DecodedSpots
 from ._functionsource import FunctionSource
 from ._spot_attributes import SpotAttributes
-from ._spot_finding_results import SpotFindingResults
+from ._spot_finding_results import PerImageSliceSpotResults, SpotFindingResults
 
 Number = Union[int, float]
 CoordinateValue = Union[Number, Tuple[Number, Number]]

--- a/starfish/core/types/_constants.py
+++ b/starfish/core/types/_constants.py
@@ -21,7 +21,6 @@ class Coordinates(AugmentedEnum):
 
 
 PHYSICAL_COORDINATE_DIMENSION = "physical_coordinate"
-
 """
 This is the xarray dimension name for the physical coordinates of the tiles.
 """

--- a/starfish/types.py
+++ b/starfish/types.py
@@ -8,6 +8,7 @@ from starfish.core.types import (  # noqa: F401
     FunctionSource,
     LOG,
     OverlapStrategy,
+    PerImageSliceSpotResults,
     PHYSICAL_COORDINATE_DIMENSION,
     PhysicalCoordinateTypes,
     STARFISH_EXTRAS_KEY,


### PR DESCRIPTION
Changes the return value for every image_to_spots method to PerImageSpotResults, a named tuple that contains the SpotAttributes found in the image as well as any extra information for QC and debugging. The only spot finder that returns extra data at this point is PeakLocalMax which now returns threshold information. 

fixes: #908, #708