### PR TITLE
Logging improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     },
     entry_points={
         'console_scripts': [
-            "starfish=starfish:starfish",
+            "starfish=starfish.core.starfish:starfish",
         ]
     },
     include_package_data=True,

--- a/starfish/__init__.py
+++ b/starfish/__init__.py
@@ -20,4 +20,4 @@ from .core.imagestack.imagestack import ImageStack
 from .core.intensity_table.decoded_intensity_table import DecodedIntensityTable
 from .core.intensity_table.intensity_table import IntensityTable
 from .core.segmentation_mask import SegmentationMaskCollection
-from .core.starfish import starfish
+from .core.util.logging import Log


### PR DESCRIPTION
1. Reduce the susceptibility for circular imports.  Right now, there is an arc from logging -> types -> SpotFindingResults -> logging.
2. Add a method to decode an encoded log back into a Log object.
3. Expose Log as a top-level starfish construct. (i.e., in the `starfish` namespace)

Test plan: travvvvvvis.