### PR TITLE
Use ArrayLike where appropriate.

### DIFF
--- a/starfish/core/image/Filter/reduce.py
+++ b/starfish/core/image/Filter/reduce.py
@@ -1,15 +1,13 @@
 from typing import (
-    cast,
     Iterable,
     MutableMapping,
-    Sequence,
     Union
 )
 
 import numpy as np
 
 from starfish.core.imagestack.imagestack import ImageStack
-from starfish.core.types import Axes, Clip, Coordinates, FunctionSource, Number
+from starfish.core.types import ArrayLike, Axes, Clip, Coordinates, FunctionSource, Number
 from starfish.core.util.dtype import preserve_float_range
 from ._base import FilterAlgorithm
 
@@ -125,7 +123,7 @@ class Reduce(FilterAlgorithm):
             reduced = preserve_float_range(reduced, rescale=True)
 
         # Update the physical coordinates
-        physical_coords: MutableMapping[Coordinates, Sequence[Number]] = {}
+        physical_coords: MutableMapping[Coordinates, ArrayLike[Number]] = {}
         for axis, coord in (
                 (Axes.X, Coordinates.X),
                 (Axes.Y, Coordinates.Y),
@@ -135,7 +133,7 @@ class Reduce(FilterAlgorithm):
                 assert coord.value not in reduced.coords
                 physical_coords[coord] = [np.average(stack._data.coords[coord.value])]
             else:
-                physical_coords[coord] = cast(Sequence[Number], reduced.coords[coord.value])
+                physical_coords[coord] = reduced.coords[coord.value]
         reduced_stack = ImageStack.from_numpy(reduced.values, coordinates=physical_coords)
 
         return reduced_stack

--- a/starfish/core/image/Segment/watershed.py
+++ b/starfish/core/image/Segment/watershed.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Optional, Sequence, Tuple
+from typing import Mapping, Optional, Tuple
 
 import numpy as np
 import scipy.ndimage.measurements as spm
@@ -12,7 +12,7 @@ from starfish.core.image.Filter.util import bin_open, bin_thresh
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.morphology.binary_mask import BinaryMaskCollection
 from starfish.core.morphology.label_image import LabelImage
-from starfish.core.types import Axes, Clip, Coordinates, Number
+from starfish.core.types import ArrayLike, Axes, Clip, Coordinates, Number
 from ._base import SegmentAlgorithm
 
 
@@ -99,7 +99,7 @@ class Watershed(SegmentAlgorithm):
         )
 
         # we max-projected and squeezed the Z-plane so label_image.ndim == 2
