### PR TITLE
Switch to version exclusion for scikit-image workaround

### DIFF
--- a/REQUIREMENTS-STRICT.txt
+++ b/REQUIREMENTS-STRICT.txt
@@ -61,7 +61,7 @@ pyzmq==18.1.0
 regional==1.1.2
 requests==2.22.0
 s3transfer==0.2.1
-scikit-image==0.16.2
+scikit-image==0.15.0
 scikit-learn==0.21.3
 scipy==1.3.1
 semantic-version==2.8.2

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -11,7 +11,10 @@ numpy != 1.13.0
 pandas >= 0.23.4
 regional
 semantic_version
-scikit-image>=0.14.0
+# 0.16.[012] are excluded because https://github.com/scikit-image/scikit-image/pull/3984 introduced
+# a bug into max peak finder.  0.16.3 presumably will have the fix from
+# https://github.com/scikit-image/scikit-image/pull/4263.
+scikit-image >= 0.14.0, != 0.16.0.*, != 0.16.1.*, != 0.16.2.*
 scikit-learn
 scipy
 showit >= 1.1.4

--- a/starfish/REQUIREMENTS-STRICT.txt
+++ b/starfish/REQUIREMENTS-STRICT.txt
@@ -61,7 +61,7 @@ pyzmq==18.1.0
 regional==1.1.2
 requests==2.22.0
 s3transfer==0.2.1
-scikit-image==0.16.2
+scikit-image==0.15.0
 scikit-learn==0.21.3
 scipy==1.3.1
 semantic-version==2.8.2

--- a/starfish/core/imagestack/test/test_slicedimage_dtype.py
+++ b/starfish/core/imagestack/test/test_slicedimage_dtype.py
@@ -102,8 +102,11 @@ def test_int_type_promotion():
     )
     with warnings.catch_warnings(record=True) as warnings_:
         stack._ensure_data_loaded()
-        assert len(warnings_) == 1
-        assert issubclass(warnings_[0].category, DataFormatWarning)
+        for warning in warnings_:
+            if issubclass(warning.category, DataFormatWarning):
+                break
+        else:
+            pytest.fail(f"No {DataFormatWarning.__name__} warning raised.")
     expected = img_as_float32(np.ones(
         (NUM_ROUND,
          NUM_CH,
@@ -125,8 +128,11 @@ def test_uint_type_promotion():
     )
     with warnings.catch_warnings(record=True) as warnings_:
         stack._ensure_data_loaded()
-        assert len(warnings_) == 1
-        assert issubclass(warnings_[0].category, DataFormatWarning)
+        for warning in warnings_:
+            if issubclass(warning.category, DataFormatWarning):
+                break
+        else:
+            pytest.fail(f"No {DataFormatWarning.__name__} warning raised.")
     expected = img_as_float32(np.ones(
         (NUM_ROUND,
          NUM_CH,
@@ -148,8 +154,11 @@ def test_float_type_demotion():
     )
     with warnings.catch_warnings(record=True) as warnings_:
         stack._ensure_data_loaded()
-        assert len(warnings_) == 1
-        assert issubclass(warnings_[0].category, DataFormatWarning)
+        for warning in warnings_:
+            if issubclass(warning.category, DataFormatWarning):
+                break
+        else:
+            pytest.fail(f"No {DataFormatWarning.__name__} warning raised.")
     expected = np.ones(
         (NUM_ROUND,
          NUM_CH,

--- a/starfish/core/spots/FindSpots/local_max_peak_finder.py
+++ b/starfish/core/spots/FindSpots/local_max_peak_finder.py
@@ -248,9 +248,6 @@ class LocalMaxPeakFinder(FindSpotsAlgorithm):
             footprint=None,
             labels=labels
         )
-        # this is a workaround for the fix https://github.com/scikit-image/scikit-image/pull/4263
-        if spot_coords.shape[0] == 0:
-            spot_coords = np.empty((0, data_image.ndim), np.int)
 
         res = {Axes.X.value: spot_coords[:, 2],
                Axes.Y.value: spot_coords[:, 1],


### PR DESCRIPTION
It's easier to exclude these versions forever and ever than it is to carry around this code workaround, I think.  Please reject if you don't agree. :) 

Also made the DataTypeWarning tests less brittle.  We only care that we raised our warning.  We don't care if others raised warnings.

Test plan: travis