### PR TITLE
Update data model for BinaryMaskCollection

### DIFF
--- a/starfish/__init__.py
+++ b/starfish/__init__.py
@@ -20,5 +20,6 @@ from .core.expression_matrix.expression_matrix import ExpressionMatrix
 from .core.imagestack.imagestack import ImageStack
 from .core.intensity_table.decoded_intensity_table import DecodedIntensityTable
 from .core.intensity_table.intensity_table import IntensityTable
+from .core.label_image import LabelImage
 from .core.segmentation_mask import SegmentationMaskCollection
 from .core.util.logging import Log

--- a/starfish/core/binary_mask/_io.py
+++ b/starfish/core/binary_mask/_io.py
@@ -1,0 +1,168 @@
+import codecs
+import io
+import pickle
+import tarfile
+import warnings
+from dataclasses import dataclass
+from typing import BinaryIO, List, Mapping, MutableSequence, Optional, Sequence, Tuple, Type
+
+import numpy as np
+from packaging.version import Version
+
+from starfish.core.errors import DataFormatWarning
+from starfish.core.types import Axes, Coordinates, Number, STARFISH_EXTRAS_KEY
+from starfish.core.util.logging import Log
+from . import binary_mask as bm
+
+
+class AttrKeys:
+    DOCTYPE = f"{STARFISH_EXTRAS_KEY}.DOCTYPE"
+    VERSION = f"{STARFISH_EXTRAS_KEY}.VERSION"
+
+
+DOCTYPE_STRING = "starfish/BinaryMaskCollection"
+
+
+class BinaryMaskIO:
+    ASCENDING_VERSIONS: List[Tuple[Version, Type["BinaryMaskIO"]]] = []
+    VERSION: Version
+
+    def __init_subclass__(cls, version_descriptor: Version, **kwargs):
+        super.__init_subclass__(**kwargs)  # type: ignore
+        cls.VERSION = version_descriptor
+        BinaryMaskIO.ASCENDING_VERSIONS.append((version_descriptor, cls))
+        BinaryMaskIO.ASCENDING_VERSIONS.sort()
+
+    @staticmethod
+    def read_versioned_binary_mask(
+            file_obj: BinaryIO,
+    ) -> bm.BinaryMaskCollection:
+        with tarfile.open(mode="r|gz", fileobj=file_obj) as tf:
+            if tf.pax_headers is None:
+                raise ValueError(
+                    f"file does not appear to be a binary mask file (does not have headers)")
+            if tf.pax_headers.get(AttrKeys.DOCTYPE, None) != DOCTYPE_STRING:
+                raise ValueError(
+                    f"file does not appear to be a binary mask file (missing or incorrect doctype)")
+            if AttrKeys.VERSION not in tf.pax_headers:
+                raise ValueError(f"file missing version data")
+
+            requested_version = Version(tf.pax_headers[AttrKeys.VERSION])
+
+            for version, implementation in BinaryMaskIO.ASCENDING_VERSIONS:
+                if version == requested_version:
+                    return implementation().read_binary_mask(tf)
+            else:
+                raise ValueError(f"No reader for version {requested_version}")
+
+    @staticmethod
+    def write_versioned_binary_mask(
+            file_obj: BinaryIO,
+            binary_mask: bm.BinaryMaskCollection,
+            requested_version: Optional[Version] = None,
+    ):
+        if requested_version is None:
+            implementation = BinaryMaskIO.ASCENDING_VERSIONS[-1][1]
+        else:
+            for version, implementing_class in BinaryMaskIO.ASCENDING_VERSIONS:
+                if version == requested_version:
+                    implementation = implementing_class
+                    break
+            else:
+                raise ValueError(f"No writer for version {requested_version}")
+
+        implementation().write_binary_mask(file_obj, binary_mask)
+
+    def read_binary_mask(self, tf: tarfile.TarFile) -> bm.BinaryMaskCollection:
+        raise NotImplementedError()
+
+    def write_binary_mask(self, file_obj: BinaryIO, binary_mask: bm.BinaryMaskCollection):
+        raise NotImplementedError()
+
+
+class v0_0(BinaryMaskIO, version_descriptor=Version("0.0")):
+    LOG_FILENAME = "log"
+    PIXEL_TICKS_FILE = "pixel_ticks.pickle"
+    PHYSICAL_TICKS_FILE = "physical_ticks.pickle"
+    MASK_PREFIX = "masks/"
+
+    @dataclass
+    class MaskOnDisk:
+        binary_mask: np.ndarray
+        offsets: Tuple[int, ...]
+
+    def read_binary_mask(self, tf: tarfile.TarFile) -> bm.BinaryMaskCollection:
+        log: Optional[Log] = None
+        masks: MutableSequence[bm.MaskData] = []
+        pixel_ticks: Optional[Mapping[Axes, Sequence[int]]] = None
+        physical_ticks: Optional[Mapping[Coordinates, Sequence[Number]]] = None
+
+        while True:
+            tarinfo: Optional[tarfile.TarInfo] = tf.next()
+            if tarinfo is None:
+                break
+
+            # wrap it in a BytesIO object to ensure we never seek backwards.
+            extracted_fh = tf.extractfile(tarinfo)
+            if extracted_fh is None:
+                raise ValueError(f"Unable to extract file {tarinfo.name}")
+            byte_stream = io.BytesIO(extracted_fh.read())
+
+            if tarinfo.name == v0_0.LOG_FILENAME:
+                string_stream = codecs.getreader("utf-8")(byte_stream)
+                log = Log.decode(string_stream.read())
+            elif tarinfo.name == v0_0.PIXEL_TICKS_FILE:
+                pixel_ticks = pickle.load(byte_stream)
+            elif tarinfo.name == v0_0.PHYSICAL_TICKS_FILE:
+                physical_ticks = pickle.load(byte_stream)
+            elif tarinfo.name.startswith(v0_0.MASK_PREFIX):
+                mask_on_disk: v0_0.MaskOnDisk = pickle.load(byte_stream)
+                if not isinstance(mask_on_disk, v0_0.MaskOnDisk):
+                    raise TypeError(f"mask does not conform to expected mask structure")
+                masks.append(bm.MaskData(mask_on_disk.binary_mask, mask_on_disk.offsets, None))
+            else:
+                warnings.warn(
+                    f"Unexpected file in binary mask collection {tarinfo.name}",
+                    DataFormatWarning
+                )
+
+        if pixel_ticks is None:
+            raise ValueError("pixel coordinates not found")
+        if physical_ticks is None:
+            raise ValueError("physical coordinates not found")
+
+        return bm.BinaryMaskCollection(pixel_ticks, physical_ticks, masks, log)
+
+    def write_binary_mask(self, file_obj: BinaryIO, binary_mask: bm.BinaryMaskCollection):
+        pax_headers: Mapping[str, str] = {
+            AttrKeys.DOCTYPE: DOCTYPE_STRING,
+            AttrKeys.VERSION: str(v0_0.VERSION),
+        }
+        with tarfile.open(
+                fileobj=file_obj,
+                mode="w|gz",
+                format=tarfile.PAX_FORMAT,
+                pax_headers=pax_headers,
+        ) as tf:
+            # write the log
+            log_bytes = binary_mask._log.encode().encode("utf-8")
+            write_to_tarfile(tf, v0_0.LOG_FILENAME, log_bytes)
+
+            # write the pixel ticks
+            pixel_ticks_bytes = pickle.dumps(binary_mask._pixel_ticks)
+            write_to_tarfile(tf, v0_0.PIXEL_TICKS_FILE, pixel_ticks_bytes)
+
+            # write the physical coordinate ticks
+            physical_ticks_bytes = pickle.dumps(binary_mask._physical_ticks)
+            write_to_tarfile(tf, v0_0.PHYSICAL_TICKS_FILE, physical_ticks_bytes)
+
+            for ix, mask in binary_mask._masks.items():
+                mask_on_disk = v0_0.MaskOnDisk(mask.binary_mask, mask.offsets)
+                mask_bytes = pickle.dumps(mask_on_disk)
+                write_to_tarfile(tf, f"{v0_0.MASK_PREFIX}{ix}", mask_bytes)
+
+
+def write_to_tarfile(tf: tarfile.TarFile, name: str, data: bytes):
+    tarinfo = tarfile.TarInfo(name=name)
+    tarinfo.size = len(data)
+    tf.addfile(tarinfo, io.BytesIO(data))