-        physical_ticks: Mapping[Coordinates, Sequence[Number]] = {
+        physical_ticks: Mapping[Coordinates, ArrayLike[Number]] = {
             coord: nuclei.xarray.coords[coord.value].data
             for coord in (Coordinates.Y, Coordinates.X)
         }

--- a/starfish/core/imagestack/imagestack.py
+++ b/starfish/core/imagestack/imagestack.py
@@ -47,6 +47,7 @@ from starfish.core.imagestack.parser.crop import CropParameters, CroppedTileColl
 from starfish.core.imagestack.parser.numpy import NumpyData
 from starfish.core.imagestack.parser.tileset import TileSetData
 from starfish.core.types import (
+    ArrayLike,
     Axes,
     Clip,
     Coordinates,
@@ -319,7 +320,7 @@ class ImageStack:
             cls,
             array: np.ndarray,
             index_labels: Optional[Mapping[Axes, Sequence[int]]]=None,
-            coordinates: Optional[Mapping[Coordinates, Sequence[Number]]]=None,
+            coordinates: Optional[Mapping[Coordinates, ArrayLike[Number]]]=None,
     ) -> "ImageStack":
         """Create an ImageStack from a 5d numpy array with shape (n_round, n_ch, n_z, y, x)
 
@@ -330,7 +331,7 @@ class ImageStack:
         index_labels : Optional[Mapping[Axes, Sequence[int]]]
             Mapping from axes (r, ch, z) to their labels.  If this is not provided, then the axes
             will be labeled from 0..(n-1), where n=the size of the axes.
-        coordinates : Optional[Mapping[Coordinates, Sequence[Number]]]
+        coordinates : Optional[Mapping[Coordinates, ArrayLike[Number]]]
             Map from Coordinates to a sequence of coordinate values.  If this is not provided, then
             the ImageStack gets fake coordinates.
 

--- a/starfish/core/imagestack/parser/_tiledata.py
+++ b/starfish/core/imagestack/parser/_tiledata.py
@@ -1,8 +1,8 @@
-from typing import Collection, Mapping, Sequence
+from typing import Collection, Mapping
 
 import numpy as np
 
-from starfish.core.types import Axes, Coordinates, Number
+from starfish.core.types import ArrayLike, Axes, Coordinates, Number
 from ._key import TileKey
 
 
@@ -26,7 +26,7 @@ class TileData:
         raise NotImplementedError()
 
     @property
-    def coordinates(self) -> Mapping[Coordinates, Sequence[Number]]:
+    def coordinates(self) -> Mapping[Coordinates, ArrayLike[Number]]:
         raise NotImplementedError()
 
     @property

--- a/starfish/core/imagestack/parser/crop.py
+++ b/starfish/core/imagestack/parser/crop.py
@@ -1,11 +1,11 @@
 from collections import OrderedDict
-from typing import Collection, List, Mapping, MutableSequence, Optional, Sequence, Tuple, Union
+from typing import Collection, List, Mapping, MutableSequence, Optional, Tuple, Union
 
 import numpy as np
 from slicedimage import Tile, TileSet
 
 from starfish.core.imagestack.parser import TileCollectionData, TileData, TileKey
-from starfish.core.types import Axes, Coordinates, Number
+from starfish.core.types import ArrayLike, Axes, Coordinates, Number
 
 
 class CropParameters:
@@ -221,8 +221,8 @@ class CropParameters:
         return image[output_y_shape[0]:output_y_shape[1], output_x_shape[0]:output_x_shape[1]]
 
     def crop_coordinates(
-            self, coordinates: Mapping[Coordinates, Sequence[Number]],
-    ) -> Mapping[Coordinates, Sequence[Number]]:
+            self, coordinates: Mapping[Coordinates, ArrayLike[Number]],
+    ) -> Mapping[Coordinates, ArrayLike[Number]]:
         """
         Given a mapping of coordinate to coordinate values, return a mapping of the coordinate to
         cropped coordinate values.
@@ -256,7 +256,7 @@ class CroppedTileData(TileData):
         return self.cropping_parameters.crop_image(self.backing_tile_data.numpy_array)
 
     @property
-    def coordinates(self) -> Mapping[Coordinates, Sequence[Number]]:
+    def coordinates(self) -> Mapping[Coordinates, ArrayLike[Number]]:
         return self.cropping_parameters.crop_coordinates(self.backing_tile_data.coordinates)
 
     @property

--- a/starfish/core/imagestack/parser/numpy/__init__.py
+++ b/starfish/core/imagestack/parser/numpy/__init__.py
@@ -3,26 +3,22 @@ This module encapsulates the logic to parse a numpy array into an ImageStack.
 """
 from itertools import product
 from typing import (
-    Any,
     Collection,
     Mapping,
     MutableMapping,
     MutableSequence,
     Optional,
     Sequence,
-    Tuple,
 )
 
 import numpy as np
-import xarray as xr
 
 from starfish.core.imagestack.parser import TileCollectionData, TileData, TileKey
 from starfish.core.types import (
+    ArrayLike,
     Axes,
     Coordinates,
     Number,
-    PHYSICAL_COORDINATE_DIMENSION,
-    PhysicalCoordinateTypes,
 )
 
 
@@ -34,7 +30,7 @@ class NumpyImageTile(TileData):
     def __init__(
             self,
             data: np.ndarray,
-            coordinates: Mapping[Coordinates, Sequence[Number]],
+            coordinates: Mapping[Coordinates, ArrayLike[Number]],
             selector: Mapping[Axes, int],
     ) -> None:
         self._data = data
@@ -53,7 +49,7 @@ class NumpyImageTile(TileData):
         return self._data
 
     @property
-    def coordinates(self) -> Mapping[Coordinates, Sequence[Number]]:
+    def coordinates(self) -> Mapping[Coordinates, ArrayLike[Number]]:
         return self._coordinates
 
     @property
@@ -70,7 +66,7 @@ class NumpyData(TileCollectionData):
             self,
             data: np.ndarray,
             index_labels: Mapping[Axes, Sequence[int]],
-            coordinates: Optional[Mapping[Coordinates, Sequence[Number]]],
+            coordinates: Optional[Mapping[Coordinates, ArrayLike[Number]]],
     ) -> None:
         self.data = data
         self.index_labels = index_labels
@@ -122,7 +118,7 @@ class NumpyData(TileCollectionData):
         pos_ch = self.index_labels[Axes.CH].index(ch)
         pos_z = self.index_labels[Axes.ZPLANE].index(z)
 
-        coordinates: MutableMapping[Coordinates, Sequence[Number]] = dict()
+        coordinates: MutableMapping[Coordinates, ArrayLike[Number]] = dict()
 
         if self.coordinates is not None:
             coordinates[Coordinates.X] = self.coordinates[Coordinates.X]

--- a/starfish/core/imagestack/parser/tileset/_parser.py
+++ b/starfish/core/imagestack/parser/tileset/_parser.py
@@ -1,7 +1,7 @@
 """
 This module parses and retains the extras metadata attached to TileSet extras.
 """
-from typing import Collection, Mapping, MutableMapping, Sequence, Tuple
+from typing import Collection, Mapping, MutableMapping, Tuple
 
 import numpy as np
 from slicedimage import Tile, TileSet
@@ -9,7 +9,7 @@ from slicedimage import Tile, TileSet
 from starfish.core.imagestack.dataorder import AXES_DATA
 from starfish.core.imagestack.parser import TileCollectionData, TileData, TileKey
 from starfish.core.imagestack.physical_coordinates import _get_physical_coordinates_of_z_plane
-from starfish.core.types import Axes, Coordinates, Number
+from starfish.core.types import ArrayLike, Axes, Coordinates, Number
 
 
 class SlicedImageTile(TileData):
@@ -51,7 +51,7 @@ class SlicedImageTile(TileData):
         return self._numpy_array
 
     @property
-    def coordinates(self) -> Mapping[Coordinates, Sequence[Number]]:
+    def coordinates(self) -> Mapping[Coordinates, ArrayLike[Number]]:
         xrange = self._wrapped_tile.coordinates[Coordinates.X]
         yrange = self._wrapped_tile.coordinates[Coordinates.Y]
         return_coords = {

--- a/starfish/core/morphology/binary_mask/_io.py
+++ b/starfish/core/morphology/binary_mask/_io.py
@@ -4,13 +4,13 @@ import pickle
 import tarfile
 import warnings
 from dataclasses import dataclass
-from typing import BinaryIO, List, Mapping, MutableSequence, Optional, Sequence, Tuple, Type
+from typing import BinaryIO, List, Mapping, MutableSequence, Optional, Tuple, Type
 
 import numpy as np
 from packaging.version import Version
 
 from starfish.core.errors import DataFormatWarning
-from starfish.core.types import Axes, Coordinates, Number, STARFISH_EXTRAS_KEY
+from starfish.core.types import ArrayLike, Axes, Coordinates, Number, STARFISH_EXTRAS_KEY
 from starfish.core.util.logging import Log
 from . import binary_mask as bm
 
@@ -94,8 +94,8 @@ class v0_0(BinaryMaskIO, version_descriptor=Version("0.0")):
     def read_binary_mask(self, tf: tarfile.TarFile) -> bm.BinaryMaskCollection:
         log: Optional[Log] = None
         masks: MutableSequence[bm.MaskData] = []
-        pixel_ticks: Optional[Mapping[Axes, Sequence[int]]] = None
-        physical_ticks: Optional[Mapping[Coordinates, Sequence[Number]]] = None
+        pixel_ticks: Optional[Mapping[Axes, ArrayLike[int]]] = None
+        physical_ticks: Optional[Mapping[Coordinates, ArrayLike[Number]]] = None
 
         while True:
             tarinfo: Optional[tarfile.TarInfo] = tf.next()

--- a/starfish/core/morphology/binary_mask/binary_mask.py
+++ b/starfish/core/morphology/binary_mask/binary_mask.py
@@ -22,7 +22,7 @@ from skimage.measure._regionprops import _RegionProperties
 
 from starfish.core.morphology.label_image import LabelImage
 from starfish.core.morphology.util import _get_axes_names
-from starfish.core.types import Axes, Coordinates, Number
+from starfish.core.types import ArrayLike, Axes, Coordinates, Number
 from starfish.core.util.logging import Log
 from .expand import fill_from_mask
 
@@ -39,10 +39,10 @@ class BinaryMaskCollection:
 
     Parameters
     ----------
-    pixel_ticks : Union[Mapping[Axes, Sequence[int]], Mapping[str, Sequence[int]]]
+    pixel_ticks : Union[Mapping[Axes, ArrayLike[int]], Mapping[str, ArrayLike[int]]]
         A map from the axis to the values for that axis.
-    physical_ticks : Union[Mapping[Coordinates, Sequence[Number]],
-                                 Mapping[str, Sequence[Number]]
+    physical_ticks : Union[Mapping[Coordinates, ArrayLike[Number]],
+                                   Mapping[str, ArrayLike[Number]]
         A map from the physical coordinate type to the values for axis.  For 2D label images,
         X and Y physical coordinates must be provided.  For 3D label images, Z physical
         coordinates must also be provided.
@@ -56,17 +56,17 @@ class BinaryMaskCollection:
     """
     def __init__(
             self,
-            pixel_ticks: Union[Mapping[Axes, Sequence[int]], Mapping[str, Sequence[int]]],
-            physical_ticks: Union[Mapping[Coordinates, Sequence[Number]],
-                                  Mapping[str, Sequence[Number]]],
+            pixel_ticks: Union[Mapping[Axes, ArrayLike[int]], Mapping[str, ArrayLike[int]]],
+            physical_ticks: Union[Mapping[Coordinates, ArrayLike[Number]],
+                                  Mapping[str, ArrayLike[Number]]],
             masks: Sequence[MaskData],
             log: Optional[Log],
     ):
-        self._pixel_ticks: Mapping[Axes, Sequence[int]] = {
+        self._pixel_ticks: Mapping[Axes, ArrayLike[int]] = {
             Axes(axis): axis_data
             for axis, axis_data in pixel_ticks.items()
         }
-        self._physical_ticks: Mapping[Coordinates, Sequence[Number]] = {
+        self._physical_ticks: Mapping[Coordinates, ArrayLike[Number]] = {
             Coordinates(coord): coord_data
             for coord, coord_data in physical_ticks.items()
         }

--- a/starfish/core/morphology/label_image/label_image.py
+++ b/starfish/core/morphology/label_image/label_image.py
@@ -1,12 +1,12 @@
 from pathlib import Path
-from typing import Any, Hashable, Mapping, MutableMapping, Optional, Sequence, Tuple, Union
+from typing import Any, Hashable, Mapping, MutableMapping, Optional, Tuple, Union
 
 import numpy as np
 import xarray as xr
 from semantic_version import Version
 
 from starfish.core.morphology.util import _get_axes_names
-from starfish.core.types import Axes, Coordinates, LOG, Number, STARFISH_EXTRAS_KEY
+from starfish.core.types import ArrayLike, Axes, Coordinates, LOG, Number, STARFISH_EXTRAS_KEY
 from starfish.core.util.logging import Log
 
 
@@ -53,11 +53,11 @@ class LabelImage:
             cls,
             array: np.ndarray,
             pixel_coordinates: Optional[Union[
-                                        Mapping[Axes, Sequence[int]],
-                                        Mapping[str, Sequence[int]]]],
+                                        Mapping[Axes, ArrayLike[int]],
+                                        Mapping[str, ArrayLike[int]]]],
             physical_coordinates: Union[
-                Mapping[Coordinates, Sequence[Number]],
-                Mapping[str, Sequence[Number]]],
+                Mapping[Coordinates, ArrayLike[Number]],
+                Mapping[str, ArrayLike[Number]]],
             log: Optional[Log],
     ) -> "LabelImage":
         """Constructs a LabelImage from an array containing the labels, a set of physical
@@ -68,23 +68,25 @@ class LabelImage:
         array : np.ndarray
             A 2D or 3D array containing the labels.  The ordering of the axes must be Y, X for 2D
             images and ZPLANE, Y, X for 3D images.
-        pixel_coordinates : Optional[Mapping[Union[Axes, str], Sequence[int]]]
+        pixel_coordinates : Optional[Union[Mapping[Axes, ArrayLike[int]],
+                                           Mapping[str, ArrayLike[int]]]]
             A map from the axis to the values for that axis.  For any axis that exist in the array
             but not in pixel_coordinates, the pixel coordinates are assigned from 0..N-1, where N is
             the size along that axis.
-        physical_coordinates : Mapping[Union[Coordinates, str], Sequence[Number]]
+        physical_coordinates : Union[Mapping[Coordinates, ArrayLike[Number]],
+                                     Mapping[str, ArrayLike[Number]]]
             A map from the physical coordinate type to the values for axis.  For 2D label images,
             X and Y physical coordinates must be provided.  For 3D label images, Z physical
             coordinates must also be provided.
         log : Optional[Log]
             A log of how this label image came to be.
         """
