### PR TITLE
Fix display tests and code

### DIFF
--- a/starfish/core/_display.py
+++ b/starfish/core/_display.py
@@ -274,7 +274,7 @@ def display(
             )
 
     if masks:
-        viewer.add_labels(masks.to_label_image(),
+        viewer.add_labels(masks.to_label_image().label_image,
                           name="masks")
 
     if new_viewer and not INTERACTIVE:

--- a/starfish/core/test/test_display.py
+++ b/starfish/core/test/test_display.py
@@ -22,7 +22,7 @@ sd = SyntheticData(
 stack = sd.spots()
 spots = sd.intensities()
 label_image = LabelImage.from_label_array_and_ticks(
-    np.random.rand(128, 128).astype(np.uint8),
+    np.random.randint(0, 4, size=(128, 128), dtype=np.uint8),
     None,
     {Coordinates.Y: np.arange(128), Coordinates.X: np.arange(128)},
     None,
@@ -43,8 +43,7 @@ def test_display(stack, spots, masks):
         app = QApplication.instance() or QApplication([])
         viewer = napari.Viewer()
         timer = QTimer()
-        timer.setInterval(500)
-        timer.timeout.connect(viewer.window.close)
+        timer.setInterval(1000)
         timer.timeout.connect(app.quit)
         timer.start()
         display(stack, spots, masks, viewer=viewer)


### PR DESCRIPTION
1. on osx, firing viewer.window.close() upon the timer's expiration seems to crash python.  Removing it seems to be ok on osx.  Will test on travis shortly.
2. Fix the synthetic mask we used to test the code.  As it turns out, the labelimage created had only 0 values (rand produces values between 0 and 1, randint is what we really wanted), so it was never exercising the masks code.
3. Fix masks.display() (same as #1663).  This is required to pass travis because (2) now catches the bug.

Test plan: this is mostly tests. :)  https://travis-ci.com/spacetx/starfish/builds/137469517 shows how it works on travis.