--- a/starfish/core/binary_mask/test/test_binary_mask.py
+++ b/starfish/core/binary_mask/test/test_binary_mask.py
@@ -1,81 +1,32 @@
 import os
 
 import numpy as np
-import pytest
-import xarray as xr
 
+from starfish.core.label_image.label_image import LabelImage
 from starfish.core.types import Axes, Coordinates
-from ..binary_mask import _validate_binary_mask, BinaryMaskCollection
-
-
-def test_validate_binary_mask():
-    good = xr.DataArray([[True, False, False],
-                         [False, True, True]],
-                        dims=('y', 'x'),
-                        coords=dict(x=[0, 1, 2],
-                                    y=[0, 1],
-                                    xc=('x', [0.5, 1.5, 2.5]),
-                                    yc=('y', [0.5, 1.5])))
-    _validate_binary_mask(good)
-
-    good = xr.DataArray([[[True], [False], [False]],
-                         [[False], [True], [True]]],
-                        dims=('z', 'y', 'x'),
-                        coords=dict(z=[0, 1],
-                                    y=[1, 2, 3],
-                                    x=[42],
-                                    zc=('z', [0.5, 1.5]),
-                                    yc=('y', [1.5, 2.5, 3.5]),
-                                    xc=('x', [42.5])))
-    _validate_binary_mask(good)
-
-    bad = xr.DataArray([[1, 2, 3],
-                        [4, 5, 6]],
-                       dims=('y', 'x'),
-                       coords=dict(x=[0, 1, 2],
-                                   y=[0, 1],
-                                   xc=('x', [0.5, 1.5, 2.5]),
-                                   yc=('y', [0.5, 1.5])))
-    with pytest.raises(TypeError):
-        _validate_binary_mask(bad)
-
-    bad = xr.DataArray([True],
-                       dims=('x'),
-                       coords=dict(x=[0],
-                                   xc=('x', [0.5])))
-    with pytest.raises(TypeError):
-        _validate_binary_mask(bad)
-
-    bad = xr.DataArray([[True]],
-                       dims=('z', 'y'),
-                       coords=dict(z=[0],
-                                   y=[0],
-                                   zc=('z', [0.5]),
-                                   yc=('y', [0.5])))
-    with pytest.raises(TypeError):
-        _validate_binary_mask(bad)
-
-    bad = xr.DataArray([[True]],
-                       dims=('x', 'y'))
-    with pytest.raises(TypeError):
-        _validate_binary_mask(bad)
+from ..binary_mask import BinaryMaskCollection
 
 
 def test_from_label_image():
