### PR TITLE
Link to the available datasets in "loading data" section

### DIFF
--- a/docs/source/getting_started/loading_data/index.rst
+++ b/docs/source/getting_started/loading_data/index.rst
@@ -140,3 +140,8 @@ will demonstrate how :py:func:`starfish.display` can be used to visually inspect
 results of spot calling.
 
 Next, see an :ref:`Example end-to-end workflow <example_workflow>` using the starfish API.
+
+Available datasets
+==================
+
+Starfish makes a small number of datasets :ref:`easily accessible<datasets>`.  To load them, import :py:mod:`starfish.data`.


### PR DESCRIPTION
The example datasets are documented in the API section.  This may make it easier to find.