### PR TITLE
Composite codebook support

### DIFF
--- a/starfish/core/codebook/codebook.py
+++ b/starfish/core/codebook/codebook.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, TypeVar, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Tuple, TypeVar, Union
 
 import numpy as np
 import pandas as pd
@@ -17,11 +17,11 @@ from starfish.core.codebook._format import (
     MIN_SUPPORTED_VERSION,
 )
 from starfish.core.config import StarfishConfig
+from starfish.core.imagestack import indexing_utils
 from starfish.core.intensity_table.decoded_intensity_table import DecodedIntensityTable
 from starfish.core.intensity_table.intensity_table import IntensityTable
 from starfish.core.spacetx_format.util import CodebookValidator
 from starfish.core.types import Axes, Features, Number
-
 
 NormalizedFeaturesArgtype = TypeVar("NormalizedFeaturesArgtype", "Codebook", IntensityTable)
 
@@ -388,6 +388,20 @@ class Codebook(xr.DataArray):
         cls._verify_version(version_str)
 
         return cls.from_code_array(codebook_doc[DocumentKeys.MAPPINGS_KEY], n_round, n_channel)
+
+    def get_partial(self, indexers: Mapping[Axes, Union[int, slice, Sequence]]):
+        """
+        Slice the codebook data according to the provided indexing parameters. Used in a composite
+        codebook scenario.
+
+        Parameters
+        ----------
+        indexers : Mapping[Axes, Union[int, Sequence]]
+            A dictionary of dim:index where index is the value, values or range to index the
+            dimension
+        """
+        selector = indexing_utils.convert_to_selector(indexers)
+        return indexing_utils.index_keep_dimensions(self, indexers=selector)
 
     def to_json(self, filename: Union[str, Path]) -> None:
         """

--- a/starfish/core/imagestack/imagestack.py
+++ b/starfish/core/imagestack/imagestack.py
@@ -375,14 +375,15 @@ class ImageStack:
         self._ensure_data_loaded()
         return self._data
 
-    def sel(self, indexers: Mapping[Axes, Union[int, tuple]]):
+    def sel(self, indexers: Mapping[Axes, Union[int, slice, Sequence]]):
         """Given a dictionary mapping the index name to either a value or a range represented as a
         tuple, return an Imagestack with each dimension indexed accordingly
 
         Parameters
         ----------
-        indexers : Mapping[Axes, Union[int, tuple]]
-            A dictionary of dim:index where index is the value or range to index the dimension
+        indexers : Mapping[Axes, Union[int, Union[int, Sequence]]
+            A dictionary of dim:index where index is the value, values, or range to index the
+            dimension
 
         Examples
         --------
@@ -413,14 +414,15 @@ class ImageStack:
         stack._data = indexing_utils.index_keep_dimensions(self.xarray, selector)
         return stack
 
-    def isel(self, indexers: Mapping[Axes, Union[int, tuple]]):
+    def isel(self, indexers: Mapping[Axes, Union[int, Sequence]]):
         """Given a dictionary mapping the index name to either a value or a range represented as a
         tuple, return an Imagestack with each dimension indexed by position accordingly
 
         Parameters
         ----------
-        indexers : Dict[Axes, (int/tuple)]
-            A dictionary of dim:index where index is the value or range to index the dimension
+        indexers : Dict[Axes, Union[int, Sequence]]
+            A dictionary of dim:index where index is the value, values, or range to index the
+            dimension
 
         Examples
         --------

--- a/starfish/core/imagestack/indexing_utils.py
+++ b/starfish/core/imagestack/indexing_utils.py
@@ -1,4 +1,4 @@
-from typing import Dict, Hashable, Mapping, MutableMapping, Tuple, Union
+from typing import Dict, Hashable, Mapping, MutableMapping, Sequence, Tuple, Union
 
 import numpy as np
 import xarray as xr
@@ -8,18 +8,20 @@ from starfish.core.types import Axes, Coordinates, CoordinateValue
 
 
 def convert_to_selector(
-        indexers: Mapping[Axes, Union[int, slice, tuple]]) -> Mapping[Hashable, Union[int, slice]]:
-    """Converts a mapping of Axis to int, slice, or tuple to a mapping of str to int or slice.  The
-    latter format is required for standard xarray indexing methods.
+        indexers: Mapping[Axes, Union[int, slice, Sequence]]
+) -> Mapping[Hashable, Union[int, slice, Sequence]]:
+    """Converts a mapping of Axis to int, slice, or Sequence to a mapping of str to int or slice.
+    The latter format is required for standard xarray indexing methods.
 
     Parameters
     ----------
-    indexers : Mapping[Axes, Union[int, slice, tuple]]
+    indexers : Mapping[Axes, Union[int, slice, Sequence]]
             A dictionary of dim:index where index is the value or range to index the dimension
 
     """