-    label_image = np.zeros((5, 5), dtype=np.int32)
-    label_image[0] = 1
-    label_image[3:5, 3:5] = 2
-    label_image[-1, -1] = 0
+    label_image_array = np.zeros((5, 5), dtype=np.int32)
+    label_image_array[0] = 1
+    label_image_array[3:5, 3:5] = 2
+    label_image_array[-1, -1] = 0
 
     physical_ticks = {Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6.0],
                       Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12]}
 
-    masks = list(BinaryMaskCollection.from_label_image(
-        label_image, physical_ticks).masks())
+    label_image = LabelImage.from_array_and_coords(
+        label_image_array,
+        None,
+        physical_ticks,
+        None,
+    )
 
-    assert len(masks) == 2
+    mask_collection = BinaryMaskCollection.from_label_image(label_image)
+    assert len(mask_collection) == 2
 
-    region_0, region_1 = masks
+    region_0, region_1 = mask_collection.masks()
 
     assert region_0.name == '0'
     assert region_1.name == '1'
@@ -104,43 +55,55 @@ def test_from_label_image():
 
 def test_to_label_image():
     # test via roundtrip
-    label_image = np.zeros((5, 6), dtype=np.int32)
-    label_image[0] = 1
-    label_image[3:6, 3:6] = 2
-    label_image[-1, -1] = 0
+    label_image_array = np.zeros((5, 6), dtype=np.int32)
+    label_image_array[0] = 1
+    label_image_array[3:6, 3:6] = 2
+    label_image_array[-1, -1] = 0
 
     physical_ticks = {Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6.0],
                       Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12, 15.5]}
 
