### PR TITLE
Modernize napari tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,13 +47,26 @@ jobs:
         - make install-dev slow-test
       after_success:
         - bash <(curl -s https://codecov.io/bash)
-    - name: Install Napari & Test napari
-      if: type = push and (branch = master or branch =~ /-alltest/)
+    - name: Install Napari & Test napari (latest)
+      if: type = push and (branch = master or branch =~ /-alltest/ or branch =~ /napari/)
       dist: xenial
       before_install:
         - sudo apt-get install -y libgl1-mesa-glx libqt5x11extras5 xvfb
         - make install-dev
-        - pip install .[napari]
+        - pip install .[napari] pytest-qt
+        - export DISPLAY=:99
+        - Xvfb $DISPLAY -ac -screen 0 1024x768x24 &
+        - sleep 10
+      script:
+        - python -c "import vispy; print(vispy.sys_info())"
+        - make napari-test
+    - name: Install Napari & Test napari (pinned)
+      if: type = push and (branch = master or branch =~ /-alltest/ or branch =~ /napari/)
+      dist: xenial
+      before_install:
+        - sudo apt-get install -y libgl1-mesa-glx libqt5x11extras5 xvfb
+        - pip install -r requirements/REQUIREMENTS-NAPARI-CI.txt
+        - make install-dev
         - export DISPLAY=:99
         - Xvfb $DISPLAY -ac -screen 0 1024x768x24 &
         - sleep 10

--- a/starfish/core/test/test_display.py
+++ b/starfish/core/test/test_display.py
@@ -34,23 +34,17 @@ masks = BinaryMaskCollection.from_label_image(label_image)
 @pytest.mark.parametrize('masks', [masks, None], ids=['masks', '     '])
 @pytest.mark.parametrize('spots', [spots, None], ids=['spots', '     '])
 @pytest.mark.parametrize('stack', [stack, None], ids=['stack', '     '])
-def test_display(stack, spots, masks):
-    import napari
-    from qtpy.QtCore import QTimer
-    from qtpy.QtWidgets import QApplication
+def test_display(qtbot, stack, spots, masks):
+    from napari import Viewer
 
-    def run():
-        app = QApplication.instance() or QApplication([])
-        viewer = napari.Viewer()
-        timer = QTimer()
-        timer.setInterval(1000)
-        timer.timeout.connect(app.quit)
-        timer.start()
-        display(stack, spots, masks, viewer=viewer)
-        app.exec_()
+    viewer = Viewer()
+    view = viewer.window.qt_viewer
+    qtbot.addWidget(view)
 
     if stack is None and spots is None and masks is None:
         with pytest.raises(TypeError):
-            run()
+            display(stack, spots, masks, viewer=viewer)
     else:
-        run()
+        display(stack, spots, masks, viewer=viewer)
+
+    view.shutdown()


### PR DESCRIPTION
1. Two sets of napari tests -- one against pinned dependencies and one against latest.  This way, we can understand where things break.
2. Use `pytest-qt` to run napari tests.  Use the qtbot fixture.
3. Run napari tests on branches with `napari` in the name.

Test plan: tests die at the same place as it did previously