### PR TITLE
Factory methods for binary mask collections

### DIFF
--- a/starfish/core/morphology/binary_mask/test/factories.py
+++ b/starfish/core/morphology/binary_mask/test/factories.py
@@ -1,0 +1,110 @@
+from typing import Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+
+from starfish.core.types import ArrayLike, Axes, Coordinates, Number
+from ..binary_mask import BinaryMaskCollection
+
+
+def label_array_2d() -> Tuple[np.ndarray, Mapping[Coordinates, ArrayLike[Number]]]:
+    """Convenience method to return a 2D label array with corresponding physical coordinates."""
+    label_array = np.zeros((5, 6), dtype=np.int32)
+    label_array[0] = 1
+    label_array[3:5, 3:6] = 2
+    label_array[-1, -1] = 0
+
+    physical_ticks = {
+        Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6.0],
+        Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12, 13.2]}
+
+    return label_array, physical_ticks
+
+
+def binary_arrays_2d() -> Tuple[Sequence[np.ndarray], Mapping[Coordinates, ArrayLike[Number]]]:
+    """Convenience method to return a set of 2D binary arrays with corresponding physical
+    coordinates."""
+    binary_arrays = [
+        np.zeros((5, 6), dtype=np.bool),
+        np.zeros((5, 6), dtype=np.bool),
+    ]
+    binary_arrays[0][0] = True
+    binary_arrays[1][3:5, 3:6] = True
+    binary_arrays[1][-1, -1] = False
+
+    physical_ticks = {
+        Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6.0],
+        Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12, 13.2]}
+
+    return binary_arrays, physical_ticks
+
+
+def label_array_3d() -> Tuple[np.ndarray, Mapping[Coordinates, ArrayLike[Number]]]:
+    """Convenience method to return a 3D label array with corresponding physical coordinates."""
+    label_array = np.zeros((2, 5, 6), dtype=np.int32)
+    label_array[0, 0] = 1
+    label_array[:, 3:5, 3:6] = 2
+    label_array[-1, -1, -1] = 0
+
+    physical_ticks = {
+        Coordinates.Z: [0.0, 1.0],
+        Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6.0],
+        Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12, 13.2]
+    }
+
+    return label_array, physical_ticks
+
+
+def binary_arrays_3d() -> Tuple[Sequence[np.ndarray], Mapping[Coordinates, ArrayLike[Number]]]:
+    """Convenience method to return a set of 2D binary arrays with corresponding physical
+    coordinates."""
+    binary_arrays = [
+        np.zeros((2, 5, 6), dtype=np.bool),
+        np.zeros((2, 5, 6), dtype=np.bool),
+    ]
+    binary_arrays[0][0, 0] = True
+    binary_arrays[1][:, 3:5, 3:6] = True
+    binary_arrays[1][-1, -1, -1] = False
+
+    physical_ticks = {
+        Coordinates.Z: [0.0, 1.0],
+        Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6.0],
+        Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12, 13.2]
+    }
+
+    return binary_arrays, physical_ticks
+
+
+def binary_mask_collection_2d(
+        label_array: Optional[np.ndarray] = None,
+        physical_ticks: Optional[Mapping[Coordinates, ArrayLike[Number]]] = None,
+        pixel_ticks: Optional[Mapping[Axes, ArrayLike[int]]] = None):
+    """Convenience method to return a 2D binary mask collection."""
+    if label_array is None or physical_ticks is None:
+        new_label_array, new_physical_ticks = label_array_2d()
+        label_array = label_array or new_label_array
+        physical_ticks = physical_ticks or new_physical_ticks
+
+    return BinaryMaskCollection.from_label_array_and_ticks(
+        label_array,
+        pixel_ticks,
+        physical_ticks,
+        None
+    )
+
+
+def binary_mask_collection_3d(
+        label_array: Optional[np.ndarray],
+        physical_ticks: Optional[Mapping[Coordinates, ArrayLike[Number]]],
+        pixel_ticks: Optional[Mapping[Axes, ArrayLike[int]]]):
+    """Convenience method to return a 3D binary mask collection."""
+    if label_array is None or physical_ticks is None:
+        new_label_array, new_physical_ticks = label_array_3d()
+        label_array = label_array or new_label_array
+        physical_ticks = physical_ticks or new_physical_ticks
+
+    return BinaryMaskCollection.from_label_array_and_ticks(
+        label_array,
+        pixel_ticks,
+        physical_ticks,
+        None
+    )

--- a/starfish/core/morphology/binary_mask/test/test_binary_mask.py
+++ b/starfish/core/morphology/binary_mask/test/test_binary_mask.py
@@ -2,17 +2,12 @@ import numpy as np
 
 from starfish.core.morphology.label_image import LabelImage
 from starfish.core.types import Axes, Coordinates
