### PR TITLE
Remove Union[np.ndarray, xr.DataArray]

### DIFF
--- a/starfish/core/image/Filter/bandpass.py
+++ b/starfish/core/image/Filter/bandpass.py
@@ -1,7 +1,6 @@
 from functools import partial
 from typing import Optional, Union
 
-import numpy as np
 import xarray as xr
 from trackpy import bandpass
 
@@ -64,14 +63,14 @@ class Bandpass(FilterAlgorithm):
 
     @staticmethod
     def _bandpass(
-            image: Union[xr.DataArray, np.ndarray],
+            image: xr.DataArray,
             lshort: Number, llong: int, threshold: Number, truncate: Number
-    ) -> np.ndarray:
+    ) -> xr.DataArray:
         """Apply a bandpass filter to remove noise and background variation
 
         Parameters
         ----------
-        image : Union[xr.DataArray, np.ndarray]
+        image : xr.DataArray
         lshort : float
             filter frequencies below this value
         llong : int
@@ -84,7 +83,7 @@ class Bandpass(FilterAlgorithm):
 
         Returns
         -------
-        np.ndarray :
+        xr.DataArray :
             bandpassed image
 
         """

--- a/starfish/core/image/Filter/clip.py
+++ b/starfish/core/image/Filter/clip.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Optional, Union
+from typing import Optional
 
 import numpy as np
 import xarray as xr
@@ -46,9 +46,9 @@ class Clip(FilterAlgorithm):
 
     @staticmethod
     def _clip(
-        image: Union[xr.DataArray, np.ndarray], p_min: int, p_max: int,
+        image: xr.DataArray, p_min: int, p_max: int,
         expand_dynamic_range: bool
-    ) -> np.ndarray:
+    ) -> xr.DataArray:
         """Clip values of image"""
         v_min, v_max = np.percentile(image, [p_min, p_max])
 

--- a/starfish/core/image/Filter/clip_percentile_to_zero.py
+++ b/starfish/core/image/Filter/clip_percentile_to_zero.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Optional, Union
+from typing import Optional
 
 import numpy as np
 import xarray as xr
@@ -52,11 +52,12 @@ class ClipPercentileToZero(FilterAlgorithm):
                                    "min_coeff": 1.0, "max_coeff": 1.0}
 
     @staticmethod
-    def _clip_percentile_to_zero(image: Union[xr.DataArray, np.ndarray],
-                                 p_min: int,
-                                 p_max: int,
-                                 min_coeff: float,
-                                 max_coeff: float) -> np.ndarray:
+    def _clip_percentile_to_zero(
+            image: xr.DataArray,
+            p_min: int,
+            p_max: int,
+            min_coeff: float,
+            max_coeff: float) -> xr.DataArray:
         v_min, v_max = np.percentile(image, [p_min, p_max])
         v_min = min_coeff * v_min
         v_max = max_coeff * v_max

--- a/starfish/core/image/Filter/clip_value_to_zero.py
+++ b/starfish/core/image/Filter/clip_value_to_zero.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Optional, Union
+from typing import Optional
 
 import numpy as np
 import xarray as xr
@@ -44,9 +44,10 @@ class ClipValueToZero(FilterAlgorithm):
     _DEFAULT_TESTING_PARAMETERS = {"v_min": 0.0, "v_max": None}
 
     @staticmethod
