### PR TITLE
Move xarray to 0.14.1

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -23,5 +23,5 @@ sympy
 tqdm
 trackpy
 validators
-xarray
+xarray >= 0.14.1
 ipywidgets


### PR DESCRIPTION
`DataArray.drop_sel` was added in 0.14.1.  The old API (removed in #1683) is being deprecated so we are want the new API.  However, that is only added in 0.14.1.

Fixes: #1726
Test plan: make -j fast