-    masks = BinaryMaskCollection.from_label_image(label_image,
-                                                  physical_ticks)
+    label_image = LabelImage.from_array_and_coords(
+        label_image_array,
+        None,
+        physical_ticks,
+        None,
+    )
 
-    assert np.array_equal(masks.to_label_image(), label_image)
+    masks = BinaryMaskCollection.from_label_image(label_image)
+
+    assert np.array_equal(masks.to_label_image().xarray, label_image.xarray)
 
 
-def test_save_load():
-    label_image = np.zeros((5, 5), dtype=np.int32)
-    label_image[0] = 1
-    label_image[3:5, 3:5] = 2
-    label_image[-1, -1] = 0
+def test_save_load(tmp_path):
+    label_image_array = np.zeros((5, 5), dtype=np.int32)
+    label_image_array[0] = 1
+    label_image_array[3:5, 3:5] = 2
+    label_image_array[-1, -1] = 0
 
     physical_ticks = {Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6.0],
                       Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12]}
 
-    masks = BinaryMaskCollection.from_label_image(label_image,
-                                                  physical_ticks)
+    label_image = LabelImage.from_array_and_coords(
+        label_image_array,
+        None,
+        physical_ticks,
+        None,
+    )
 
-    path = 'data.tgz'
+    binary_mask_collection = BinaryMaskCollection.from_label_image(label_image)
+
+    path = tmp_path / "data.tgz"
     try:
-        masks.save(path)
-        masks2 = BinaryMaskCollection.from_disk(path)
-        for m, m2 in zip(masks.masks(), masks2.masks()):
+        binary_mask_collection.to_targz(path)
+        masks2 = BinaryMaskCollection.open_targz(path)
+        for m, m2 in zip(binary_mask_collection.masks(), masks2.masks()):
             assert np.array_equal(m, m2)
     finally:
         os.remove(path)
 
     # ensure that the regionprops are equal
-    for ix in range(len(masks)):
-        original_props = masks.mask_regionprops(ix)
-        recalculated_props = masks.mask_regionprops(ix)
+    for ix in range(len(binary_mask_collection)):
+        original_props = binary_mask_collection.mask_regionprops(ix)
+        recalculated_props = binary_mask_collection.mask_regionprops(ix)
         assert original_props == recalculated_props

--- a/starfish/core/binary_mask/test/test_expand.py
+++ b/starfish/core/binary_mask/test/test_expand.py
@@ -1,24 +1,17 @@
 import numpy as np
 import pytest
-import xarray as xr
 
-from starfish.core.types import Axes
 from ..expand import fill_from_mask
 
 
 def test_expand_mask_2d(shape=(15, 15)):
-    mask = xr.DataArray(
+    mask = np.array(
         [[True, False, False],
          [False, True, True]],
-        dims=('y', 'x'),
-        coords=dict(
-            x=[3, 4, 5],
-            y=[2, 3],
-            xc=('x', [0.5, 1.5, 2.5]),
-            yc=('y', [0.5, 1.5])))
+        dtype=np.bool)
     label_image = np.random.randint(30, np.iinfo(np.uint16).max, size=shape, dtype=np.uint16)
     label_image_clone = np.copy(label_image)
