### PR TITLE
Refactor watershed's label image generation using the new API

### DIFF
--- a/starfish/core/image/Segment/watershed.py
+++ b/starfish/core/image/Segment/watershed.py
@@ -1,10 +1,7 @@
 from typing import Mapping, Optional, Tuple
 
 import numpy as np
-import scipy.ndimage.measurements as spm
-from scipy.ndimage import distance_transform_edt
 from showit import image
-from skimage.feature import peak_local_max
 from skimage.morphology import disk, watershed
 
 from starfish.core.image.Filter import Reduce
@@ -13,6 +10,10 @@ from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.morphology import Filter
 from starfish.core.morphology.Binarize import ThresholdBinarize
 from starfish.core.morphology.binary_mask import BinaryMaskCollection
+from starfish.core.morphology.Filter.areafilter import AreaFilter
+from starfish.core.morphology.Filter.min_distance_label import MinDistanceLabel
+from starfish.core.morphology.Filter.structural_label import StructuralLabel
+from starfish.core.morphology.label_image import LabelImage
 from starfish.core.types import ArrayLike, Axes, Coordinates, FunctionSource, Levels, Number
 from ._base import SegmentAlgorithm
 
@@ -140,7 +141,7 @@ class _WatershedSegmenter:
         self.stain = stain_img / stain_img.max()
 
         self.nuclei_thresholded: Optional[np.ndarray] = None  # dtype: bool
-        self.markers = None
+        self.markers: Optional[LabelImage] = None
         self.num_cells: Optional[int] = None
         self.mask = None
         self.segmented = None
@@ -152,7 +153,7 @@ class _WatershedSegmenter:
             size_lim: Tuple[int, int],
             disk_size_markers: Optional[int]=None,  # TODO ambrosejcarr what is this doing?
             disk_size_mask: Optional[int]=None,  # TODO ambrosejcarr what is this doing?
-            min_dist: Optional[Number]=None
+            min_dist: Optional[int] = None
     ) -> np.ndarray:
         """Execute watershed cell segmentation.
 
@@ -178,10 +179,15 @@ class _WatershedSegmenter:
         """
         min_allowed_size, max_allowed_size = size_lim
         self.binarized_nuclei = self.filter_nuclei(nuclei_thresh, disk_size_markers)
-        self.markers, self.num_cells = self.label_nuclei(
-            self.binarized_nuclei,
-            min_allowed_size, max_allowed_size, min_dist
-        )
+        # label thresholded nuclei image
+        if min_dist is None:
+            labeled_masks = StructuralLabel().run(self.binarized_nuclei)
+        else:
+            labeled_masks = MinDistanceLabel(min_dist, 1).run(self.binarized_nuclei)
+
+        filtered_masks = AreaFilter(min_allowed_size, max_allowed_size).run(labeled_masks)
+        self.num_cells = len(filtered_masks)
+        self.markers = filtered_masks.to_label_image()
         self.mask = self.watershed_mask(stain_thresh, self.markers, disk_size_mask)
         self.segmented = self.watershed(self.markers, self.mask)
         return self.segmented
@@ -215,93 +221,12 @@ class _WatershedSegmenter:
         assert len(nuclei_binarized) == 1
         return nuclei_binarized
 
-    def label_nuclei(
-        self,
-        binarized_nuclei: BinaryMaskCollection,
-        min_allowed_size: int,
-        max_allowed_size: int,
-        min_dist: Optional[Number]=None
-    ) -> Tuple[np.ndarray, int]:
-        """Construct a labeled nuclei image, which will be combined with the point cloud to seed
-        the watershed
-
-        Parameters
-        ----------
-        binarized_nuclei : BinaryMaskCollection
-            BinaryMaskCollection with a single mask, containing the binarized nuclei image
-        min_allowed_size : int
-            minimum allowable thresholded nuclei size
-        max_allowed_size : int
-            maximum allowable nuclei size
-
-        Returns
-        -------
-        np.ndarray :
-            labeled nuclei, excluding those whose size is outside the area boundaries
-
-        """
-        binarized_nuclei_mask = binarized_nuclei.uncropped_mask(0).values.squeeze(axis=0)
-
-        # label thresholded nuclei image
-        if min_dist is None:
-            markers, num_objs = spm.label(binarized_nuclei_mask)
-        else:
-            markers, num_objs = self._unclump(min_dist)
-
-        # TODO dganguli: does it really make sense to assume a square area?
-        min_allowed_area = min_allowed_size ** 2
-        max_allowed_area = max_allowed_size ** 2
-
-        # spm.sum sums the values of an array by label. This counts the pixels in each object
-        areas = spm.sum(
-            np.ones(binarized_nuclei_mask.shape),
-            markers,
-            np.array(range(0, num_objs + 1), dtype=np.int32)
-        )
-
-        # each label value is replaced by its area
-        area_image = areas[markers]
-
-        # areas are used to mask values that are outside the allowable sizes
-        markers[area_image <= min_allowed_area] = 0
-        markers[area_image >= max_allowed_area] = 0
-
-        # re-label the image with sequential integers, accounting for exclusion based on size
-        markers_reduced, num_objs = self.relabel_image(markers)
-
-        return markers_reduced, num_objs
-
-    def _unclump(self, min_dist: Number) -> Tuple[np.ndarray, int]:
-        """
-        Run watershed on the thresholded basin image, restricted to basins at least min_dist apart
-
-        Functionally, this reproduces the thresholded nuclei image with overlapping nuclei merged.
-
-        Parameters
-        ----------
-        min_dist : int
-            minimum distance between watershed basins
-
-        """
-        im: np.ndarray = self.binarized_nuclei.uncropped_mask(0).values.squeeze(axis=0)
-
-        # calculates the distance of every pixel to the nearest background (0) point
-        distance: np.ndarray = distance_transform_edt(im)  # dtype: np.float64
-
-        # boolean array marking local maxima, excluding any maxima within min_dist
-        local_maxi: np.ndarray = peak_local_max(
-            distance, labels=im, indices=False, min_distance=min_dist
-        )
-
-        # label the maxima for watershed
-        markers, num_objs = spm.label(local_maxi)
-
-        # run watershed, using the distances in the thresholded image as basins.
-        # Uses the original image as a mask, preventing any background pixels from being labeled
-        labels_ws: np.ndarray = watershed(-distance, markers, mask=im)
-        return labels_ws, num_objs
-
-    def watershed_mask(self, stain_thresh: Number, markers: np.ndarray, disk_size: Optional[int]):
+    def watershed_mask(
+            self,
+            stain_thresh: Number,
+            markers: LabelImage,
+            disk_size: Optional[int],
+    ) -> np.ndarray:
         """Create a watershed mask that is the union of the spot intensities above stain_thresh and
         a marker image generated from nuclei
 
@@ -309,8 +234,8 @@ class _WatershedSegmenter:
         ----------
         stain_thresh : Number
             threshold to apply to the stain image
-        markers : np.ndarray[bool]
-            markers for the stain_image
+        markers : LabelImage
+            markers image generated from nuclei
         disk_size : Optional[int]
             if provided, execute a morphological opening operation over the thresholded stain image
 
@@ -321,19 +246,19 @@ class _WatershedSegmenter:
 
         """
         st = self.stain >= stain_thresh