-    def _clip_value_to_zero(image: Union[xr.DataArray, np.ndarray],
-                            v_min: float,
-                            v_max: Optional[Number]) -> np.ndarray:
+    def _clip_value_to_zero(
+            image: xr.DataArray,
+            v_min: float,
+            v_max: Optional[Number]) -> xr.DataArray:
         return image.clip(min=v_min, max=v_max) - np.float32(v_min)
 
     def run(self,

--- a/starfish/core/image/Filter/gaussian_high_pass.py
+++ b/starfish/core/image/Filter/gaussian_high_pass.py
@@ -1,7 +1,6 @@
 from functools import partial
 from typing import Callable, Optional, Tuple, Union
 
-import numpy as np
 import xarray as xr
 
 from starfish.core.image.Filter.gaussian_low_pass import GaussianLowPass
@@ -55,10 +54,10 @@ class GaussianHighPass(FilterAlgorithm):
 
     @staticmethod
     def _high_pass(
-            image: Union[xr.DataArray, np.ndarray],
+            image: xr.DataArray,
             sigma: Union[Number, Tuple[Number]],
             rescale: bool = False
-    ) -> Union[xr.DataArray, np.ndarray]:
+    ) -> xr.DataArray:
         """
         Applies a gaussian high pass filter to an image
 
@@ -74,7 +73,7 @@ class GaussianHighPass(FilterAlgorithm):
         Returns
         -------
         np.ndarray :
-            filtered image of the same shape as the input image
+            filtered image of the same type and shape as the input image
         """
 
         blurred = GaussianLowPass._low_pass(image, sigma)

--- a/starfish/core/image/Filter/gaussian_low_pass.py
+++ b/starfish/core/image/Filter/gaussian_low_pass.py
@@ -1,7 +1,6 @@
 from functools import partial
 from typing import Callable, Optional, Tuple, Union
 
-import numpy as np
 import xarray as xr
 from skimage.filters import gaussian
 
@@ -54,16 +53,16 @@ class GaussianLowPass(FilterAlgorithm):
 
     @staticmethod
     def _low_pass(
-            image: Union[xr.DataArray, np.ndarray],
+            image: xr.DataArray,
             sigma: Union[Number, Tuple[Number]],
             rescale: bool = False
-    ) -> np.ndarray:
+    ) -> xr.DataArray:
         """
         Apply a Gaussian blur operation over a multi-dimensional image.
 
         Parameters
         ----------
-        image : Union[xr.DataArray, np.ndarray]
+        image : xr.DataArray
             2-d or 3-d image data
         sigma : Union[Number, Tuple[Number]]
             Standard deviation of the Gaussian kernel that will be applied. If a float, an
@@ -73,7 +72,7 @@ class GaussianLowPass(FilterAlgorithm):
 
         Returns
         -------
-        np.ndarray :
+        xr.DataArray :
             Blurred data in same shape as input image
 
         """

--- a/starfish/core/image/Filter/laplace.py
+++ b/starfish/core/image/Filter/laplace.py
@@ -2,7 +2,6 @@
 from functools import partial
 from typing import Callable, Optional, Tuple, Union
 
-import numpy as np
 import xarray as xr
 from scipy.ndimage import gaussian_laplace
 
@@ -79,9 +78,9 @@ class Laplace(FilterAlgorithm):
 
     @staticmethod
     def _gaussian_laplace(
-        image: Union[xr.DataArray, np.ndarray], sigma: Union[Number, Tuple[Number]],
+        image: xr.DataArray, sigma: Union[Number, Tuple[Number]],
         mode: str = 'reflect', cval: float = 0.0
-    ) -> np.ndarray:
+    ) -> xr.DataArray:
         filtered = gaussian_laplace(
             image, sigma=sigma, mode=mode, cval=cval)
 

--- a/starfish/core/image/Filter/mean_high_pass.py
+++ b/starfish/core/image/Filter/mean_high_pass.py
@@ -57,14 +57,14 @@ class MeanHighPass(FilterAlgorithm):
 
     @staticmethod
     def _high_pass(
-        image: Union[xr.DataArray, np.ndarray], size: Number, rescale: bool = False
-    ) -> np.ndarray:
+        image: xr.DataArray, size: Number, rescale: bool = False
+    ) -> xr.DataArray:
         """
         Applies a mean high pass filter to an image
 
         Parameters
         ----------
-        image : Union[xr.DataArray, numpy.ndarray]
+        image : xr.DataArray
             2-d or 3-d image data
         size : Union[Number, Tuple[Number]]
             width of the kernel
@@ -73,7 +73,7 @@ class MeanHighPass(FilterAlgorithm):
 
         Returns
         -------
-        np.ndarray[np.float32]:
+        xr.DataArray:
             Filtered image, same shape as input
         """
 

