### PR TITLE
Fix install issues

### DIFF
--- a/REQUIREMENTS-STRICT.txt
+++ b/REQUIREMENTS-STRICT.txt
@@ -3,8 +3,8 @@ appnope==0.1.0
 attrs==19.3.0
 backcall==0.1.0
 bleach==3.1.0
-boto3==1.10.8
-botocore==1.13.8
+boto3==1.10.13
+botocore==1.13.13
 certifi==2019.9.11
 chardet==3.0.4
 Click==7.0
@@ -38,7 +38,7 @@ mpmath==1.1.0
 nbconvert==5.6.1
 nbformat==4.4.0
 networkx==2.4
-notebook==6.0.1
+notebook==6.0.2
 numpy==1.17.3
 packaging==19.2
 pandas==0.25.3
@@ -51,9 +51,9 @@ prometheus-client==0.7.1
 prompt-toolkit==2.0.10
 ptyprocess==0.6.0
 Pygments==2.4.2
-pyparsing==2.4.2
+pyparsing==2.4.4
 pyrsistent==0.15.5
-python-dateutil==2.8.1
+python-dateutil==2.8.0
 pytz==2019.3
 PyWavelets==1.1.1
 PyYAML==5.1.2
@@ -67,12 +67,11 @@ scipy==1.3.1
 semantic-version==2.8.2
 Send2Trash==1.5.0
 showit==1.1.4
-six==1.12.0
+six==1.13.0
 slicedimage==4.1.0
 sympy==1.4
 terminado==0.8.2
-testpath==0.4.3
-tifffile==2019.7.26
+testpath==0.4.4
 tornado==6.0.3
 tqdm==4.37.0
 trackpy==0.4.2

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,3 +1,8 @@
+# The following requirement is here because botocore restricts the version of python-dateutil (see
+# https://github.com/boto/botocore/commit/e87e7a745fd972815b235a9ee685232745aa94f9).  Since pip is
+# not a full dependency solver, it has already installed python-dateutil before botocore is
+# installed, and bombs after the fact.
+python-dateutil < 2.8.1
 click
 dataclasses;python_version<"3.7"
 jsonschema
@@ -11,7 +16,6 @@ scikit-learn
 scipy
 showit >= 1.1.4
 slicedimage==4.1.0
-scikit-learn
 sympy
 tqdm
 trackpy

--- a/starfish/REQUIREMENTS-STRICT.txt
+++ b/starfish/REQUIREMENTS-STRICT.txt
@@ -3,8 +3,8 @@ appnope==0.1.0
 attrs==19.3.0
 backcall==0.1.0
 bleach==3.1.0
-boto3==1.10.8
-botocore==1.13.8
+boto3==1.10.13
+botocore==1.13.13
 certifi==2019.9.11
 chardet==3.0.4
 Click==7.0
@@ -38,7 +38,7 @@ mpmath==1.1.0
 nbconvert==5.6.1
 nbformat==4.4.0
 networkx==2.4
-notebook==6.0.1
+notebook==6.0.2
 numpy==1.17.3
 packaging==19.2
 pandas==0.25.3
@@ -51,9 +51,9 @@ prometheus-client==0.7.1
 prompt-toolkit==2.0.10
 ptyprocess==0.6.0
 Pygments==2.4.2
-pyparsing==2.4.2
+pyparsing==2.4.4
 pyrsistent==0.15.5
-python-dateutil==2.8.1
+python-dateutil==2.8.0
 pytz==2019.3
 PyWavelets==1.1.1
 PyYAML==5.1.2
@@ -67,12 +67,11 @@ scipy==1.3.1
 semantic-version==2.8.2
 Send2Trash==1.5.0
 showit==1.1.4
-six==1.12.0
+six==1.13.0
 slicedimage==4.1.0
 sympy==1.4
 terminado==0.8.2
-testpath==0.4.3
-tifffile==2019.7.26
+testpath==0.4.4
 tornado==6.0.3
 tqdm==4.37.0
 trackpy==0.4.2


### PR DESCRIPTION
The latest version of botocore caps python-dateutil at 2.8.0.  Unfortunately, if another package has already declared an unversioned dependency on python-dateutil, 2.8.1 is installed.  Later on, when botocore is installed, it blows up and install fails.

This adds a temporary (hopefully) restriction to match botocore's requirement so that we can successfully install.

Test plan: `pip install -e .` without any angry errors.