-        # normalize the pixel coordinates to Mapping[Axes, Sequence[int]]
+        # normalize the pixel coordinates to Mapping[Axes, ArrayLike[int]]
         pixel_coordinates = {
             axis if isinstance(axis, Axes) else Axes(axis): axis_values
             for axis, axis_values in (pixel_coordinates or {}).items()
         }
-        # normalize the physical coordinates to Mapping[Coordinates, Sequence[Number]]
+        # normalize the physical coordinates to Mapping[Coordinates, ArrayLike[Number]]
         physical_coordinates = {
             coord if isinstance(coord, Coordinates) else Coordinates(coord): coord_values
             for coord, coord_values in physical_coordinates.items()

--- a/starfish/core/morphology/label_image/test/test_label_image.py
+++ b/starfish/core/morphology/label_image/test/test_label_image.py
@@ -1,11 +1,11 @@
-from typing import Mapping, Optional, Sequence, Type
+from typing import Mapping, Optional, Type
 
 import numpy as np
 import pytest
 
 from starfish import Log
 from starfish.image import Filter
-from starfish.types import Axes, Coordinates, Number
+from starfish.types import ArrayLike, Axes, Coordinates, Number
 from ..label_image import AttrKeys, CURRENT_VERSION, DOCTYPE_STRING, LabelImage
 
 
@@ -56,7 +56,7 @@ from ..label_image import AttrKeys, CURRENT_VERSION, DOCTYPE_STRING, LabelImage
 )
 def test_from_array_and_coords(
         array: np.ndarray,
-        physical_coordinates: Mapping[Coordinates, Sequence[Number]],
+        physical_coordinates: Mapping[Coordinates, ArrayLike[Number]],
         log: Optional[Log],
         expected_error: Optional[Type[Exception]],
 ):