--- a/starfish/core/image/Filter/richardson_lucy_deconvolution.py
+++ b/starfish/core/image/Filter/richardson_lucy_deconvolution.py
@@ -87,14 +87,14 @@ class DeconvolvePSF(FilterAlgorithm):
     # and the results look bad. #548 addresses this problem.
     @staticmethod
     def _richardson_lucy_deconv(
-            image: Union[xr.DataArray, np.ndarray], iterations: int, psf: np.ndarray
-    ) -> np.ndarray:
+            image: xr.DataArray, iterations: int, psf: np.ndarray
+    ) -> xr.DataArray:
         """
         Deconvolves input image with a specified point spread function.
 
         Parameters
         ----------
-        image : Union[xr.DataArray, np.ndarray]
+        image : xr.DataArray
            Input degraded image (can be N dimensional).
         psf : ndarray
            The point spread function.
@@ -104,7 +104,7 @@ class DeconvolvePSF(FilterAlgorithm):
 
         Returns
         -------
-        im_deconv : ndarray
+        im_deconv : xr.DataArray
            The deconvolved image.
 
         """

--- a/starfish/core/image/Filter/white_tophat.py
+++ b/starfish/core/image/Filter/white_tophat.py
@@ -1,6 +1,5 @@
 from typing import Optional, Union
 
-import numpy as np
 import xarray as xr
 from skimage.morphology import ball, disk, white_tophat
 
@@ -51,7 +50,7 @@ class WhiteTophat(FilterAlgorithm):
 
     _DEFAULT_TESTING_PARAMETERS = {"masking_radius": 3}
 
-    def _white_tophat(self, image: Union[xr.DataArray, np.ndarray]) -> np.ndarray:
+    def _white_tophat(self, image: xr.DataArray) -> xr.DataArray:
         if self.is_volume:
             structuring_element = ball(self.masking_radius)
         else:

--- a/starfish/core/image/_registration/ApplyTransform/warp.py
+++ b/starfish/core/image/_registration/ApplyTransform/warp.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Optional, Union
+from typing import Optional
 
 import numpy as np
 import xarray as xr
@@ -62,17 +62,18 @@ class Warp(ApplyTransformAlgorithm):
         return None
 
 