+from .factories import binary_mask_collection_2d, label_array_2d
 from ..binary_mask import BinaryMaskCollection
 
 
 def test_from_label_image():
-    label_image_array = np.zeros((5, 6), dtype=np.int32)
-    label_image_array[0] = 1
-    label_image_array[3:5, 3:6] = 2
-    label_image_array[-1, -1] = 0
-
-    physical_ticks = {Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6.0],
-                      Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12, 13.2]}
+    label_image_array, physical_ticks = label_array_2d()
 
     label_image = LabelImage.from_label_array_and_ticks(
         label_image_array,
@@ -54,13 +49,7 @@ def test_from_label_image():
 def test_uncropped_mask():
     """Test that BinaryMaskCollection.uncropped_mask() works correctly.
     """
-    label_image_array = np.zeros((5, 5), dtype=np.int32)
-    label_image_array[0] = 1
-    label_image_array[3:5, 3:5] = 2
-    label_image_array[-1, -1] = 0
-
-    physical_ticks = {Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6.0],
-                      Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12]}
+    label_image_array, physical_ticks = label_array_2d()
 
     label_image = LabelImage.from_label_array_and_ticks(
         label_image_array,
@@ -83,18 +72,16 @@ def test_uncropped_mask():
     assert region_1.dtype == np.bool
     assert np.all(region_1[0:3, :] == 0)
     assert np.all(region_1[:, 0:3] == 0)
-    assert np.all(region_1[3:5, 3:5] == [[1, 1],
-                                         [1, 0]])
+    assert np.all(region_1[3:5, 3:6] == [[1, 1, 1],
+                                         [1, 1, 0]])
 
 
 def test_uncropped_mask_no_uncropping():
     """If the mask doesn't need to be uncropped, it should still work.  This is an optimized code
     path, so it is separately validated.
     """
-    label_image_array = np.full((5, 5), fill_value=1, dtype=np.int32)
-
-    physical_ticks = {Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6.0],
-                      Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12]}
+    label_image_array, physical_ticks = label_array_2d()
+    label_image_array.fill(1)
 
     label_image = LabelImage.from_label_array_and_ticks(
         label_image_array,
@@ -113,13 +100,7 @@ def test_uncropped_mask_no_uncropping():
 
 def test_to_label_image():
     # test via roundtrip
-    label_image_array = np.zeros((5, 6), dtype=np.int32)
-    label_image_array[0] = 1
-    label_image_array[3:5, 3:6] = 2
-    label_image_array[-1, -1] = 0
-
-    physical_ticks = {Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6.0],
-                      Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12, 13.2]}
+    label_image_array, physical_ticks = label_array_2d()
 
     label_image = LabelImage.from_label_array_and_ticks(
         label_image_array,
@@ -134,22 +115,7 @@ def test_to_label_image():
 
 
 def test_save_load(tmp_path):
-    label_image_array = np.zeros((5, 6), dtype=np.int32)
-    label_image_array[0] = 1
-    label_image_array[3:5, 3:6] = 2
-    label_image_array[-1, -1] = 0
-
-    physical_ticks = {Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6.0],
-                      Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12, 13.2]}
-
-    label_image = LabelImage.from_label_array_and_ticks(
-        label_image_array,
-        None,
-        physical_ticks,
-        None,
-    )
-
-    binary_mask_collection = BinaryMaskCollection.from_label_image(label_image)
+    binary_mask_collection = binary_mask_collection_2d()
 
     path = tmp_path / "data.tgz"
     binary_mask_collection.to_targz(path)
@@ -165,13 +131,11 @@ def test_save_load(tmp_path):
 
 
 def test_from_empty_label_image(tmp_path):
