### PR TITLE
Move napari pin back to 0.2.6 for CI purposes

### DIFF
--- a/requirements/REQUIREMENTS-NAPARI-CI.txt
+++ b/requirements/REQUIREMENTS-NAPARI-CI.txt
@@ -44,7 +44,7 @@ mistune==0.8.4
 monotonic==1.5
 more-itertools==8.0.2
 mpmath==1.1.0
-napari==0.2.7
+napari==0.2.6
 nbconvert==5.6.1
 nbformat==4.4.0
 networkx==2.4

--- a/starfish/core/test/test_display.py
+++ b/starfish/core/test/test_display.py
@@ -47,4 +47,8 @@ def test_display(qtbot, stack, spots, masks):
     else:
         display(stack, spots, masks, viewer=viewer)
 
-    view.shutdown()
+    # TODO: napari 0.2.7 adds view.shutdown, but we're using 0.2.6 for tests until
+    # https://github.com/napari/napari/pull/822 gets released.
+    view.pool.clear()
+    view.canvas.close()
+    view.console.shutdown()


### PR DESCRIPTION
This passes everything except for the starfish+"latest napari" test.