### PR TITLE
[easy] fix deprecation warnings for indexing using a sequence

### DIFF
--- a/starfish/core/morphology/binary_mask/binary_mask.py
+++ b/starfish/core/morphology/binary_mask/binary_mask.py
@@ -354,7 +354,7 @@ class BinaryMaskCollection:
 
         masks: MutableSequence[MaskData] = list()
         for array in arrays:
-            selection_range: Sequence[slice] = BinaryMaskCollection._crop_mask(array)
+            selection_range: Tuple[slice, ...] = BinaryMaskCollection._crop_mask(array)
 
             masks.append(MaskData(
                 array[selection_range],
@@ -372,7 +372,7 @@ class BinaryMaskCollection:
         )
 
     @staticmethod
-    def _crop_mask(array: np.ndarray) -> Sequence[slice]:
+    def _crop_mask(array: np.ndarray) -> Tuple[slice, ...]:
         selection_range: MutableSequence[slice] = list()
 
         # calculate the first and last True pixel across each axis.
@@ -389,7 +389,7 @@ class BinaryMaskCollection:
             else:
                 selection_range.append(slice(non_zero_indices[0], non_zero_indices[-1] + 1))
 
-        return selection_range
+        return tuple(selection_range)
 
     @classmethod
     def from_label_array_and_ticks(

--- a/starfish/core/morphology/binary_mask/expand.py
+++ b/starfish/core/morphology/binary_mask/expand.py
@@ -33,7 +33,7 @@ def fill_from_mask(
             f"mask ({mask.ndim}) should have the same number of dimensions as the number of "
             f"offsets ({len(offsets)})")
 
-    selector: MutableSequence[slice] = []
+    _selector: MutableSequence[slice] = []
     for ix, (mask_size, result_size, axis_offset) in enumerate(
             zip(mask.shape, result_array.shape, offsets)):
         end_offset = axis_offset + mask_size
@@ -45,7 +45,8 @@ def fill_from_mask(
                 f"{ix}th dimension of mask does not fit within the result (ends at {end_offset}, "
                 f"result size is {result_size}")
 
-        selector.append(slice(axis_offset, end_offset))
+        _selector.append(slice(axis_offset, end_offset))
+    selector: Tuple[slice, ...] = tuple(_selector)
 
     fill_value_array = result_array[selector]
     fill_value_array[mask] = fill_value


### PR DESCRIPTION
xarray prefers to be indexed with a tuple of selectors rather than a sequence.  Update the API to generate tuples and use them instead.

Test plan: Saw fewer deprecation warnings in the test console.