### PR TITLE
Area filter for binary masks

### DIFF
--- a/starfish/core/morphology/Filter/areafilter.py
+++ b/starfish/core/morphology/Filter/areafilter.py
@@ -1,0 +1,45 @@
+from typing import MutableSequence, Optional
+
+from starfish.core.morphology.binary_mask import BinaryMaskCollection, MaskData
+from ._base import FilterAlgorithm
+
+
+class AreaFilter(FilterAlgorithm):
+    """
+    Create a BinaryMaskCollection using only the masks that meet the minimum and maximum area
+    criteria.
+
+    Parameters
+    ----------
+    min_area : Optional[int]
+        Only masks that have area larger or equal to this will be included in the output mask
+        collection.
+    max_area : Optional[int]
+        Only masks that have area smaller or equal to this will be included in the output mask
+        collection.
+    """
+
+    def __init__(self, min_area: Optional[int], max_area: Optional[int]):
+        self._min_area = min_area
+        self._max_area = max_area
+
+    def run(
+            self,
+            binary_mask_collection: BinaryMaskCollection,
+            *args, **kwargs) -> BinaryMaskCollection:
+        matching_mask_data: MutableSequence[MaskData] = list()
+        for ix in range(len(binary_mask_collection)):
+            props = binary_mask_collection.mask_regionprops(ix)
+            if self._min_area is not None and props.area < self._min_area:
+                continue
+            if self._max_area is not None and props.area > self._max_area:
+                continue
+
+            matching_mask_data.append(binary_mask_collection._masks[ix])
+
+        return BinaryMaskCollection(
+            binary_mask_collection._pixel_ticks,
+            binary_mask_collection._physical_ticks,
+            matching_mask_data,
+            binary_mask_collection._log,
+        )

--- a/starfish/core/morphology/Filter/test/test_areafilter.py
+++ b/starfish/core/morphology/Filter/test/test_areafilter.py
@@ -1,0 +1,25 @@
+from starfish.core.morphology.binary_mask.test.factories import binary_mask_collection_2d
+from ..areafilter import AreaFilter
+
+
+def test_empty_filter():
+    input_mask_collection = binary_mask_collection_2d()
+    output_mask_collection = AreaFilter(None, None).run(input_mask_collection)
+    assert len(output_mask_collection) == len(input_mask_collection)
+
+    for mask_num in range(len(input_mask_collection)):
+        input_mask = input_mask_collection.uncropped_mask(mask_num)
+        output_mask = output_mask_collection.uncropped_mask(mask_num)
+        assert input_mask.equals(output_mask)
+
+
+def test_min_area():
+    input_mask_collection = binary_mask_collection_2d()
+    output_mask_collection = AreaFilter(6, None).run(input_mask_collection)
+    assert len(output_mask_collection) == 1
+
+
+def test_max_area():
+    input_mask_collection = binary_mask_collection_2d()
+    output_mask_collection = AreaFilter(None, 5).run(input_mask_collection)
+    assert len(output_mask_collection) == 1


### PR DESCRIPTION
This filter allows us to filter a BinaryMaskCollection based on the size of the masks.

Test plan: Added some basic test cases.