-    label_image_array = np.zeros((5, 6), dtype=np.int32)
-
-    physical_ticks = {Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6.0],
-                      Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12, 13.2]}
+    label_array, physical_ticks = label_array_2d()
+    label_array.fill(0)
 
     label_image = LabelImage.from_label_array_and_ticks(
-        label_image_array,
+        label_array,
         None,
         physical_ticks,
         None,

--- a/starfish/core/morphology/binary_mask/test/test_from_binary_arrays_and_ticks.py
+++ b/starfish/core/morphology/binary_mask/test/test_from_binary_arrays_and_ticks.py
@@ -2,23 +2,14 @@ import numpy as np
 import pytest
 
 from starfish.core.types import Axes, Coordinates
+from .factories import binary_arrays_2d, binary_arrays_3d
 from ..binary_mask import BinaryMaskCollection
 
 
 def test_2d():
     """Simple case of BinaryMaskCollection.from_binary_arrays_and_ticks with 2D data.  Pixel ticks
     are inferred."""
-    binary_arrays = [
-        np.zeros((5, 6), dtype=np.bool),
-        np.zeros((5, 6), dtype=np.bool),
-    ]
-    binary_arrays[0][0] = True
-    binary_arrays[1][3:5, 3:6] = True
-    binary_arrays[1][-1, -1] = False
-
-    physical_ticks = {
-        Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6.0],
-        Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12, 13.2]}
+    binary_arrays, physical_ticks = binary_arrays_2d()
 
     binary_mask_collection = BinaryMaskCollection.from_binary_arrays_and_ticks(
         binary_arrays,
@@ -57,19 +48,7 @@ def test_2d():
 def test_3d():
     """Simple case of BinaryMaskCollection.from_binary_arrays_and_ticks with 3D data.  Pixel ticks
     are inferred."""
-    binary_arrays = [
-        np.zeros((2, 5, 6), dtype=np.bool),
-        np.zeros((2, 5, 6), dtype=np.bool),
-    ]
-    binary_arrays[0][0, 0] = True
-    binary_arrays[1][:, 3:5, 3:6] = True
-    binary_arrays[1][-1, -1, -1] = False
-
-    physical_ticks = {
-        Coordinates.Z: [0.0, 1.0],
-        Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6.0],
-        Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12, 13.2]
-    }
+    binary_arrays, physical_ticks = binary_arrays_3d()
 
     binary_mask_collection = BinaryMaskCollection.from_binary_arrays_and_ticks(
         binary_arrays,
@@ -114,9 +93,7 @@ def test_3d():
 def test_no_mask():
     """Simple case of BinaryMaskCollection.from_binary_arrays_and_ticks with no masks.  Pixel ticks
     are inferred."""
-    physical_ticks = {
-        Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6],
-        Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12, 13.2]}
+    _, physical_ticks = binary_arrays_2d()
 
     binary_mask_collection = BinaryMaskCollection.from_binary_arrays_and_ticks(
         [],
@@ -142,9 +119,7 @@ def test_empty_mask():
     binary_arrays = [
         np.zeros((5, 6), dtype=np.bool),
     ]
-    physical_ticks = {
-        Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6],
-        Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12, 13.2]}
+    _, physical_ticks = binary_arrays_2d()
 
     binary_mask_collection = BinaryMaskCollection.from_binary_arrays_and_ticks(
         binary_arrays,
@@ -177,9 +152,7 @@ def test_mismatched_binary_array_sizes():
     binary_arrays[1][3:5, 3:6] = True
     binary_arrays[1][-1, -1] = False
 
-    physical_ticks = {
-        Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6.0],
-        Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12, 13.2]}
+    _, physical_ticks = binary_arrays_2d()
 
     with pytest.raises(ValueError):
         BinaryMaskCollection.from_binary_arrays_and_ticks(
@@ -201,9 +174,7 @@ def test_mismatched_binary_array_types():
     binary_arrays[1][3:5, 3:6] = True
     binary_arrays[1][-1, -1] = False
 
-    physical_ticks = {
-        Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6.0],
-        Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12, 13.2]}
+    _, physical_ticks = binary_arrays_2d()
 
     with pytest.raises(TypeError):
         BinaryMaskCollection.from_binary_arrays_and_ticks(
@@ -217,21 +188,12 @@ def test_mismatched_binary_array_types():
 def test_incorrectly_sized_pixel_ticks():
     """BinaryMaskCollection.from_binary_arrays_and_ticks with 2D data.  Pixel ticks are incorrectly
     sized."""
-    binary_arrays = [
-        np.zeros((5, 6), dtype=np.bool),
-        np.zeros((5, 6), dtype=np.bool),
-    ]
-    binary_arrays[0][0] = True
-    binary_arrays[1][3:5, 3:6] = True
-    binary_arrays[1][-1, -1] = False
+    binary_arrays, physical_ticks = binary_arrays_2d()
 
     pixel_ticks = {
         Axes.Y: [0, 1, 2, 3],
         Axes.X: [0, 1, 2, 3, 4, 5],
     }
-    physical_ticks = {
-        Coordinates.Y: [1.2, 2.4, 3.6, 4.8, 6.0],
-        Coordinates.X: [7.2, 8.4, 9.6, 10.8, 12, 13.2]}
 
     with pytest.raises(ValueError):
         BinaryMaskCollection.from_binary_arrays_and_ticks(


### PR DESCRIPTION
Methods to create label arrays, binary arrays, and binary masks.  This is mostly to reduce a bit of copy pasta, and to make it easier to write simple examples in docblocks.

Depends on #1637
Test plan: `pytest starfish/core/morphology/object/binary_mask/test/`