### PR TITLE
Clean up binary mask

### DIFF
--- a/starfish/core/binary_mask/expand.py
+++ b/starfish/core/binary_mask/expand.py
@@ -4,14 +4,14 @@ import numpy as np
 import xarray as xr
 
 from starfish.types import Axes
-from .util import _get_axes_names, AXES_ORDER
+from .util import _get_axes_names
 
 
 def fill_from_mask(
         mask: xr.DataArray,
         fill_value: int,
         result_array: np.ndarray,
-        axes_order: Sequence[Union[str, Axes]] = AXES_ORDER,
+        axes_order: Sequence[Union[str, Axes]] = (Axes.ZPLANE, Axes.Y, Axes.X),
 ):
     """Take a binary mask with labeled axes and write `fill_value` to an array `result_array` where
     the binary mask has a True value.  The output array is assumed to have a zero origin.  The input

--- a/starfish/core/binary_mask/test/test_binary_mask.py
+++ b/starfish/core/binary_mask/test/test_binary_mask.py
@@ -75,30 +75,30 @@ def test_from_label_image():
 
     assert len(masks) == 2
 
-    region_1, region_2 = masks
+    region_0, region_1 = masks
 
+    assert region_0.name == '0'
     assert region_1.name == '1'
-    assert region_2.name == '2'
 
-    assert np.array_equal(region_1, np.ones((1, 5), dtype=np.bool))
+    assert np.array_equal(region_0, np.ones((1, 5), dtype=np.bool))
     temp = np.ones((2, 2), dtype=np.bool)
     temp[-1, -1] = False
-    assert np.array_equal(region_2, temp)
+    assert np.array_equal(region_1, temp)
 
-    assert np.array_equal(region_1[Axes.Y.value], [0])
-    assert np.array_equal(region_1[Axes.X.value], [0, 1, 2, 3, 4])
+    assert np.array_equal(region_0[Axes.Y.value], [0])
+    assert np.array_equal(region_0[Axes.X.value], [0, 1, 2, 3, 4])
 
-    assert np.array_equal(region_2[Axes.Y.value], [3, 4])
-    assert np.array_equal(region_2[Axes.X.value], [3, 4])
+    assert np.array_equal(region_1[Axes.Y.value], [3, 4])
+    assert np.array_equal(region_1[Axes.X.value], [3, 4])
 
-    assert np.array_equal(region_1[Coordinates.Y.value],
+    assert np.array_equal(region_0[Coordinates.Y.value],
                           physical_ticks[Coordinates.Y][0:1])
-    assert np.array_equal(region_1[Coordinates.X.value],
+    assert np.array_equal(region_0[Coordinates.X.value],
                           physical_ticks[Coordinates.X][0:5])
 
-    assert np.array_equal(region_2[Coordinates.Y.value],
+    assert np.array_equal(region_1[Coordinates.Y.value],
                           physical_ticks[Coordinates.Y][3:5])
-    assert np.array_equal(region_2[Coordinates.X.value],
+    assert np.array_equal(region_1[Coordinates.X.value],
                           physical_ticks[Coordinates.X][3:5])
 
 

--- a/starfish/core/binary_mask/util.py
+++ b/starfish/core/binary_mask/util.py
@@ -3,32 +3,28 @@ from typing import List, Tuple
 from starfish.core.types import Axes, Coordinates
 
 
-AXES = [a.value for a in Axes if a not in (Axes.ROUND, Axes.CH)]
-COORDS = [c.value for c in Coordinates]
-AXES_ORDER = Axes.ZPLANE, Axes.Y, Axes.X
-
-
-def _get_axes_names(ndim: int) -> Tuple[List[str], List[str]]:
-    """Get needed axes names given the number of dimensions.
+def _get_axes_names(ndim: int) -> Tuple[List[Axes], List[Coordinates]]:
+    """Get needed axes and coordinates given the number of dimensions.  The axes and coordinates are
+    returned in the order expected for binary masks.  For instance, the first axis/coordinate
+    should be the first index into the mask.
 
     Parameters
     ----------
     ndim : int
         Number of dimensions.
-
     Returns
     -------
-    axes : List[str]
-        Axes names.
-    coords : List[str]
-        Coordinates names.
+    axes : List[Axes]
+        Axes.
+    coords : List[Coordinates]
+        Coordinates.
     """
     if ndim == 2:
-        axes = [axis for axis in AXES if axis != Axes.ZPLANE.value]
-        coords = [coord for coord in COORDS if coord != Coordinates.Z.value]
+        axes = [Axes.Y, Axes.X]
+        coords = [Coordinates.Y, Coordinates.X]
     elif ndim == 3:
-        axes = AXES
-        coords = COORDS
+        axes = [Axes.ZPLANE, Axes.Y, Axes.X]
+        coords = [Coordinates.Z, Coordinates.Y, Coordinates.X]
     else:
         raise TypeError('expected 2- or 3-D image')
 

--- a/starfish/test/full_pipelines/api/test_iss_api.py
+++ b/starfish/test/full_pipelines/api/test_iss_api.py
@@ -138,5 +138,5 @@ def test_iss_pipeline_cropped_data(tmpdir):
     assert pipeline_log[2]['method'] == 'BlobDetector'
     assert pipeline_log[3]['method'] == 'PerRoundMaxChannel'
 
-    # 28 of the spots are assigned to cell 1 (although most spots do not decode!)
-    assert np.sum(assigned['cell_id'] == '1') == 28
+    # 28 of the spots are assigned to cell 0 (although most spots do not decode!)
+    assert np.sum(assigned['cell_id'] == '0') == 28


### PR DESCRIPTION
1. Use typed axes/coordinates when possible.
2. Have `_get_axes_names` return axes/coordinates in the order they are expected in the numpy arrays.
3. Improve how we render the mask names.

Test plan: `pytest starfish/core/binary_mask/test`