### PR TITLE
[easy] Test for Codebook.to_json / open_json

### DIFF
--- a/starfish/core/codebook/codebook.py
+++ b/starfish/core/codebook/codebook.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, TypeVar, Union
 
 import numpy as np
@@ -388,13 +389,13 @@ class Codebook(xr.DataArray):
 
         return cls.from_code_array(codebook_doc[DocumentKeys.MAPPINGS_KEY], n_round, n_channel)
 
-    def to_json(self, filename: str) -> None:
+    def to_json(self, filename: Union[str, Path]) -> None:
         """
         Save a codebook to json using SpaceTx Format.
 
         Parameters
         ----------
-        filename : str
+        filename : Union[str, Path]
             The name of the file in which to save the codebook.
 
         """

--- a/starfish/core/codebook/test/test_to_json.py
+++ b/starfish/core/codebook/test/test_to_json.py
@@ -1,0 +1,14 @@
+import os
+
+from .factories import simple_codebook_array
+from ..codebook import Codebook
+
+
+def test_to_json(tmp_path):
+    code_array = simple_codebook_array()
+    codebook = Codebook.from_code_array(code_array)
+    codebook_path = tmp_path / "codebook.json"
+    codebook.to_json(codebook_path)
+
+    loaded_codebook = Codebook.open_json(os.fspath(codebook_path))
+    assert codebook.equals(loaded_codebook)


### PR DESCRIPTION
This verifies that the two operations are symmetric.

Test plan: this is the test.