### PR TITLE
Fix docs build

### DIFF
--- a/docs/source/api/data_structures/binary_mask.rst
+++ b/docs/source/api/data_structures/binary_mask.rst
@@ -1,0 +1,7 @@
+.. _binary_mask:
+
+BinaryMaskCollection
+====================
+
+.. autoclass:: starfish.morphology.BinaryMaskCollection
+   :members:

--- a/docs/source/api/data_structures/index.rst
+++ b/docs/source/api/data_structures/index.rst
@@ -59,3 +59,9 @@ serialization for use in single-cell analysis environments such as Seurat_ and S
 
 .. toctree::
    decoded_intensity_table.rst
+
+.. toctree::
+   binary_mask.rst
+
+.. toctree::
+   label_image.rst

--- a/docs/source/api/data_structures/label_image.rst
+++ b/docs/source/api/data_structures/label_image.rst
@@ -1,0 +1,7 @@
+.. _label_image:
+
+LabelImage
+==========
+
+.. autoclass:: starfish.morphology.LabelImage
+   :members:

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -19,6 +19,9 @@ API
    spots/index.rst
 
 .. toctree::
+   morphology/index.rst
+
+.. toctree::
    types/index.rst
 
 .. toctree::
@@ -28,4 +31,4 @@ API
    utils/index.rst
 
 .. toctree::
-  datasets/index.rst
+   datasets/index.rst

--- a/docs/source/api/morphology/index.rst
+++ b/docs/source/api/morphology/index.rst
@@ -1,0 +1,36 @@
+.. _morphology:
+
+Morphology Transformations
+==========================
+
+starfish provides a variety of methods to perform transformations on morphological data.  These include :py:class:`~starfish.morphology.Binarize`, which transform image data into morphological data and
+:py:class:`~starfish.morphology.Filter`, which performs filtering operations on morphological data.
+
+
+.. _binarize:
+
+Binarize
+--------
+
+Binarizing operations can be imported using ``starfish.morphology.Binarize``, which registers all classes that subclass :py:class:`~starfish.morphology.Binarize.BinarizeAlgorithm`:
+
+.. code-block:: python
+
+    from starfish.morphology import Binarize
+
+.. automodule:: starfish.morphology.Binarize
+   :members:
+
+.. _morphological_filter:
+
+Filter
+------
+
+Filtering operations can be imported using ``starfish.morphology.Filter``, which registers all classes that subclass :py:class:`~starfish.morphology.Filter.FilterAlgorithm`:
+
+.. code-block:: python
+
+    from starfish.morphology import Filter
+
+.. automodule:: starfish.morphology.Filter
+   :members:

--- a/docs/source/api/types/index.rst
+++ b/docs/source/api/types/index.rst
@@ -62,9 +62,17 @@ detected spots.
     :members:
 
 Clip
-_____
+----
 
-.. autoclass:: starfish.core.types.Clip
+Clip is deprecated in favor of :py:class:`~starfish.types.Levels`.
+
+.. autoclass:: starfish.types.Clip
     :members:
     :undoc-members:
 
+Levels
+------
+
+.. autoclass:: starfish.types.Levels
+    :members:
+    :undoc-members:

--- a/starfish/core/morphology/binary_mask/binary_mask.py
+++ b/starfish/core/morphology/binary_mask/binary_mask.py
@@ -48,8 +48,7 @@ class BinaryMaskCollection:
     ----------
     pixel_ticks : Union[Mapping[Axes, ArrayLike[int]], Mapping[str, ArrayLike[int]]]
         A map from the axis to the values for that axis.
