### PR TITLE
[easy] Document workaround for python3.8

### DIFF
--- a/docs/source/getting_started/installation/index.rst
+++ b/docs/source/getting_started/installation/index.rst
@@ -13,6 +13,11 @@ The output should look similar to this:
    % python --version
    Python 3.6.5
 
+While starfish itself has no known issues with python 3.8, scikit-image is not fully compatible with
+python 3.8.  As such, installation of scikit-image, as part of starfish installation, may
+unexpectedly fail.  The workaround is to install numpy first before installing starfish or
+scikit-image.
+
 Using virtual environments
 --------------------------
 


### PR DESCRIPTION
I dug into it a bit more and the issue is that installing scikit-image from source requires numpy to already be installed.  Typically, scikit-image is installed from prebuilt binaries, which circumvents the issue.  However, scikit-image has not declared itself fully compatible with python3.8, and as such, is not producing prebuilt binaries.