-    return_dict: MutableMapping[Hashable, Union[int, slice]] = {
-        ind.value: slice(None, None) for ind in Axes}
+    return_dict: MutableMapping[Hashable, Union[int, slice, Sequence]] = {
+        ind.value: ind.value if isinstance(ind.value, list)
+        else slice(None, None) for ind in indexers.keys()}
     for key, value in indexers.items():
         if isinstance(value, tuple):
             return_dict[key.value] = slice(value[0], value[1])
@@ -63,7 +65,7 @@ def convert_coords_to_indices(
 
 
 def index_keep_dimensions(data: xr.DataArray,
-                          indexers: Mapping[Hashable, Union[int, slice]],
+                          indexers: Mapping[Hashable, Union[int, slice, Sequence]],
                           by_pos: bool=False
                           ) -> xr.DataArray:
     """Takes an xarray and key to index it. Indexes then adds back in lost dimensions"""

--- a/starfish/core/spots/DecodeSpots/__init__.py
+++ b/starfish/core/spots/DecodeSpots/__init__.py
@@ -1,6 +1,7 @@
 from ._base import DecodeSpotsAlgorithm
 from .metric_decoder import MetricDistance
 from .per_round_max_channel_decoder import PerRoundMaxChannel
+from .simple_lookup_decoder import SimpleLookupDecoder
 
 # autodoc's automodule directive only captures the modules explicitly listed in __all__.
 all_filters = {

--- a/starfish/core/spots/DecodeSpots/simple_lookup_decoder.py
+++ b/starfish/core/spots/DecodeSpots/simple_lookup_decoder.py
@@ -1,0 +1,53 @@
+from typing import Dict, Tuple
+
+from starfish.core.codebook.codebook import Codebook
+from starfish.core.intensity_table.decoded_intensity_table import DecodedIntensityTable
+from starfish.core.spots.DecodeSpots.trace_builders import build_traces_sequential
+from starfish.core.types import Axes, Features, SpotFindingResults
+from ._base import DecodeSpotsAlgorithm
+
+
+class SimpleLookupDecoder(DecodeSpotsAlgorithm):
+    """
+    Decode spots by assiging the target value of a spot to the corresponding target value of the
+    round/ch it was found in. This method only makes sense to use in non mulitplexed sequential
+    assays where each r/ch pair only has one target assigned to it.
+
+    Parameters
+    ----------
+    codebook : Codebook
+        Contains codes to decode IntensityTable
+
+    """
+
+    def __init__(self, codebook: Codebook):
+        self.codebook = codebook
+
+    def run(self, spots: SpotFindingResults, *args) -> DecodedIntensityTable:
+        """
+        Decode spots by looking up the associated target value for the round and ch each spot is
+        in.
+
+        Parameters
+        ----------
+        spots: SpotFindingResults
+            A Dict of tile indices and their corresponding measured spots
+
+        Returns
+        -------
+        DecodedIntensityTable :
+            IntensityTable decoded and appended with Features.TARGET and values.
+
+        """
+        lookup_table: Dict[Tuple, str] = {}
+        for target in self.codebook[Features.TARGET]:
+            for ch_label in self.codebook[Axes.CH.value]:
+                for round_label in self.codebook[Axes.ROUND.value]:
+                    if self.codebook.loc[target, round_label, ch_label]:
+                        lookup_table[(int(round_label), int(ch_label))] = str(target.values)
+
+        for r_ch_index, results in spots.items():
+            target = lookup_table[r_ch_index] if r_ch_index in lookup_table else 'nan'
+            results.spot_attrs.data[Features.TARGET] = target
+        intensities = build_traces_sequential(spots)
+        return DecodedIntensityTable(intensities)

--- a/starfish/core/spots/DecodeSpots/test/test_composite_codebook.py
+++ b/starfish/core/spots/DecodeSpots/test/test_composite_codebook.py
@@ -1,0 +1,355 @@
+from typing import Tuple
+
+import numpy as np
+import xarray as xr
+
+from starfish.core.codebook.codebook import Codebook
+from starfish.core.imagestack.imagestack import ImageStack
+from starfish.core.imagestack.test.factories import create_imagestack_from_codebook
+from starfish.core.spots.DecodeSpots import MetricDistance, PerRoundMaxChannel, SimpleLookupDecoder
+from starfish.core.spots.FindSpots import BlobDetector
+from starfish.core.types import Axes, Features
+
+
+def simple_gaussian_spot_detector() -> BlobDetector:
+    """create a basic gaussian spot detector"""
+    return BlobDetector(
+        min_sigma=1,
+        max_sigma=4,
+        num_sigma=5,
+        threshold=0,
+        measurement_type='max')
+
+
+def composite_codebook() -> Tuple[Codebook, ImageStack]:
+    """
+    Produce an Imagestack representing a composite experiment where the first 2 rounds are
+    multiplexed data and the last round is sequential data.
+
+    Returns
+    -------
+    Codebook :
+        codebook containing codes that match the data
+    ImageStack :
+        noiseless ImageStack containing one spot per code in codebook
+    """
+    codebook_data = [
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 0, Axes.CH.value: 0, Features.CODE_VALUE: 1},
+                {Axes.ROUND.value: 1, Axes.CH.value: 1, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_A"
+        },
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 0, Axes.CH.value: 1, Features.CODE_VALUE: 1},
+                {Axes.ROUND.value: 1, Axes.CH.value: 0, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_B"
+        },
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 2, Axes.CH.value: 0, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_C"
+        },
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 2, Axes.CH.value: 1, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_D"
+        }
+    ]
+
+    codebook = Codebook.from_code_array(codebook_data)
+    imagestack = create_imagestack_from_codebook(
+        pixel_dimensions=(10, 100, 100),
+        spot_coordinates=((4, 10, 90), (5, 90, 10), (6, 90, 10), (7, 90, 10)),
+        codebook=codebook
+    )
+    return codebook, imagestack
+
+
+def composite_codebook_mixed_round() -> Tuple[Codebook, ImageStack]:
+    """
+    Produce an Imagestack representing a composite experiment where the first 2 and a half rounds
+    are multiplexed data and the last round and a half is sequential data. This represents the type
+    of hybrid experiment happening at the allen.
+
+    Returns
+    -------
+    Codebook :
+        codebook containing codes that match the data
+    ImageStack :
+        noiseless ImageStack containing one spot per code in codebook
+    """
+    codebook_data = [
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 0, Axes.CH.value: 0, Features.CODE_VALUE: 1},
+                {Axes.ROUND.value: 1, Axes.CH.value: 1, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_A"
+        },
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 0, Axes.CH.value: 1, Features.CODE_VALUE: 1},
+                {Axes.ROUND.value: 1, Axes.CH.value: 0, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_B"
+        },
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 2, Axes.CH.value: 0, Features.CODE_VALUE: 1},
+                {Axes.ROUND.value: 1, Axes.CH.value: 1, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_C"
+        },
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 2, Axes.CH.value: 2, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_D"
+        },
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 3, Axes.CH.value: 0, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_E"
+        },
+    ]
+
+    codebook = Codebook.from_code_array(codebook_data)
+    imagestack = create_imagestack_from_codebook(
+        pixel_dimensions=(1, 10, 10),
+        spot_coordinates=((0, 5, 6), (0, 2, 3), (0, 7, 1), (0, 8, 2), (0, 3, 6)),
+        codebook=codebook
+    )
+    return codebook, imagestack
+
+
+def compostie_codebook_seperate_stacks() -> Tuple[Codebook, ImageStack, ImageStack]:
+    """
+    Produce separate different sized ImageStacks containing data from two different experiment
+    types (multiplexed and non multiplexed) and one codebook with the information for both.
+
+    Returns
+    -------
+    Codebook :
+        codebook containing codes that match the data
+    ImageStack :
+        noiseless ImageStack containing one spot per code in codebook
+    """
+
+    # 3 round 3 ch multiplexed data
+    multiplexed_data = [
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 0, Axes.CH.value: 0, Features.CODE_VALUE: 1},
+                {Axes.ROUND.value: 2, Axes.CH.value: 1, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_A"
+        },
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 0, Axes.CH.value: 1, Features.CODE_VALUE: 1},
+                {Axes.ROUND.value: 1, Axes.CH.value: 2, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_B"
+        },
+    ]
+    codebook = Codebook.from_code_array(multiplexed_data)
+    multiplexed_stack = create_imagestack_from_codebook(
+        pixel_dimensions=(10, 100, 100),
+        spot_coordinates=((4, 10, 90), (5, 90, 10)),
+        codebook=codebook
+    )
+
+    # 3 rounds 1 ch non multiplexed data
+    sequential_data = [
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 3, Axes.CH.value: 1, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_C"
+        },
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 4, Axes.CH.value: 0, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_D"
+        },
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 5, Axes.CH.value: 1, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_D"
+        }
+    ]
+    codebook = Codebook.from_code_array(sequential_data)
+    sequential_stack = create_imagestack_from_codebook(
+        pixel_dimensions=(10, 100, 100),
+        spot_coordinates=((4, 10, 90), (5, 90, 10), (7, 90, 10)),
+        codebook=codebook
+    )
+    sequential_stack = sequential_stack.sel(indexers={Axes.ROUND: (3, 6)})
+
+    # create codebook with combined target values
+    combined = [
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 0, Axes.CH.value: 0, Features.CODE_VALUE: 1},
+                {Axes.ROUND.value: 2, Axes.CH.value: 1, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_A"
+        },
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 0, Axes.CH.value: 1, Features.CODE_VALUE: 1},
+                {Axes.ROUND.value: 1, Axes.CH.value: 2, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_B"
+        },
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 3, Axes.CH.value: 1, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_C"
+        },
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 4, Axes.CH.value: 0, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_D"
+        },
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 5, Axes.CH.value: 1, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "GENE_E"
+        }
+
+    ]
+    codebook = Codebook.from_code_array(combined)
+    return codebook, multiplexed_stack, sequential_stack
+
+
+gaussian_spot_detector = simple_gaussian_spot_detector()
+
+
+def test_composite_codebook_decoding():
+    """
+    Test a decoding workflow in which one ImageStack is composed of both multiplexed data and
+    sequential data in separate rounds. Show that it's easier to select our the two different
+    sections and process them separately.
+    """
+    # create an ImageStack where rounds 0,1 contain multiplexed data and round 2 contains
+    # sequential data
+    codebook, stack = composite_codebook()
+
+    # select out the different portions of the imagestack
+    multiplexed_stack = stack.sel(indexers={Axes.ROUND: (0, 1)})
+    sequential_stack = stack.sel(indexers={Axes.ROUND: 2})
+
+    # select out the corresponding portions of the codebooks
+    codebook_multiplexed = codebook.get_partial(indexers={Axes.ROUND: (0, 1)})
+    codebook_sequential = codebook.get_partial(indexers={Axes.ROUND: 2})
+
+    # find spots
+    reference_image = multiplexed_stack.reduce((Axes.ROUND, Axes.CH), func="max")
+    multiplexed_spots = gaussian_spot_detector.run(
+        image_stack=multiplexed_stack, reference_image=reference_image)
+
+    sequential_spots = gaussian_spot_detector.run(image_stack=sequential_stack)
+
+    # decode
+    per_round_decoder = PerRoundMaxChannel(codebook=codebook_multiplexed)
+    decoded_multiplexed = per_round_decoder.run(spots=multiplexed_spots)
+    assert np.array_equal(decoded_multiplexed[Features.TARGET].values, ['GENE_B', 'GENE_A'])
+
+    simple_lookup_decoder = SimpleLookupDecoder(codebook=codebook_sequential)
+    decoded_sequential = simple_lookup_decoder.run(spots=sequential_spots)
+    assert np.array_equal(decoded_sequential[Features.TARGET].values, ['GENE_C', 'GENE_D'])
+
+
+def test_composite_codebook_decoding_seperate_sized_stacks():
+    """
+    Test a decoding workflow in which two different ImageStacks of differing sizes and experiment
+    types are created from the same codebook. Show that it's possible to select out the portion of
+    the codebook to use successfully for each ImageStack.
+    """
+
+    # create two different sized ImageStacks with the same codebook
+    codebook, multiplexed_stack, sequential_stack = compostie_codebook_seperate_stacks()
+    codebook_multiplexed = codebook.get_partial(indexers={Axes.ROUND: (0, 2)})
+
+    # find spots
+    reference_image = multiplexed_stack.reduce((Axes.ROUND, Axes.CH), func="max")
+    multiplexed_spots = gaussian_spot_detector.run(
+        image_stack=multiplexed_stack, reference_image=reference_image)
+
+    sequential_spots = gaussian_spot_detector.run(image_stack=sequential_stack)
+
+    metric_decoder = MetricDistance(codebook=codebook_multiplexed,
+                                    max_distance=0,
+                                    min_intensity=.1,
+                                    norm_order=2)
+
+    decoded_multiplexed = metric_decoder.run(spots=multiplexed_spots)
+
+    assert np.array_equal(decoded_multiplexed[Features.TARGET].values, ['GENE_B', 'GENE_A'])
+
+    lookup_decoder = SimpleLookupDecoder(codebook=codebook)
+    decoded_sequential = lookup_decoder.run(spots=sequential_spots)
+
+    assert np.array_equal(sorted(decoded_sequential[Features.TARGET].values),
+                          ['GENE_C', 'GENE_D', 'GENE_E'])
+
+
+def test_composite_codebook_mixed_round():
+    """
+    Test a decoding workflow in which one ImageStack is composed of both multiplexed data and
+    sequential data with one round having both. Show that a decoding workflow is possible by
+    selecting out three different sections of the stack and processing them separately.
+    """
+    codebook, stack = composite_codebook_mixed_round()
+
+    # select the multiplexed portion of the stack
+    multiplexed_stack = stack.sel(indexers={Axes.ROUND: (0, 2), Axes.CH: (0, 1)})
+
+    # select the the sequential portion of the combined round
+    sequential_stack_part_1 = stack.sel(indexers={Axes.ROUND: 2, Axes.CH: (1, 2)})
+    # select the rest of the sequential portion of the stack
+    sequential_stack_part_2 = stack.sel(indexers={Axes.ROUND: 3, Axes.CH: (0, 2)})
+
+    # select out the multiplexed portion of the codebook
+    codebook_multiplexed = codebook.get_partial(indexers={Axes.ROUND: (0, 2), Axes.CH: (0, 1)})
+
+    # find spots
+    reference_image = multiplexed_stack.reduce((Axes.ROUND, Axes.CH), func="max")
+    multiplexed_spots = gaussian_spot_detector.run(
+        image_stack=multiplexed_stack, reference_image=reference_image)
+
+    # the easiest way to process the sequential portion is to process the two parts independently
+    sequential_spots_part_1 = gaussian_spot_detector.run(image_stack=sequential_stack_part_1)
+    sequential_spots_part_2 = gaussian_spot_detector.run(image_stack=sequential_stack_part_2)
+
+    metric_decoder = MetricDistance(codebook=codebook_multiplexed,
+                                    max_distance=0,
+                                    min_intensity=.1,
+                                    norm_order=2)
+
+    decoded_multiplexed = metric_decoder.run(spots=multiplexed_spots)
+
+    assert np.array_equal(sorted(decoded_multiplexed[Features.TARGET].values),
+                          ['GENE_A', 'GENE_B', 'GENE_C'])
+
+    # decode sequential portions independently then combine the results
+    lookup_decoder = SimpleLookupDecoder(codebook=codebook)
+    decoded_sequential_part_1 = lookup_decoder.run(spots=sequential_spots_part_1)
+    decoded_sequential_part_2 = lookup_decoder.run(spots=sequential_spots_part_2)
+    decoded_sequential = xr.concat([decoded_sequential_part_1, decoded_sequential_part_2],
+                                   dim="features")
+
+    assert np.array_equal(sorted(decoded_sequential[Features.TARGET].values), ['GENE_D', 'GENE_E'])

--- a/starfish/core/types/_spot_finding_results.py
+++ b/starfish/core/types/_spot_finding_results.py
@@ -90,7 +90,7 @@ class SpotFindingResults:
 
     def items(self):
         """
-        Return iterator for Spot finding results
+        Return iterator for (r,ch) and SpotAttributes in Spot finding results
         """
         return self._results.items()
 


### PR DESCRIPTION
- Added a slicing method in codebook that allows a user to easily get a portion of the data.
- Added a new SimpleLookupDecoder for non multiplexed data that just makes a table of r/ch keys to target value and decodes. 
- Added a few tests to demonstrate workflows with composite experiment data 