### PR TITLE
Improve coordinate handling code for BinaryMaskCollection and LabelImage

### DIFF
--- a/starfish/core/image/Segment/watershed.py
+++ b/starfish/core/image/Segment/watershed.py
@@ -104,7 +104,7 @@ class Watershed(SegmentAlgorithm):
             for coord in (Coordinates.Y, Coordinates.X)
         }
 
-        label_image = LabelImage.from_array_and_coords(
+        label_image = LabelImage.from_label_array_and_coords(
             label_image_array,
             None,
             physical_ticks,

--- a/starfish/core/morphology/binary_mask/binary_mask.py
+++ b/starfish/core/morphology/binary_mask/binary_mask.py
@@ -21,7 +21,11 @@ from skimage.measure import regionprops
 from skimage.measure._regionprops import _RegionProperties
 
 from starfish.core.morphology.label_image import LabelImage
-from starfish.core.morphology.util import _get_axes_names
+from starfish.core.morphology.util import (
+    _get_axes_names,
+    _normalize_physical_ticks,
+    _normalize_pixel_ticks,
+)
 from starfish.core.types import ArrayLike, Axes, Coordinates, Number
 from starfish.core.util.logging import Log
 from .expand import fill_from_mask
@@ -62,14 +66,9 @@ class BinaryMaskCollection:
             masks: Sequence[MaskData],
             log: Optional[Log],
     ):
-        self._pixel_ticks: Mapping[Axes, ArrayLike[int]] = {
-            Axes(axis): axis_data
-            for axis, axis_data in pixel_ticks.items()
-        }
-        self._physical_ticks: Mapping[Coordinates, ArrayLike[Number]] = {
-            Coordinates(coord): coord_data
-            for coord, coord_data in physical_ticks.items()
-        }
+        self._pixel_ticks: Mapping[Axes, ArrayLike[int]] = _normalize_pixel_ticks(pixel_ticks)
+        self._physical_ticks: Mapping[Coordinates, ArrayLike[Number]] = _normalize_physical_ticks(
+            physical_ticks)
         self._masks: MutableMapping[int, MaskData] = {}
         self._log: Log = log or Log()
 
@@ -225,7 +224,7 @@ class BinaryMaskCollection:
                 label_image_array,
             )
 
-        return LabelImage.from_array_and_coords(
+        return LabelImage.from_label_array_and_coords(
             label_image_array,
             self._pixel_ticks,
             self._physical_ticks,

--- a/starfish/core/morphology/binary_mask/test/test_binary_mask.py
+++ b/starfish/core/morphology/binary_mask/test/test_binary_mask.py
@@ -14,7 +14,7 @@ def test_from_label_image():
     physical_ticks = {Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6.0],
                       Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12]}
 
-    label_image = LabelImage.from_array_and_coords(
+    label_image = LabelImage.from_label_array_and_coords(
         label_image_array,
         None,
         physical_ticks,
@@ -61,7 +61,7 @@ def test_to_label_image():
     physical_ticks = {Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6.0],
                       Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12, 15.5]}
 
-    label_image = LabelImage.from_array_and_coords(
+    label_image = LabelImage.from_label_array_and_coords(
         label_image_array,
         None,
         physical_ticks,
@@ -82,7 +82,7 @@ def test_save_load(tmp_path):
     physical_ticks = {Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6.0],
                       Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12]}
 
-    label_image = LabelImage.from_array_and_coords(
+    label_image = LabelImage.from_label_array_and_coords(
         label_image_array,
         None,
         physical_ticks,
@@ -110,7 +110,7 @@ def test_from_empty_label_image(tmp_path):
     physical_ticks = {Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6.0],
                       Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12, 13.2]}
 
-    label_image = LabelImage.from_array_and_coords(
+    label_image = LabelImage.from_label_array_and_coords(
         label_image_array,
         None,
         physical_ticks,

--- a/starfish/core/morphology/util.py
+++ b/starfish/core/morphology/util.py
@@ -1,6 +1,6 @@
-from typing import List, Tuple
+from typing import List, Mapping, MutableMapping, Optional, Tuple, Union
 
-from starfish.core.types import Axes, Coordinates
+from starfish.core.types import ArrayLike, Axes, Coordinates, Number
 
 
 def _get_axes_names(ndim: int) -> Tuple[List[Axes], List[Coordinates]]:
@@ -29,3 +29,32 @@ def _get_axes_names(ndim: int) -> Tuple[List[Axes], List[Coordinates]]:
         raise TypeError('expected 2- or 3-D image')
 
     return axes, coords
+
+
+def _normalize_pixel_ticks(
+        pixel_ticks: Optional[Union[
+            Mapping[Axes, ArrayLike[int]],
+            Mapping[str, ArrayLike[int]]]],
+) -> MutableMapping[Axes, ArrayLike[int]]:
+    """Given pixel ticks in a mapping from an axis or a string representing an axis, return a
+    mapping from an axis.  The mapping may also not be present (i.e., None), in which an empty
+    dictionary is returned.
+    """
+    return {
+        Axes(axis): axis_data
+        for axis, axis_data in (pixel_ticks or {}).items()
+    }
+
+
+def _normalize_physical_ticks(
+        physical_ticks: Union[
+            Mapping[Coordinates, ArrayLike[Number]],
+            Mapping[str, ArrayLike[Number]]],
+) -> Mapping[Coordinates, ArrayLike[Number]]:
+    """Given physical coordinate ticks in a mapping from a coordinate or a string representing a
+    coordinate, return a mapping from a coordinate.
+    """
+    return {
+        Coordinates(coord): coord_data
+        for coord, coord_data in physical_ticks.items()
+    }

--- a/starfish/core/test/test_display.py
+++ b/starfish/core/test/test_display.py
@@ -21,7 +21,7 @@ sd = SyntheticData(
 
 stack = sd.spots()
 spots = sd.intensities()
-label_image = LabelImage.from_array_and_coords(
+label_image = LabelImage.from_label_array_and_coords(
     np.random.rand(128, 128).astype(np.uint8),
     None,
     {Coordinates.Y: np.arange(128), Coordinates.X: np.arange(128)},


### PR DESCRIPTION
1. Refactored all the normalization code (i.e., code that handles optional coordinates, code that handles dictionary with differently typed keys) to a couple modules.
2. Renamed `LabelImage.from_array_and_coords` to `LabelImage.from_label_array_and_coords` to be more clear about what it does.
3. Added a docblock to better describe `test_pixel_coordinates` test.
4. Added a test to verify that we correctly normalize coordinates are passed in by string.

Depends on #1631, #1650 

Test plan: `pytest starfish/core/morphology`