-        watershed_mask: np.ndarray = np.logical_or(st, markers > 0)  # dtype bool
+        markers_any = (markers.xarray > 0).values.squeeze(axis=0)
+        watershed_mask: np.ndarray = np.logical_or(st, markers_any)  # dtype bool
         if disk_size is not None:
             watershed_mask = bin_open(watershed_mask, disk_size)
         return watershed_mask
 
-    def watershed(self, markers: np.ndarray, watershed_mask: np.ndarray) -> np.ndarray:
+    def watershed(self, markers: LabelImage, watershed_mask: np.ndarray) -> np.ndarray:
         """Run watershed on the thresholded primary_images max projection
 
         Parameters
         ----------
-        markers : np.ndarray[np.int64]
-            an array marking the basins with the values to be assigned in the label matrix.
-            Zero means not a marker.
+        markers : LabelImage
+            markers image generated from nuclei
         watershed_mask : np.ndarray[bool]
             Mask array. only points at which mask == True will be labeled in the output.
 
@@ -345,34 +270,12 @@ class _WatershedSegmenter:
         img = 1 - self.stain
 
         res = watershed(image=img,
-                        markers=markers,
+                        markers=markers.xarray.values.squeeze(axis=0),
                         connectivity=np.ones((3, 3), bool),
                         mask=watershed_mask
                         )
 
         return res
-
-    @staticmethod
-    def relabel_image(image: np.ndarray) -> np.ndarray:
-        """given a label image where some objects have been removed, relabel it with sequential integers
-
-        Parameters
-        ----------
-        image : np.ndarray[np.uint32]
-            image whose values identify which object each pixel corresponds to. the values may
-            not be sequential integers.
-
-        Returns
-        -------
-        image : np.ndarray[np.uint32]
-            same as input, but the values are re-labled as sequential integers
-        num_labels : int
-            number of unique objects
-        """
-        output = np.empty_like(image)
-        for i, v in enumerate(np.unique(image)):
-            output[np.where(image == v)] = i
-        return output, i
 
     def show(self, figsize=(10, 10)):
         import matplotlib.pyplot as plt
@@ -399,7 +302,11 @@ class _WatershedSegmenter:
         plt.title('Watershed Mask')
 
         plt.subplot(325)
-        image(self.markers, size=20, cmap=plt.cm.nipy_spectral, ax=plt.gca())
+        image(
+            self.markers.xarray.values.squeeze(axis=0),
+            size=20,
+            cmap=plt.cm.nipy_spectral,
+            ax=plt.gca())
         plt.title('Found: {} cells'.format(self.num_cells))
 
         plt.subplot(326)

--- a/starfish/test/full_pipelines/api/test_iss_api.py
+++ b/starfish/test/full_pipelines/api/test_iss_api.py
@@ -108,7 +108,7 @@ def test_iss_pipeline_cropped_data(tmpdir):
     seg = iss.seg
 
     # segmentation identifies only one cell
-    assert seg._segmentation_instance.num_cells == 1
+    assert seg._segmentation_instance.num_cells == 6
 
     # assign targets
     lab = AssignTargets.Label()
@@ -139,4 +139,4 @@ def test_iss_pipeline_cropped_data(tmpdir):
     assert pipeline_log[3]['method'] == 'PerRoundMaxChannel'
 
     # 28 of the spots are assigned to cell 0 (although most spots do not decode!)
-    assert np.sum(assigned['cell_id'] == '0') == 28
+    assert np.sum(assigned['cell_id'] == '1') == 28


### PR DESCRIPTION
Uses the labeling algorithms provided by #1680 and the area filter from #1673 to implement labeling.

Depends on #1671, #1673, #1680
Test plan: ISS notebook yields 96 cells.  The previous implementation did not support 3D and flattened everything along the Z axis.  Processing in 3D exposed issues in `peak_local_max`.  If we use the footprint + exclude borders approach, there is an off-by-one error in trimming the Z axis, resulting in completely blank images and no peaks.  Therefore, we have to exclude the borders.  Because of that, we detect more cells.