### PR TITLE
RFC: Add step to trim the changelog to user-relevant notes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,8 @@ help-install:
 #      perform other edits. Important is that each section is
 #      separated by a line beginning with '##'.
 #
+#      Remove changelog entries that do not pertain to end users.
+#
 #  (2) Commit all files and remove any untracked files.
 #      `git status` should show nothing.
 #


### PR DESCRIPTION
I think this would generally be better.  The caveat is that occasionally, when I discover an upstream dependency breaks starfish, that the detailed changelog turns out to be useful.