-def warp(image: Union[xr.DataArray, np.ndarray],
-         transformation_object: GeometricTransform,
-         **kwargs
-         ) -> np.ndarray:
+def warp(
+        image: xr.DataArray,
+        transformation_object: GeometricTransform,
+        **kwargs
+) -> xr.DataArray:
     """
     Wrapper around :py:func:`skimage.transform.warp`. Warps an image according to a
     given coordinate transformation.
 
     Parameters
     ----------
-    image : np.ndarray
+    image : xr.DataArray
         The image to be transformed
     transformation_object : :py:class:`~skimage.transform._geometric.GeometricTransform`
         The transformation object to apply.

--- a/starfish/core/imagestack/imagestack.py
+++ b/starfish/core/imagestack/imagestack.py
@@ -173,7 +173,7 @@ class ImageStack:
         return imagestack
 
     @staticmethod
-    def _validate_data_dtype_and_range(data: Union[np.ndarray, xr.DataArray]) -> None:
+    def _validate_data_dtype_and_range(data: np.ndarray) -> None:
         """verify that data is of dtype float32 and in range [0, 1]"""
         if data.dtype != np.float32:
             raise TypeError(
@@ -804,7 +804,7 @@ class ImageStack:
 
     @staticmethod
     def _in_place_apply(
-            apply_func: Callable[..., Union[xr.DataArray, np.ndarray]],
+            apply_func: Callable[..., xr.DataArray],
             data: np.ndarray,
             *args,
             clip_method: Union[str, Clip],

--- a/starfish/core/intensity_table/intensity_table.py
+++ b/starfish/core/intensity_table/intensity_table.py
@@ -1,6 +1,6 @@
 from itertools import product
 from json import loads
-from typing import Dict, Hashable, List, Optional, Sequence, Union
+from typing import Dict, Hashable, List, Optional, Sequence
 
 import numpy as np
 import pandas as pd
@@ -136,7 +136,7 @@ class IntensityTable(xr.DataArray):
     @classmethod
     def from_spot_data(
             cls,
-            intensities: Union[xr.DataArray, np.ndarray],
+            intensities: xr.DataArray,
             spot_attributes: SpotAttributes,
             round_values: Sequence[int],
             ch_values: Sequence[int],
@@ -148,7 +148,7 @@ class IntensityTable(xr.DataArray):
 
         Parameters
         ----------
-        intensities : Union[xr.DataArray, np.ndarray]
+        intensities : xr.DataArray
             Intensity data.
         spot_attributes : SpotAttributes
             Table containing spot metadata. Must contain the values specified in Axes.X,

--- a/starfish/core/spots/FindSpots/_base.py
+++ b/starfish/core/spots/FindSpots/_base.py
@@ -1,8 +1,7 @@
 from abc import abstractmethod
-from typing import Callable, Optional, Union
+from typing import Callable, Optional
 
 import numpy as np
-import xarray as xr
 
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.pipeline.algorithmbase import AlgorithmBase
@@ -49,7 +48,7 @@ class FindSpotsAlgorithm(metaclass=AlgorithmBase):
     @staticmethod
     def _get_measurement_function(
             measurement_type: str
-    ) -> Callable[[Union[np.ndarray, xr.DataArray]], Number]:
+    ) -> Callable[[np.ndarray], Number]:
         try:
             measurement_function = getattr(np, measurement_type)
         except AttributeError:

--- a/starfish/core/spots/FindSpots/blob.py
+++ b/starfish/core/spots/FindSpots/blob.py
@@ -3,14 +3,19 @@ from typing import Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
-import xarray as xr
 from skimage.feature import blob_dog, blob_doh, blob_log
 
 from starfish.core.image.Filter.util import determine_axes_to_group_by
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.spots.FindSpots import spot_finding_utils
-from starfish.core.types import Axes, Features, Number, PerImageSliceSpotResults, SpotAttributes,  \
-    SpotFindingResults
+from starfish.core.types import (
+    Axes,
+    Features,
+    Number,
+    PerImageSliceSpotResults,
+    SpotAttributes,
+    SpotFindingResults,
+)
 from ._base import FindSpotsAlgorithm
 
 blob_detectors = {
@@ -85,14 +90,15 @@ class BlobDetector(FindSpotsAlgorithm):
         except ValueError:
             raise ValueError("Detector method must be one of {blob_log, blob_dog, blob_doh}")
 
-    def image_to_spots(self, data_image: Union[np.ndarray, xr.DataArray]
-                       ) -> PerImageSliceSpotResults:
+    def image_to_spots(
+            self, data_image: np.ndarray,
+    ) -> PerImageSliceSpotResults:
         """
         Find spots using a gaussian blob finding algorithm
 
         Parameters
         ----------
-        data_image : Union[np.ndarray, xr.DataArray]
+        data_image : np.ndarray
             image containing spots to be detected
 
         Returns
@@ -123,7 +129,7 @@ class BlobDetector(FindSpotsAlgorithm):
         y_inds = fitted_blobs_array[:, 1].astype(int)
         x_inds = fitted_blobs_array[:, 2].astype(int)
         radius = np.round(fitted_blobs_array[:, 3] * np.sqrt(3))
-        data_image = data_image.values if isinstance(data_image, xr.DataArray) else data_image
+        data_image = np.asarray(data_image)
         intensities = data_image[tuple([z_inds, y_inds, x_inds])]
 
         # construct dataframe
@@ -158,7 +164,7 @@ class BlobDetector(FindSpotsAlgorithm):
         ----------
         image_stack : ImageStack
             ImageStack where we find the spots in.