--- a/starfish/core/segmentation_mask/segmentation_mask.py
+++ b/starfish/core/segmentation_mask/segmentation_mask.py
@@ -7,9 +7,9 @@ from typing import (
 )
 from warnings import warn
 
-from starfish.core.morphology.binary_mask import BinaryMaskCollection, MaskData
+from starfish.core.morphology.binary_mask.binary_mask import BinaryMaskCollection, MaskData
 from starfish.core.morphology.label_image import label_image as li
-from starfish.core.types import Axes, Coordinates, Number
+from starfish.core.types import ArrayLike, Axes, Coordinates, Number
 from starfish.core.util.logging import Log
 
 
@@ -17,9 +17,9 @@ class SegmentationMaskCollection(BinaryMaskCollection):
     """Deprecated in favor of BinaryMaskCollection."""
     def __init__(
             self,
-            pixel_ticks: Union[Mapping[Axes, Sequence[int]], Mapping[str, Sequence[int]]],
-            physical_ticks: Union[Mapping[Coordinates, Sequence[Number]],
-                                  Mapping[str, Sequence[Number]]],
+            pixel_ticks: Union[Mapping[Axes, ArrayLike[int]], Mapping[str, ArrayLike[int]]],
+            physical_ticks: Union[Mapping[Coordinates, ArrayLike[Number]],
+                                  Mapping[str, ArrayLike[Number]]],
             masks: Sequence[MaskData],
             log: Optional[Log],
     ):


### PR DESCRIPTION
Mostly this is a no-op in terms of complexity, but we got rid of one ugly cast!  Later on, we'll also get some benefits from segmentation code.

Depends on #1649 
Test plan: make -j lint mypy