-    fill_from_mask(mask, 20, label_image, (Axes.Y, Axes.X))
+    fill_from_mask(mask, (2, 3), 20, label_image)
 
     assert label_image.dtype == np.uint16
     assert label_image.shape == shape
@@ -36,7 +29,7 @@ def test_expand_mask_2d(shape=(15, 15)):
 
 
 def test_expand_mask_3d(shape=(15, 15, 15)):
-    mask = xr.DataArray(
+    mask = np.array(
         [[[True, False, True],
           [True, False, True],
           [False, False, False],
@@ -46,17 +39,10 @@ def test_expand_mask_3d(shape=(15, 15, 15)):
           [False, False, False],
           [True, False, False],
           [False, False, False]]],
-        dims=('z', 'y', 'x'),
-        coords=dict(
-            x=[3, 4, 5],
-            y=[7, 8, 9, 10],
-            z=[2, 3],
-            xc=('x', [0.5, 1.5, 2.5]),
-            yc=('y', [0.5, 1.5, 2.5, 3.5]),
-            zc=('z', [0.5, 1.5])))
+        dtype=np.bool)
     label_image = np.random.randint(30, np.iinfo(np.uint16).max, size=shape, dtype=np.uint16)
     label_image_clone = np.copy(label_image)
-    fill_from_mask(mask, 20, label_image)
+    fill_from_mask(mask, (2, 7, 3), 20, label_image)
 
     assert label_image.dtype == np.uint16
     assert label_image.shape == shape
@@ -79,30 +65,20 @@ def test_expand_mask_3d(shape=(15, 15, 15)):
 
 
 def test_expand_image_too_small(shape=(2, 2)):
-    mask = xr.DataArray(
+    mask = np.array(
         [[True, False, False],
          [False, True, True]],
-        dims=('y', 'x'),
-        coords=dict(
-            x=[3, 4, 5],
-            y=[2, 3],
-            xc=('x', [0.5, 1.5, 2.5]),
-            yc=('y', [0.5, 1.5])))
+        dtype=np.bool)
     label_image = np.random.randint(30, np.iinfo(np.uint16).max, size=shape, dtype=np.uint16)
     with pytest.raises(ValueError):
-        fill_from_mask(mask, 20, label_image, (Axes.Y, Axes.X))
+        fill_from_mask(mask, (2, 3), 20, label_image)
 
 
 def test_expand_image_negative_axis_labels(shape=(15, 15)):
-    mask = xr.DataArray(
+    mask = np.array(
         [[True, False, False],
          [False, True, True]],
-        dims=('y', 'x'),
-        coords=dict(
-            x=[-1, 0, 1],
-            y=[2, 3],
-            xc=('x', [0.5, 1.5, 2.5]),
-            yc=('y', [0.5, 1.5])))
+        dtype=np.bool)
     label_image = np.random.randint(30, np.iinfo(np.uint16).max, size=shape, dtype=np.uint16)
     with pytest.raises(ValueError):
-        fill_from_mask(mask, 20, label_image, (Axes.Y, Axes.X))
+        fill_from_mask(mask, (2, -1), 20, label_image)

--- a/starfish/core/segmentation_mask/segmentation_mask.py
+++ b/starfish/core/segmentation_mask/segmentation_mask.py
@@ -1,51 +1,49 @@
+from pathlib import Path
 from typing import (
-    Dict,
-    Iterable,
+    Mapping,
     Optional,
     Sequence,
+    Union,
 )
 from warnings import warn
 