-    physical_ticks : Union[Mapping[Coordinates, ArrayLike[Number]],
-                                   Mapping[str, ArrayLike[Number]]
+    physical_ticks : Union[Mapping[Coordinates, ArrayLike[Number]], Mapping[str, ArrayLike[Number]]
         A map from the physical coordinate type to the values for axis.  For 2D label images,
         X and Y physical coordinates must be provided.  For 3D label images, Z physical
         coordinates must also be provided.
@@ -280,8 +279,7 @@ class BinaryMaskCollection:
         the smallest size that contains the non-zero values, but pixel and physical coordinates
         ticks are retained.  Masks extracted from BinaryMaskCollections will be cropped.  To extract
         masks sized to the original label image, use
-        :py:meth:`starfish.BinaryMaskCollection.uncropped_mask`.
-
+        :py:meth:`starfish.morphology.BinaryMaskCollection.uncropped_mask`.
 
         Parameters
         ----------
@@ -289,13 +287,12 @@ class BinaryMaskCollection:
             A set of 2D or 3D binary arrays.  The ordering of the axes must be Y, X for 2D images
             and ZPLANE, Y, X for 3D images.  The arrays must have identical sizes and match the
             sizes of pixel_ticks and physical_ticks.
-        pixel_ticks : Optional[Union[Mapping[Axes, ArrayLike[int]],
-                                     Mapping[str, ArrayLike[int]]]]
+        pixel_ticks : Optional[Union[Mapping[Axes, ArrayLike[int]], Mapping[str, ArrayLike[int]]]]
             A map from the axis to the values for that axis.  For any axis that exist in the array
             but not in pixel_ticks, the pixel coordinates are assigned from 0..N-1, where N is
             the size along that axis.
-        physical_ticks : Union[Mapping[Coordinates, ArrayLike[Number]],
-                               Mapping[str, ArrayLike[Number]]]
+        physical_ticks : Union[Mapping[Coordinates, ArrayLike[Number]], Mapping[str,
+        ArrayLike[Number]]]
             A map from the physical coordinate type to the values for axis.  For 2D label images,
             X and Y physical coordinates must be provided.  For 3D label images, Z physical
             coordinates must also be provided.
@@ -408,20 +405,19 @@ class BinaryMaskCollection:
         the smallest size that contains the non-zero values, but pixel and physical coordinates
         ticks are retained.  Masks extracted from BinaryMaskCollections will be cropped.  To extract
         masks sized to the original label image, use
-        :py:meth:`starfish.BinaryMaskCollection.uncropped_mask`.
+        :py:meth:`starfish.morphology.BinaryMaskCollection.uncropped_mask`.
 
         Parameters
         ----------
         array : np.ndarray
             A 2D or 3D array containing the labels.  The ordering of the axes must be Y, X for 2D
             images and ZPLANE, Y, X for 3D images.
-        pixel_ticks : Optional[Union[Mapping[Axes, ArrayLike[int]],
-                                     Mapping[str, ArrayLike[int]]]]
+        pixel_ticks : Optional[Union[Mapping[Axes, ArrayLike[int]], Mapping[str, ArrayLike[int]]]]
             A map from the axis to the values for that axis.  For any axis that exist in the array
             but not in pixel_ticks, the pixel coordinates are assigned from 0..N-1, where N is
             the size along that axis.
-        physical_ticks : Union[Mapping[Coordinates, ArrayLike[Number]],
-                               Mapping[str, ArrayLike[Number]]]
+        physical_ticks : Union[Mapping[Coordinates, ArrayLike[Number]], Mapping[str,
+        ArrayLike[Number]]]
             A map from the physical coordinate type to the values for axis.  For 2D label images,
             X and Y physical coordinates must be provided.  For 3D label images, Z physical
             coordinates must also be provided.

--- a/starfish/core/morphology/label_image/label_image.py
+++ b/starfish/core/morphology/label_image/label_image.py
@@ -72,13 +72,12 @@ class LabelImage:
         array : np.ndarray
             A 2D or 3D array containing the labels.  The ordering of the axes must be Y, X for 2D
             images and ZPLANE, Y, X for 3D images.
-        pixel_ticks : Optional[Union[Mapping[Axes, ArrayLike[int]],
-                                     Mapping[str, ArrayLike[int]]]]
+        pixel_ticks : Optional[Union[Mapping[Axes, ArrayLike[int]], Mapping[str, ArrayLike[int]]]]
             A map from the axis to the values for that axis.  For any axis that exist in the array
             but not in pixel_coordinates, the pixel coordinates are assigned from 0..N-1, where N is
             the size along that axis.
-        physical_ticks : Union[Mapping[Coordinates, ArrayLike[Number]],
-                               Mapping[str, ArrayLike[Number]]]
+        physical_ticks : Union[Mapping[Coordinates, ArrayLike[Number]], Mapping[str,
+        ArrayLike[Number]]]
             A map from the physical coordinate type to the values for axis.  For 2D label images,
             X and Y physical coordinates must be provided.  For 3D label images, Z physical
             coordinates must also be provided.

--- a/starfish/core/types/_constants.py
+++ b/starfish/core/types/_constants.py
@@ -120,7 +120,7 @@ class Levels(AugmentedEnum):
     SCALE_BY_CHUNK = 'scale_by_chunk'
     """Rescale the intensity of an image chunk by the peak intensity.  Note that if the peak
     intensity of an image chunk is not saturated, this behaves differently than
-    Clip.SCALE_BY_IMAGE."""
+    Clip.SCALE_BY_CHUNK."""
 
 
 class TransformType(AugmentedEnum):

--- a/starfish/morphology.py
+++ b/starfish/morphology.py
@@ -1,1 +1,6 @@
-from starfish.core.morphology import Filter  # noqa: F401
+from starfish.core.morphology import (  # noqa: F401
+    Binarize,
+    Filter,
+)
+from starfish.core.morphology.binary_mask import BinaryMaskCollection  # noqa: F401
+from starfish.core.morphology.label_image import LabelImage  # noqa: F401


### PR DESCRIPTION
- Added top-level .rst files for a bunch of packages/modules that should be autodoc'ed.
- Fixed places where things didn't generate correctly.
- Added top-level constructs to starfish.morphology
- Fixed inadvertent copy-pasta in `starfish/core/types/_constants.py`

Test plan: `make docs-html lint mypy`