### PR TITLE
Support multiple codewords for the same target

### DIFF
--- a/starfish/core/codebook/test/test_to_json.py
+++ b/starfish/core/codebook/test/test_to_json.py
@@ -1,11 +1,44 @@
 import os
 
+from starfish.types import Axes, Features
 from .factories import simple_codebook_array
 from ..codebook import Codebook
 
 
 def test_to_json(tmp_path):
     code_array = simple_codebook_array()
+    codebook = Codebook.from_code_array(code_array)
+    codebook_path = tmp_path / "codebook.json"
+    codebook.to_json(codebook_path)
+
+    loaded_codebook = Codebook.open_json(os.fspath(codebook_path))
+    assert codebook.equals(loaded_codebook)
+
+
+def test_to_json_multiple_codes_for_target(tmp_path):
+    code_array = [
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 0, Axes.CH.value: 0, Features.CODE_VALUE: 1},
+                {Axes.ROUND.value: 1, Axes.CH.value: 1, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "SCUBE2"
+        },
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 0, Axes.CH.value: 1, Features.CODE_VALUE: 1},
+                {Axes.ROUND.value: 1, Axes.CH.value: 1, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "BRCA"
+        },
+        {
+            Features.CODEWORD: [
+                {Axes.ROUND.value: 0, Axes.CH.value: 1, Features.CODE_VALUE: 1},
+                {Axes.ROUND.value: 1, Axes.CH.value: 0, Features.CODE_VALUE: 1}
+            ],
+            Features.TARGET: "SCUBE2"
+        }
+    ]
     codebook = Codebook.from_code_array(code_array)
     codebook_path = tmp_path / "codebook.json"
     codebook.to_json(codebook_path)


### PR DESCRIPTION
`to_json` walks through each of the targets/r/c in a codebook when trying to save.  Unfortunately, selecting an array with the same target twice results in a 3D array (target/r/c) rather than a 2D array (r/c).

This PR rewrites to_json so it can handle multiple codewords that decode to the same target.  Rather than selecting by label, we walk through each of the targets by integer offset.  This also optimizes the walkthrough of the codebook object by finding all the non-zero points in numpy code rather than in python code.  With the seqFISH dataset, this is at least a 10x speedup in writing out the json file.  With denser codebooks, the speedup probably is inconsequential.

Test plan: wrote a test that has multiple codewords for the same target.  it crashes without the fix and succeehds with the fix.
Fixes: #1643