### PR TITLE
Fix autodoc of SimpleMerge

### DIFF
--- a/starfish/core/morphology/Merge/_base.py
+++ b/starfish/core/morphology/Merge/_base.py
@@ -6,6 +6,7 @@ from starfish.core.pipeline.algorithmbase import AlgorithmBase
 
 
 class MergeAlgorithm(metaclass=AlgorithmBase):
+    """Merge multiple binary mask collections together."""
 
     @abstractmethod
     def run(
@@ -14,5 +15,4 @@ class MergeAlgorithm(metaclass=AlgorithmBase):
             *args,
             **kwargs
     ) -> BinaryMaskCollection:
-        """Merge multiple binary mask collections together."""
         raise NotImplementedError()

--- a/starfish/core/morphology/Merge/simple.py
+++ b/starfish/core/morphology/Merge/simple.py
@@ -9,14 +9,26 @@ from ._base import MergeAlgorithm
 
 
 class SimpleMerge(MergeAlgorithm):
+    """Merge multiple binary mask collections together.  This implementation requires that all
+    the binary mask collections have the same pixel and physical ticks."""
+
     def run(
             self,
             binary_mask_collections: Sequence[BinaryMaskCollection],
             *args,
             **kwargs
     ) -> BinaryMaskCollection:
-        """Merge multiple binary mask collections together.  This implementation requires that all
-        the binary mask collections have the same pixel and physical ticks."""
+        """
+        Parameters
+        ----------
+        binary_mask_collections : Sequence[BinaryMaskCollection]
+            A sequence of binary mask collections with identical pixel and physical ticks.
+
+        Returns
+        -------
+        BinaryMaskCollection
+            A binary mask collection with the input mask collections merged together.
+        """
         pixel_ticks: Optional[Mapping[Axes, ArrayLike[int]]] = None
         physical_ticks: Optional[Mapping[Coordinates, ArrayLike[Number]]] = None
 


### PR DESCRIPTION
It turns out that sphinx skips classes with documentation identical to the superclass, even if the individual methods have different documentation.  Right now, the documentation for SimpleMerge isn't being outputted.  With this PR, the documentation is generated.

Test plan: `make docs-html`