### PR TITLE
Linear image leveling

### DIFF
--- a/starfish/core/image/Filter/element_wise_mult.py
+++ b/starfish/core/image/Filter/element_wise_mult.py
@@ -6,7 +6,7 @@ import xarray as xr
 
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Clip
-from starfish.core.util.dtype import preserve_float_range
+from starfish.core.util.levels import preserve_float_range
 from ._base import FilterAlgorithm
 
 

--- a/starfish/core/image/Filter/gaussian_high_pass.py
+++ b/starfish/core/image/Filter/gaussian_high_pass.py
@@ -6,7 +6,7 @@ import xarray as xr
 from starfish.core.image.Filter.gaussian_low_pass import GaussianLowPass
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Clip, Number
-from starfish.core.util.dtype import preserve_float_range
+from starfish.core.util.levels import preserve_float_range
 from ._base import FilterAlgorithm
 from .util import (
     determine_axes_to_group_by,

--- a/starfish/core/image/Filter/gaussian_low_pass.py
+++ b/starfish/core/image/Filter/gaussian_low_pass.py
@@ -6,7 +6,7 @@ from skimage.filters import gaussian
 
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Clip, Number
-from starfish.core.util.dtype import preserve_float_range
+from starfish.core.util.levels import preserve_float_range
 from ._base import FilterAlgorithm
 from .util import (
     determine_axes_to_group_by,

--- a/starfish/core/image/Filter/mean_high_pass.py
+++ b/starfish/core/image/Filter/mean_high_pass.py
@@ -7,7 +7,7 @@ from scipy.ndimage.filters import uniform_filter
 
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Clip, Number
-from starfish.core.util.dtype import preserve_float_range
+from starfish.core.util.levels import preserve_float_range
 from ._base import FilterAlgorithm
 from .util import (
     determine_axes_to_group_by, validate_and_broadcast_kernel_size

--- a/starfish/core/image/Filter/reduce.py
+++ b/starfish/core/image/Filter/reduce.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import ArrayLike, Axes, Clip, Coordinates, FunctionSource, Number
-from starfish.core.util.dtype import preserve_float_range
+from starfish.core.util.levels import preserve_float_range
 from ._base import FilterAlgorithm
 
 

--- a/starfish/core/imagestack/imagestack.py
+++ b/starfish/core/imagestack/imagestack.py
@@ -56,7 +56,7 @@ from starfish.core.types import (
     Number,
     STARFISH_EXTRAS_KEY
 )
-from starfish.core.util.dtype import preserve_float_range
+from starfish.core.util.levels import preserve_float_range
 from starfish.core.util.logging import Log
 from .dataorder import AXES_DATA, N_AXES
 

--- a/starfish/core/intensity_table/intensity_table.py
+++ b/starfish/core/intensity_table/intensity_table.py
@@ -15,7 +15,7 @@ from starfish.core.types import (
     SpotAttributes,
     STARFISH_EXTRAS_KEY
 )
-from starfish.core.util.dtype import preserve_float_range
+from starfish.core.util.levels import preserve_float_range
 from .overlap import (
     find_overlaps_of_xarrays,
     OVERLAP_STRATEGY_MAP,

--- a/starfish/core/types/__init__.py
+++ b/starfish/core/types/__init__.py
@@ -9,6 +9,7 @@ from ._constants import (
     Coordinates,
     CORE_DEPENDENCIES,
     Features,
+    Levels,
     LOG,
     OverlapStrategy,
     PHYSICAL_COORDINATE_DIMENSION,

--- a/starfish/core/types/_constants.py
+++ b/starfish/core/types/_constants.py
@@ -98,6 +98,30 @@ class Clip(AugmentedEnum):
     SCALE_BY_CHUNK = 'scale_by_chunk'
 
 
+class Levels(AugmentedEnum):
+    """
+    Contains options that determine how to determine the peak value of the output of a filter.
+    """
+    CLIP = "clip"
+    """Clips all values above 1 back to 1."""
+    SCALE_SATURATED_BY_IMAGE = 'scale_saturated_by_image'
+    """If peak intensity of the entire image is saturated (i.e., > 1), rescale the intensity of the
+    entire image by the peak intensity.  If peak intensity of the entire image is not saturated
+    (i.e., <= 1), do not rescale.  This is functionally equivalent to Clip.SCALE_BY_IMAGE."""
+    SCALE_SATURATED_BY_CHUNK = 'scale_saturated_by_chunk'
+    """If the peak intensity of an image chunk is saturated (i.e., > 1), rescale the intensity of
+    the chunk by the peak intensity.  If peak intensity of an image chunk is not saturated
+    (i.e., <= 1), do not rescale.  This is functionally equivalent to Clip.SCALE_BY_CHUNK."""
+    SCALE_BY_IMAGE = 'scale_by_image'
+    """Rescale the intensity of the entire image by the peak intensity.  Note that if the peak
+    intensity of the entire image is not saturated, this behaves differently than
+    Clip.SCALE_BY_IMAGE."""
+    SCALE_BY_CHUNK = 'scale_by_chunk'
+    """Rescale the intensity of an image chunk by the peak intensity.  Note that if the peak
+    intensity of an image chunk is not saturated, this behaves differently than
+    Clip.SCALE_BY_IMAGE."""
+
+
 class TransformType(AugmentedEnum):
     """
     currently supported transform types

--- a/starfish/core/util/levels.py
+++ b/starfish/core/util/levels.py
@@ -5,6 +5,7 @@ import xarray as xr
 
 
 PreserveFloatRangeType = TypeVar("PreserveFloatRangeType", xr.DataArray, np.ndarray)
+LevelsType = TypeVar("LevelsType", xr.DataArray, np.ndarray)
 
 
 def preserve_float_range(
@@ -15,7 +16,7 @@ def preserve_float_range(
     """
     Clips values below zero to zero. If values above one are detected, clips them
     to 1 unless `rescale` is True, in which case the input is scaled by
-    the max value and the dynamic range is preserved.
+    the max value and the linearity of the dynamic range is preserved.
 
     Input arrays may be modified by this operation if `preserve_input` is False.  There is no
     guarantee that the input array is returned even if `preserve_input` is True, however.
@@ -39,6 +40,48 @@ def preserve_float_range(
         Array whose values are in the interval [0, 1].
 
     """
+    return levels(array, rescale=False, rescale_saturated=rescale, preserve_input=preserve_input)
+
+
+def levels(
+        array: LevelsType,
+        rescale: bool = False,
+        rescale_saturated: bool = False,
+        preserve_input: bool = False,
+) -> LevelsType:
+    """
+    Clips values below zero to zero.  If values above one are detected, clip them to 1 if both
+    ``rescale`` and ``rescale_saturated`` are False.  If ``rescale`` is True, then the input is
+    rescaled by the peak intensity.  If ``rescale_saturated`` is True, then the image is rescaled
+    by the peak intensity provided the peak intensity is saturated.  It is illegal for both
+    ``rescale`` and ``rescale_saturated`` to be True.
+
+    Input arrays may be modified by this operation if `preserve_input` is False.  There is no
+    guarantee that the input array is returned even if `preserve_input` is True, however.
+
+    Parameters
+    ----------
+    array : Union[xr.DataArray, np.ndarray]
+        Array whose values should be in the interval [0, 1] but may not be.
+    rescale : bool
+        If true, scale values by the max.
+    rescale_saturated : bool
+        If true, scale values by the max if the max is saturated (i.e., >= 1).
+    preserve_input : bool
+        If True, ensure that we do not modify the input data.  This may either be done by making a
+        copy of the input data or ensuring that the operation does not modify the input array.
+
+        Even if `preserve_input` is True, modifications to the resulting array may modify the input
+        array.
+
+    Returns
+    -------
+    array : Union[xr.DataArray, np.ndarray]
+        Array whose values are in the interval [0, 1].
+    """
+    if rescale and rescale_saturated:
+        raise ValueError("rescale and rescale_saturated cannot both be set.")
+
     if isinstance(array, xr.DataArray):
         # do a shallow copy
         array = array.copy(deep=False)
@@ -56,13 +99,15 @@ def preserve_float_range(
         # copy.
         belowzero = np.any(data < 0)
         aboveone = np.any(data > 1)
-        if belowzero or aboveone:
+        # we could potentially skip the copy if it's just 'rescale' and the max is exactly 1.0, but
+        # that is a pretty unlikely scenario, so we assume the max is not going to be exactly 1.0.
+        if belowzero or aboveone or rescale:
             data = data.copy()
-            _preserve_float_range_in_place(data, rescale and aboveone)
+            _adjust_image_levels_in_place(data, rescale or (rescale_saturated and aboveone))
     else:
         # we don't want a copy, so we just do it in place.
         aboveone = np.any(data > 1)
-        _preserve_float_range_in_place(data, rescale and aboveone)
+        _adjust_image_levels_in_place(data, rescale or (rescale_saturated and aboveone))
 
     if isinstance(array, xr.DataArray):
         if data is not array.values:
@@ -73,14 +118,13 @@ def preserve_float_range(
     return array
 
 
-def _preserve_float_range_in_place(
+def _adjust_image_levels_in_place(
         array: np.ndarray,
         rescale: bool = False,
 ):
     """
-    Clips values below zero to zero. If values above one are detected, clips them
-    to 1 unless `rescale` is True, in which case the input is scaled by
-    the max value and the dynamic range is preserved.
+    Clips values below zero to zero.  If rescale is True, the input is scaled by the max value and
+    the linearity of the dynamic range is preserved.
 
     Parameters
     ----------

--- a/starfish/core/util/test/test_levels.py
+++ b/starfish/core/util/test/test_levels.py
@@ -1,0 +1,174 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from ..levels import levels
+
+
+def combos(make_xarrays: bool):
+    test_parameters = (
+        # none of these will change the data
+        (
+            np.asarray((0.0, 0.0, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 1.0), dtype=np.float32),
+        ),
+
+        # different dtype.
+        (
+            np.asarray((0.0, 0.0, 1.0), dtype=np.float64),
+            np.asarray((0.0, 0.0, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 1.0), dtype=np.float32),
+        ),
+
+        # some below zero stuff
+        (
+            np.asarray((-1.0, 0.0, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 1.0), dtype=np.float32),
+        ),
+
+        # some above one stuff
+        (
+            np.asarray((0.0, 1.0, 2.0), dtype=np.float32),
+            np.asarray((0.0, 1.0, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.5, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.5, 1.0), dtype=np.float32),
+        ),
+
+        # peak below one
+        (
+            np.asarray((0.0, 0.25, 0.5), dtype=np.float32),
+            np.asarray((0.0, 0.25, 0.5), dtype=np.float32),
+            np.asarray((0.0, 0.5, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.25, 0.5), dtype=np.float32),
+        ),
+
+        # both below zero and above one stuff
+        (
+            np.asarray((-1.0, 0.0, 1.0, 2.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 1.0, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 0.5, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 0.5, 1.0), dtype=np.float32),
+        ),
+
+        # both below zero and above one stuff, different dtype
+        (
+            np.asarray((-1.0, 0.0, 1.0, 2.0), dtype=np.float64),
+            np.asarray((0.0, 0.0, 1.0, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 0.5, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 0.5, 1.0), dtype=np.float32),
+        ),
+
+        # both below zero and above one stuff
+        (
+            np.asarray((-1, 0, 1, 2), dtype=np.int16),
+            np.asarray((0.0, 0.0, 1.0, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 0.5, 1.0), dtype=np.float32),
+            np.asarray((0.0, 0.0, 0.5, 1.0), dtype=np.float32),
+        ),
+    )
+
+    if make_xarrays:
+        return (
+            (xr.DataArray(source),
+             xr.DataArray(expected_clip_output),
+             xr.DataArray(expected_rescale_output),
+             xr.DataArray(expected_rescale_saturated_output))
+            for (source,
+                 expected_clip_output,
+                 expected_rescale_output,
+                 expected_rescale_saturated_output) in test_parameters
+        )
+    else:
+        return test_parameters
+
+
+@pytest.mark.parametrize(
+    ("_source",
+     "expected_clip_output",
+     "expected_rescale_output",
+     "expected_rescale_saturated_output",
+     ),
+    combos(True)
+)
+def test_levels_xarray(
+        _source: xr.DataArray,
+        expected_clip_output: xr.DataArray,
+        expected_rescale_output: xr.DataArray,
+        expected_rescale_saturated_output: xr.DataArray,
+):
+    def run(
+            source: xr.DataArray,
+            expected_output: xr.DataArray,
+            rescale: bool,
+            rescale_saturated: bool,
+    ):
+        original_data = source.copy(deep=True)
+
+        # compute while trying to preserve the input.  if there is no change to the data, we should
+        # come back with the same block of memory.
+        output_preserve_input = levels(
+            source, rescale=rescale, rescale_saturated=rescale_saturated, preserve_input=True)
+        assert expected_output.equals(output_preserve_input)
+        assert original_data.equals(source)
+        if source.dtype == np.float32 and expected_output.equals(source) and not rescale:
+            assert output_preserve_input.values is source.values
+
+        # compute it while trying to save memory.
+        output_stingy_memory = levels(
+            source, rescale=rescale, rescale_saturated=rescale_saturated, preserve_input=False)
+        assert expected_output.equals(output_stingy_memory)
+        if source.dtype == np.float32:
+            assert output_stingy_memory.values is source.values
+
+    run(_source.copy(deep=True), expected_clip_output, False, False)
+    run(_source.copy(deep=True), expected_rescale_output, True, False)
+    run(_source.copy(deep=True), expected_rescale_saturated_output, False, True)
+
+
+@pytest.mark.parametrize(
+    ("_source",
+     "expected_clip_output",
+     "expected_rescale_output",
+     "expected_rescale_saturated_output",
+     ),
+    combos(False)
+)
+def test_levels_ndarray(
+        _source: np.ndarray,
+        expected_clip_output: np.ndarray,
+        expected_rescale_output: np.ndarray,
+        expected_rescale_saturated_output: np.ndarray,
+):
+    def run(
+            source: np.ndarray,
+            expected_output: np.ndarray,
+            rescale: bool,
+            rescale_saturated: bool,
+    ):
+        original_data = source.copy()
+
+        # compute while trying to preserve the input.  if there is no change to the data, we should
+        # come back with the same block of memory.
+        output_preserve_input = levels(
+            source, rescale=rescale, rescale_saturated=rescale_saturated, preserve_input=True)
+        assert np.all(np.equal(expected_output, output_preserve_input))
+        assert np.all(np.equal(original_data, source))
+        if source.dtype == np.float32 and np.all(np.equal(expected_output, source)) and not rescale:
+            # no change
+            assert output_preserve_input is source
+
+        # compute it while trying to save memory.
+        output_stingy_memory = levels(
+            source, rescale=rescale, rescale_saturated=rescale_saturated, preserve_input=False)
+        assert np.all(np.equal(expected_output, output_stingy_memory))
+        if source.dtype == np.float32:
+            assert output_stingy_memory is source
+
+    run(_source.copy(), expected_clip_output, False, False)
+    run(_source.copy(), expected_rescale_output, True, False)
+    run(_source.copy(), expected_rescale_saturated_output, False, True)

--- a/starfish/core/util/test/test_preserve_float_range.py
+++ b/starfish/core/util/test/test_preserve_float_range.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from ..dtype import preserve_float_range
+from ..levels import preserve_float_range
 
 
 def combos(make_xarrays: bool):
@@ -42,7 +42,7 @@ def combos(make_xarrays: bool):
             np.asarray((0.0, 0.0, 0.5, 1.0), dtype=np.float32),
         ),
 
-        # both below zero and above one stuff
+        # both below zero and above one stuff, different dtype
         (
             np.asarray((-1.0, 0.0, 1.0, 2.0), dtype=np.float64),
             np.asarray((0.0, 0.0, 1.0, 1.0), dtype=np.float32),

--- a/starfish/types.py
+++ b/starfish/types.py
@@ -8,6 +8,7 @@ from starfish.core.types import (  # noqa: F401
     CORE_DEPENDENCIES,
     Features,
     FunctionSource,
+    Levels,
     LOG,
     Number,
     OverlapStrategy,


### PR DESCRIPTION
Clip is nice and useful, but doesn't allow for the expansion of dynamic range when the peak intensity is less than fully saturated.

This PR adds linear image leveling.  Five modes are offered:

1. Clip supersaturated values.
2. Scale by the peak intensity of the entire image if any part of the image is supersaturated.
3. Scale by the peak intensity of each image chunk if any part of the image chunk is supersaturated.
4. Scale by the peak intensity of the entire image.
5. Scale by the peak intensity of each image chunk.

1-3 matches the existing modes of Clip, so we reimplement Clip using the new linear image leveler.

Test plan: Add test cases for the new image leveling approaches.  Existing Clip tests pass.