### PR TITLE
Fix stain generation in watershed

### DIFF
--- a/starfish/core/image/Segment/watershed.py
+++ b/starfish/core/image/Segment/watershed.py
@@ -11,7 +11,7 @@ from starfish.core.image.Filter import Reduce
 from starfish.core.image.Filter.util import bin_open, bin_thresh
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.morphology.binary_mask import BinaryMaskCollection
-from starfish.core.types import ArrayLike, Axes, Clip, Coordinates, Number
+from starfish.core.types import ArrayLike, Axes, Coordinates, Levels, Number
 from ._base import SegmentAlgorithm
 
 
@@ -81,7 +81,7 @@ class Watershed(SegmentAlgorithm):
         mean = Reduce(
             dims=(Axes.ROUND,),
             func="mean",
-            clip_method=Clip.SCALE_BY_IMAGE).run(mp)
+            level_method=Levels.SCALE_BY_IMAGE).run(mp)
         stain = mean._squeezed_numpy(Axes.ROUND, Axes.CH, Axes.ZPLANE)
 
         # TODO make these parameterizable or determine whether they are useful or not


### PR DESCRIPTION
#1652 replaced a block of code that scales the intensity of the image by the max, with a reduce operation that does Clip.SCALE_BY_IMAGE.  As I discovered later, Clip.SCALE_BY_IMAGE does not do what the documentation says it does, and in fact, it only scales by the max intensity if the max intensity is > 1.0.  That means it's not a refactor and actually affected the output.

Levels.SCALE_BY_IMAGE, however, does what we want here and can do what we originally had here.

Depends on #1669
Test plan: pretty much none.