### PR TITLE
[EASY] fixes path to logo for sphinx-gallery

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -116,7 +116,7 @@ sphinx_gallery_conf = {
     # # this case sphinx_gallery and numpy in a tuple of strings.
     # 'doc_module': ('neuroglia',),
     'download_section_examples': False,
-    'default_thumb_file': 'source/_static/design/logo-solo.png',
+    'default_thumb_file': f'{dir_}/_static/design/logo-solo.png',
     'min_reported_time': 10,
 
 }


### PR DESCRIPTION
docs currently are not building on readthedocs b/c the relative path to the logo for sphinx-gallery cannot be resolved.

this PR fixes the build by calling the absolute path

test plan: build on readthedocs. https://readthedocs.org/projects/spacetx-starfish/builds/10211763/