-import numpy as np
-import xarray as xr
-from skimage.measure._regionprops import _RegionProperties
-
-from starfish.core.binary_mask import BinaryMaskCollection
-from starfish.core.types import Coordinates
+from starfish.core.binary_mask.binary_mask import BinaryMaskCollection, MaskData
+from starfish.core.label_image import label_image as li
+from starfish.core.types import Axes, Coordinates, Number
+from starfish.core.util.logging import Log
 
 
 class SegmentationMaskCollection(BinaryMaskCollection):
     """Deprecated in favor of BinaryMaskCollection."""
     def __init__(
             self,
-            masks: Iterable[xr.DataArray],
-            props: Optional[Iterable[Optional[_RegionProperties]]] = None,
+            pixel_ticks: Union[Mapping[Axes, Sequence[int]], Mapping[str, Sequence[int]]],
+            physical_ticks: Union[Mapping[Coordinates, Sequence[Number]],
+                                  Mapping[str, Sequence[Number]]],
+            masks: Sequence[MaskData],
+            log: Optional[Log],
     ):
         warn(
             f"{self.__class__.__name__} has been deprecated in favor of "
             f"{BinaryMaskCollection.__name__}",
             DeprecationWarning
         )
-        super().__init__(masks, props)
+        super().__init__(pixel_ticks, physical_ticks, masks, log)
 
     @classmethod
-    def from_label_image(
-            cls,
-            label_image: np.ndarray,
-            physical_ticks: Dict[Coordinates, Sequence[float]]
-    ) -> "BinaryMaskCollection":
+    def from_label_image(cls, label_image: li.LabelImage) -> "BinaryMaskCollection":
         warn(
             f"{cls.__class__.__name__} has been deprecated in favor of "
             f"{BinaryMaskCollection.__name__}",
             DeprecationWarning
         )
-        return BinaryMaskCollection.from_label_image(label_image, physical_ticks)
+        return BinaryMaskCollection.from_label_image(label_image)
 
     @classmethod
-    def from_disk(cls, path: str) -> "BinaryMaskCollection":
+    def open_targz(cls, path: Union[str, Path]) -> "BinaryMaskCollection":
         warn(
             f"{cls.__class__.__name__} has been deprecated in favor of "
             f"{BinaryMaskCollection.__name__}",
             DeprecationWarning
         )
-        return BinaryMaskCollection.from_disk(path)
+        return BinaryMaskCollection.open_targz(path)

--- a/starfish/core/test/test_display.py
+++ b/starfish/core/test/test_display.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from starfish import BinaryMaskCollection, display
+from starfish import BinaryMaskCollection, display, LabelImage
 from starfish.core.test.factories import SyntheticData
 from starfish.types import Coordinates
 
@@ -21,10 +21,13 @@ sd = SyntheticData(
 
 stack = sd.spots()
 spots = sd.intensities()
-masks = BinaryMaskCollection.from_label_image(
+label_image = LabelImage.from_array_and_coords(
     np.random.rand(128, 128).astype(np.uint8),
-    {Coordinates.Y: np.arange(128), Coordinates.X: np.arange(128)}
+    None,
+    {Coordinates.Y: np.arange(128), Coordinates.X: np.arange(128)},
+    None,
 )
+masks = BinaryMaskCollection.from_label_image(label_image)
 
 
 @pytest.mark.napari


### PR DESCRIPTION
LabelImage requires all the pixel coordinate and physical coordinate values along each axis, so to facilitate the easy conversion to and from BinaryMaskCollection and LabelImage, we need to change the data model for BinaryMaskCollection.

Previously, BinaryMaskCollection stored a series of xarrays for each of the masks.  This does not guarantee that the pixel/physical coordinates for every position along each axis.  Furthermore, it duplicates a lot of data.

This new approach stores the coordinates as independent arrays, and then stores each mask as a naked np.ndarray with offsets.  Conversions to and from LabelImage is pretty straightforward.  Returning each mask as an xarray (to maintain compatibility with the existing API) requires generating an xarray on the fly, but is not terribly expensive.

Writing to disk is now through a versioned interface similar to what was done for slicedimage.

Test plan: Updated tests to reflect the API changes.
Part of #1497
Depends on #1619, #1622