### PR TITLE
fix masks display()

### DIFF
--- a/starfish/core/_display.py
+++ b/starfish/core/_display.py
@@ -274,7 +274,8 @@ def display(
             )
 
     if masks:
-        viewer.add_labels(masks.to_label_image(),
+        label_im = masks.to_label_image().label_image
+        viewer.add_labels(label_im.values,
                           name="masks")
 
     if new_viewer and not INTERACTIVE:


### PR DESCRIPTION
# Description
This PR fixes the display of masks in a `BinaryMaskCollection` using `starfish.display()`. As proposed in #1662 , I updated how the label image array is retrieved to match the new `BinaryMaskCollection` / `LabelImage' API.

This PR closes #1662 

# Testing
I tested this by running the `ISS.ipynb` notebook and displaying the masks with `starfish.display(registered_imgs, decoded, masks)`. 
 