-        reference_image : xr.DataArray
+        reference_image : Optional[ImageStack]
             (Optional) a reference image. If provided, spots will be found in this image, and then
             the locations that correspond to these spots will be measured across each channel.
         n_processes : Optional[int] = None,

--- a/starfish/core/spots/FindSpots/local_max_peak_finder.py
+++ b/starfish/core/spots/FindSpots/local_max_peak_finder.py
@@ -1,9 +1,8 @@
 from functools import partial
-from typing import Any, List, Mapping, Optional, Tuple, Union
+from typing import Any, List, Mapping, Optional, Tuple
 
 import numpy as np
 import pandas as pd
-import xarray as xr
 from scipy.ndimage import label
 from skimage.feature import peak_local_max
 from skimage.measure import regionprops
@@ -180,19 +179,19 @@ class LocalMaxPeakFinder(FindSpotsAlgorithm):
 
         return selected_thr
 
-    def _compute_threshold(self, img: Union[np.ndarray, xr.DataArray]
-                           ) -> Tuple[float, Optional[np.ndarray], Optional[List[int]]]:
+    def _compute_threshold(
+            self, img: np.ndarray) -> Tuple[float, Optional[np.ndarray], Optional[List[int]]]:
         """Finds spots on a number of thresholds then selects and returns the optimal threshold
 
         Parameters
         ----------
-        img: Union[np.ndarray, xr.DataArray]
+        img: np.ndarray
             data array in which spots should be detected and over which to compute different
             intensity thresholds
 
         Returns
         -------
-        Union[np.ndarray, xr.DataArray] :
+        np.ndarray :
             The intensity threshold
         """
         img = np.asarray(img)
@@ -202,13 +201,14 @@ class LocalMaxPeakFinder(FindSpotsAlgorithm):
             return img.min(), None, None
         return self._select_optimal_threshold(thresholds, spot_counts), thresholds, spot_counts
 
-    def image_to_spots(self, data_image: Union[np.ndarray, xr.DataArray]
-                       ) -> PerImageSliceSpotResults:
+    def image_to_spots(
+            self, data_image: np.ndarray
+    ) -> PerImageSliceSpotResults:
         """measure attributes of spots detected by binarizing the image using the selected threshold
 
         Parameters
         ----------
-        data_image : Union[np.ndarray, xr.DataArray]
+        data_image : np.ndarray
             image containing spots to be detected
 
         Returns
@@ -285,7 +285,7 @@ class LocalMaxPeakFinder(FindSpotsAlgorithm):
         ----------
         image_stack : ImageStack
             ImageStack where we find the spots in.
-        reference_image : xr.DataArray
+        reference_image : Optional[ImageStack]
             (Optional) a reference image. If provided, spots will be found in this image, and then
             the locations that correspond to these spots will be measured across each channel.
         n_processes : Optional[int] = None,

--- a/starfish/core/spots/FindSpots/spot_finding_utils.py
+++ b/starfish/core/spots/FindSpots/spot_finding_utils.py
@@ -1,9 +1,8 @@
 from itertools import product
-from typing import Callable, Union
+from typing import Callable
 
 import numpy as np
 import pandas as pd
-import xarray as xr
 
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import (
@@ -17,20 +16,20 @@ from starfish.core.types import (
 
 
 def measure_intensities_at_spot_locations_in_image(
-        image: Union[np.ndarray, xr.DataArray],
+        image: np.ndarray,
         spots: SpotAttributes,
-        measurement_function: Callable[[Union[np.ndarray, xr.DataArray]], Number],
+        measurement_function: Callable[[np.ndarray], Number],
         radius_is_gyration: bool = False,
 ) -> pd.Series:
     """measure the intensity of each spot in spots in the corresponding image
 
     Parameters
     ----------
-    image : Union[np.ndarray, xr.DataArray],
+    image : np.ndarray,
         3-d volume in which to measure intensities
     spots : pd.DataFrame
         SpotAttributes table containing coordinates and radii of spots
