### PR TITLE
Refactor watershed's label image generation using the new API

### DIFF
--- a/starfish/test/full_pipelines/api/test_iss_api.py
+++ b/starfish/test/full_pipelines/api/test_iss_api.py
@@ -108,7 +108,7 @@ def test_iss_pipeline_cropped_data(tmpdir):
     seg = iss.seg
 
     # segmentation identifies only one cell
-    assert seg._segmentation_instance.num_cells == 1
+    assert seg._segmentation_instance.num_cells == 6
 
     # assign targets
     lab = AssignTargets.Label()
@@ -139,4 +139,4 @@ def test_iss_pipeline_cropped_data(tmpdir):
     assert pipeline_log[3]['method'] == 'PerRoundMaxChannel'
 
     # 28 of the spots are assigned to cell 0 (although most spots do not decode!)
-    assert np.sum(assigned['cell_id'] == '0') == 28
+    assert np.sum(assigned['cell_id'] == '1') == 28


### PR DESCRIPTION
Uses the labeling algorithms provided by #1680 and the area filter from #1673 to implement labeling.

Depends on #1671, #1673, #1680
Test plan: ISS notebook yields 96 cells.  The previous implementation did not support 3D and flattened everything along the Z axis.  Processing in 3D exposed issues in `peak_local_max`.  If we use the footprint + exclude borders approach, there is an off-by-one error in trimming the Z axis, resulting in completely blank images and no peaks.  Therefore, we have to exclude the borders.  Because of that, we detect more cells.