-    measurement_function : Callable[[Sequence], Number])
+    measurement_function : Callable[[np.ndarray], Number])
         Function to apply over the spot volumes to identify the intensity (e.g. max, mean, ...)
     radius_is_gyration : bool
         if True, indicates that the radius corresponds to radius of gyration, which is a
@@ -66,7 +65,7 @@ def measure_intensities_at_spot_locations_in_image(
 def measure_intensities_at_spot_locations_across_imagestack(
         data_image: ImageStack,
         reference_spots: PerImageSliceSpotResults,
-        measurement_function: Callable[[Union[np.ndarray, xr.DataArray]], Number],
+        measurement_function: Callable[[np.ndarray], Number],
         radius_is_gyration: bool = False) -> SpotFindingResults:
     """given spots found from a reference image, find those spots across a data_image
 
@@ -76,7 +75,7 @@ def measure_intensities_at_spot_locations_across_imagestack(
         ImageStack containing multiple volumes for which spots' intensities must be calculated
     reference_spots : PerImageSliceSpotResults
         Spots found in a reference image
-    measurement_function : Callable[[Sequence], Number])
+    measurement_function : Callable[[np.ndarray], Number])
         Function to apply over the spot volumes to identify the intensity (e.g. max, mean, ...)
     radius_is_gyration : bool
         if True, indicates that the radius corresponds to radius of gyration, which is

--- a/starfish/core/spots/FindSpots/trackpy_local_max_peak_finder.py
+++ b/starfish/core/spots/FindSpots/trackpy_local_max_peak_finder.py
@@ -1,9 +1,8 @@
 import warnings
 from functools import partial
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple
 
 import numpy as np
-import xarray as xr
 from trackpy import locate
 
 from starfish.core.image.Filter.util import determine_axes_to_group_by
@@ -92,8 +91,9 @@ class TrackpyLocalMaxPeakFinder(FindSpotsAlgorithm):
         self.verbose = verbose
         self.radius_is_gyration = radius_is_gyration
 
-    def image_to_spots(self, data_image: Union[np.ndarray, xr.DataArray]
-                       ) -> PerImageSliceSpotResults:
+    def image_to_spots(
+            self, data_image: np.ndarray,
+    ) -> PerImageSliceSpotResults:
         """
 
         Parameters
@@ -158,7 +158,7 @@ class TrackpyLocalMaxPeakFinder(FindSpotsAlgorithm):
         ----------
         image_stack : ImageStack
             ImageStack where we find the spots in.
-        reference_image : xr.DataArray
+        reference_image : Optional[ImageStack]
             (Optional) a reference image. If provided, spots will be found in this image, and then
             the locations that correspond to these spots will be measured across each channel.
         n_processes : Optional[int] = None,

--- a/starfish/core/types/__init__.py
+++ b/starfish/core/types/__init__.py
@@ -25,8 +25,10 @@ from ._spot_finding_results import PerImageSliceSpotResults, SpotFindingResults
 Number = Union[int, float]
 CoordinateValue = Union[Number, Tuple[Number, Number]]
 
+NPArrayLike = TypeVar("NPArrayLike", np.ndarray, xr.DataArray)
+
 ArrayLikeTypes = TypeVar("ArrayLikeTypes", int, Number)
-ArrayLike = Union[np.ndarray, xr.DataArray, Sequence[ArrayLikeTypes]]
+ArrayLike = Union[xr.DataArray, np.ndarray, Sequence[ArrayLikeTypes]]
 """ArrayLike is a parameterizable custom type that includes np.ndarrays, xr.DataArrays, and
 Sequences of typed values.  Once the scipy stack supports typed arrays
 (https://github.com/numpy/numpy/issues/7370), we can extend that to the array types."""


### PR DESCRIPTION
Most places either expect a numpy array or an xarray.  Remove the Union where it's not necessary.

Fixes #1564
Test plan: travis