### PR TITLE
Remove starfish.types.Clip

### DIFF
--- a/docs/source/api/types/index.rst
+++ b/docs/source/api/types/index.rst
@@ -61,15 +61,6 @@ detected spots.
 .. autoclass:: starfish.core.types.SpotAttributes
     :members:
 
-Clip
-----
-
-Clip is deprecated in favor of :py:class:`~starfish.types.Levels`.
-
-.. autoclass:: starfish.types.Clip
-    :members:
-    :undoc-members:
-
 Levels
 ------
 

--- a/starfish/core/image/Filter/bandpass.py
+++ b/starfish/core/image/Filter/bandpass.py
@@ -1,11 +1,11 @@
 from functools import partial
-from typing import Optional, Union
+from typing import Optional
 
 import xarray as xr
 from trackpy import bandpass
 
-from starfish.core.imagestack.imagestack import _reconcile_clip_and_level, ImageStack
-from starfish.core.types import Clip, Levels, Number
+from starfish.core.imagestack.imagestack import ImageStack
+from starfish.core.types import Levels, Number
 from ._base import FilterAlgorithm
 from .util import determine_axes_to_group_by
 
@@ -33,19 +33,6 @@ class Bandpass(FilterAlgorithm):
         deviations (default 4)
     is_volume : bool
         If True, 3d (z, y, x) volumes will be filtered. By default, filter 2-d (y, x) planes
-    clip_method : Optional[Union[str, :py:class:`~starfish.types.Clip`]]
-        Deprecated method to control the way that data are scaled to retain skimage dtype
-        requirements that float data fall in [0, 1].  In all modes, data below 0 are set to 0.
-
-        - Clip.CLIP: data above 1 are set to 1.  This has been replaced with
-          level_method=Levels.CLIP.
-        - Clip.SCALE_BY_IMAGE: when any data in the entire ImageStack is greater than 1, the entire
-          ImageStack is scaled by the maximum value in the ImageStack.  This has been replaced with
-          level_method=Levels.SCALE_SATURATED_BY_IMAGE.
-        - Clip.SCALE_BY_CHUNK: when any data in any slice is greater than 1, each slice is scaled by
-          the maximum value found in that slice.  The slice shapes are determined by the
-          ``group_by`` parameters.  This has been replaced with
-          level_method=Levels.SCALE_SATURATED_BY_CHUNK.
     level_method : :py:class:`~starfish.types.Levels`
         Controls the way that data are scaled to retain skimage dtype requirements that float data
         fall in [0, 1].  In all modes, data below 0 are set to 0.
@@ -69,8 +56,7 @@ class Bandpass(FilterAlgorithm):
             threshold: Number = 0,
             truncate: Number = 4,
             is_volume: bool = False,
-            clip_method: Optional[Union[str, Clip]] = None,
-            level_method: Optional[Levels] = None
+            level_method: Levels = Levels.CLIP
     ) -> None:
         self.lshort = lshort
         self.llong = llong
@@ -81,7 +67,7 @@ class Bandpass(FilterAlgorithm):
         self.threshold = threshold
         self.truncate = truncate
         self.is_volume = is_volume
-        self.level_method = _reconcile_clip_and_level(clip_method, level_method)
+        self.level_method = level_method
 
     _DEFAULT_TESTING_PARAMETERS = {"lshort": 1, "llong": 3, "threshold": 0.01}
 

--- a/starfish/core/image/Filter/element_wise_mult.py
+++ b/starfish/core/image/Filter/element_wise_mult.py
@@ -1,11 +1,11 @@
 from copy import deepcopy
-from typing import Optional, Union
+from typing import Optional
 
 import numpy as np
 import xarray as xr
 
-from starfish.core.imagestack.imagestack import _reconcile_clip_and_level, ImageStack
-from starfish.core.types import Clip, Levels
+from starfish.core.imagestack.imagestack import ImageStack
+from starfish.core.types import Levels
 from starfish.core.util.levels import levels
 from ._base import FilterAlgorithm
 
@@ -17,17 +17,8 @@ class ElementWiseMultiply(FilterAlgorithm):
 
     Parameters
     ----------
-    mult_mat : xr.DataArray
+    mult_array : xr.DataArray
         the image is element-wise multiplied with this array
-    clip_method : Optional[Union[str, :py:class:`~starfish.types.Clip`]]
-        Deprecated method to control the way that data are scaled to retain skimage dtype
-        requirements that float data fall in [0, 1].  In all modes, data below 0 are set to 0.
-
-        - Clip.CLIP: data above 1 are set to 1.  This has been replaced with
-          level_method=Levels.CLIP.
-        - Clip.SCALE_BY_IMAGE: when any data in the entire ImageStack is greater than 1, the entire
-          ImageStack is scaled by the maximum value in the ImageStack.  This has been replaced with
-          level_method=Levels.SCALE_SATURATED_BY_IMAGE.
     level_method : :py:class:`~starfish.types.Levels`
         Controls the way that data are scaled to retain skimage dtype requirements that float data
         fall in [0, 1].  In all modes, data below 0 are set to 0.
@@ -42,12 +33,11 @@ class ElementWiseMultiply(FilterAlgorithm):
     def __init__(
             self,
             mult_array: xr.DataArray,
-            clip_method: Optional[Union[str, Clip]] = None,
-            level_method: Optional[Levels] = None,
+            level_method: Levels = Levels.CLIP,
     ) -> None:
 
         self.mult_array = mult_array
-        self.level_method = _reconcile_clip_and_level(clip_method, level_method)
+        self.level_method = level_method
         if self.level_method in (Levels.SCALE_BY_CHUNK, Levels.SCALE_SATURATED_BY_CHUNK):
             raise ValueError("`scale_by_chunk` is not a valid clip_method for ElementWiseMultiply")
 

--- a/starfish/core/image/Filter/gaussian_high_pass.py
+++ b/starfish/core/image/Filter/gaussian_high_pass.py
@@ -4,8 +4,8 @@ from typing import Callable, Optional, Tuple, Union
 import xarray as xr
 
 from starfish.core.image.Filter.gaussian_low_pass import GaussianLowPass
-from starfish.core.imagestack.imagestack import _reconcile_clip_and_level, ImageStack
-from starfish.core.types import Clip, Levels, Number
+from starfish.core.imagestack.imagestack import ImageStack
+from starfish.core.types import Levels, Number
 from starfish.core.util.levels import levels
 from ._base import FilterAlgorithm
 from .util import (
@@ -30,19 +30,6 @@ class GaussianHighPass(FilterAlgorithm):
     is_volume : bool
         If True, 3d (z, y, x) volumes will be filtered, otherwise, filter 2d tiles
         independently.
-    clip_method : Optional[Union[str, :py:class:`~starfish.types.Clip`]]
-        Deprecated method to control the way that data are scaled to retain skimage dtype
-        requirements that float data fall in [0, 1].  In all modes, data below 0 are set to 0.
-
-        - Clip.CLIP: data above 1 are set to 1.  This has been replaced with
-          level_method=Levels.CLIP.
-        - Clip.SCALE_BY_IMAGE: when any data in the entire ImageStack is greater than 1, the entire
-          ImageStack is scaled by the maximum value in the ImageStack.  This has been replaced with
-          level_method=Levels.SCALE_SATURATED_BY_IMAGE.
-        - Clip.SCALE_BY_CHUNK: when any data in any slice is greater than 1, each slice is scaled by
-          the maximum value found in that slice.  The slice shapes are determined by the
-          ``group_by`` parameters.  This has been replaced with
-          level_method=Levels.SCALE_SATURATED_BY_CHUNK.
     level_method : :py:class:`~starfish.types.Levels`
         Controls the way that data are scaled to retain skimage dtype requirements that float data
         fall in [0, 1].  In all modes, data below 0 are set to 0.
@@ -63,13 +50,12 @@ class GaussianHighPass(FilterAlgorithm):
             self,
             sigma: Union[Number, Tuple[Number]],
             is_volume: bool = False,
-            clip_method: Optional[Union[str, Clip]] = None,
-            level_method: Optional[Levels] = None
+            level_method: Levels = Levels.CLIP
     ) -> None:
 
         self.sigma = validate_and_broadcast_kernel_size(sigma, is_volume)
         self.is_volume = is_volume
-        self.level_method = _reconcile_clip_and_level(clip_method, level_method)
+        self.level_method = level_method
 
     _DEFAULT_TESTING_PARAMETERS = {"sigma": 3}
 

--- a/starfish/core/image/Filter/gaussian_low_pass.py
+++ b/starfish/core/image/Filter/gaussian_low_pass.py
@@ -4,8 +4,8 @@ from typing import Callable, Optional, Tuple, Union
 import xarray as xr
 from skimage.filters import gaussian
 
-from starfish.core.imagestack.imagestack import _reconcile_clip_and_level, ImageStack
-from starfish.core.types import Clip, Levels, Number
+from starfish.core.imagestack.imagestack import ImageStack
+from starfish.core.types import Levels, Number
 from ._base import FilterAlgorithm
 from .util import (
     determine_axes_to_group_by,
@@ -28,19 +28,6 @@ class GaussianLowPass(FilterAlgorithm):
     is_volume : bool
         If True, 3d (z, y, x) volumes will be filtered, otherwise, filter 2d tiles
         independently.
-    clip_method : Optional[Union[str, :py:class:`~starfish.types.Clip`]]
-        Deprecated method to control the way that data are scaled to retain skimage dtype
-        requirements that float data fall in [0, 1].  In all modes, data below 0 are set to 0.
-
-        - Clip.CLIP: data above 1 are set to 1.  This has been replaced with
-          level_method=Levels.CLIP.
-        - Clip.SCALE_BY_IMAGE: when any data in the entire ImageStack is greater than 1, the entire
-          ImageStack is scaled by the maximum value in the ImageStack.  This has been replaced with
-          level_method=Levels.SCALE_SATURATED_BY_IMAGE.
-        - Clip.SCALE_BY_CHUNK: when any data in any slice is greater than 1, each slice is scaled by
-          the maximum value found in that slice.  The slice shapes are determined by the
-          ``group_by`` parameters.  This has been replaced with
-          level_method=Levels.SCALE_SATURATED_BY_CHUNK.
     level_method : :py:class:`~starfish.types.Levels`
         Controls the way that data are scaled to retain skimage dtype requirements that float data
         fall in [0, 1].  In all modes, data below 0 are set to 0.
@@ -61,13 +48,12 @@ class GaussianLowPass(FilterAlgorithm):
             self,
             sigma: Union[Number, Tuple[Number]],
             is_volume: bool = False,
-            clip_method: Optional[Union[str, Clip]] = None,
-            level_method: Optional[Levels] = None
+            level_method: Levels = Levels.CLIP
     ) -> None:
 
         self.sigma = validate_and_broadcast_kernel_size(sigma, is_volume)
         self.is_volume = is_volume
-        self.level_method = _reconcile_clip_and_level(clip_method, level_method)
+        self.level_method = level_method
 
     _DEFAULT_TESTING_PARAMETERS = {"sigma": 1}
 

--- a/starfish/core/image/Filter/laplace.py
+++ b/starfish/core/image/Filter/laplace.py
@@ -10,8 +10,8 @@ from starfish.core.image.Filter.util import (
     determine_axes_to_group_by,
     validate_and_broadcast_kernel_size,
 )
-from starfish.core.imagestack.imagestack import _reconcile_clip_and_level, ImageStack
-from starfish.core.types import Clip, Levels, Number
+from starfish.core.imagestack.imagestack import ImageStack
+from starfish.core.types import Levels, Number
 
 
 class Laplace(FilterAlgorithm):
@@ -51,19 +51,6 @@ class Laplace(FilterAlgorithm):
         (Default 0) Value to fill past edges of input if mode is ‘constant’.
     is_volume: bool
         If True, 3d (z, y, x) volumes will be filtered. By default, filter 2-d (y, x) planes
-    clip_method : Optional[Union[str, :py:class:`~starfish.types.Clip`]]
-        Deprecated method to control the way that data are scaled to retain skimage dtype
-        requirements that float data fall in [0, 1].  In all modes, data below 0 are set to 0.
-
-        - Clip.CLIP: data above 1 are set to 1.  This has been replaced with
-          level_method=Levels.CLIP.
-        - Clip.SCALE_BY_IMAGE: when any data in the entire ImageStack is greater than 1, the entire
-          ImageStack is scaled by the maximum value in the ImageStack.  This has been replaced with
-          level_method=Levels.SCALE_SATURATED_BY_IMAGE.
-        - Clip.SCALE_BY_CHUNK: when any data in any slice is greater than 1, each slice is scaled by
-          the maximum value found in that slice.  The slice shapes are determined by the
-          ``group_by`` parameters.  This has been replaced with
-          level_method=Levels.SCALE_SATURATED_BY_CHUNK.
     level_method : :py:class:`~starfish.types.Levels`
         Controls the way that data are scaled to retain skimage dtype requirements that float data
         fall in [0, 1].  In all modes, data below 0 are set to 0.
@@ -86,15 +73,14 @@ class Laplace(FilterAlgorithm):
             mode: str = 'reflect',
             cval: float = 0.0,
             is_volume: bool = False,
-            clip_method: Optional[Union[str, Clip]] = None,
-            level_method: Optional[Levels] = None
+            level_method: Levels = Levels.CLIP
     ) -> None:
 
         self.sigma = validate_and_broadcast_kernel_size(sigma, is_volume=is_volume)
         self.mode = mode
         self.cval = cval
         self.is_volume = is_volume
-        self.level_method = _reconcile_clip_and_level(clip_method, level_method)
+        self.level_method = level_method
 
     _DEFAULT_TESTING_PARAMETERS = {"sigma": 0.5}
 

--- a/starfish/core/image/Filter/linear_unmixing.py
+++ b/starfish/core/image/Filter/linear_unmixing.py
@@ -1,11 +1,11 @@
 from functools import partial
-from typing import Optional, Union
+from typing import Optional
 
 import numpy as np
 import xarray as xr
 
-from starfish.core.imagestack.imagestack import _reconcile_clip_and_level, ImageStack
-from starfish.core.types import Axes, Clip, Levels
+from starfish.core.imagestack.imagestack import ImageStack
+from starfish.core.types import Axes, Levels
 from ._base import FilterAlgorithm
 
 
@@ -39,19 +39,6 @@ class LinearUnmixing(FilterAlgorithm):
         matrix of the linear unmixing coefficients. Should take the form: B = AX, where B are
         the unmixed values, A is coeff_mat and X are the observed values. coeff_mat has shape
         (n_ch, n_ch), and poses each channel (column) as a combination of other columns (rows).
-    clip_method : Optional[Union[str, :py:class:`~starfish.types.Clip`]]
-        Deprecated method to control the way that data are scaled to retain skimage dtype
-        requirements that float data fall in [0, 1].  In all modes, data below 0 are set to 0.
-
-        - Clip.CLIP: data above 1 are set to 1.  This has been replaced with
-          level_method=Levels.CLIP.
-        - Clip.SCALE_BY_IMAGE: when any data in the entire ImageStack is greater than 1, the entire
-          ImageStack is scaled by the maximum value in the ImageStack.  This has been replaced with
-          level_method=Levels.SCALE_SATURATED_BY_IMAGE.
-        - Clip.SCALE_BY_CHUNK: when any data in any slice is greater than 1, each slice is scaled by
-          the maximum value found in that slice.  The slice shapes are determined by the
-          ``group_by`` parameters.  This has been replaced with
-          level_method=Levels.SCALE_SATURATED_BY_CHUNK.
     level_method : :py:class:`~starfish.types.Levels`
         Controls the way that data are scaled to retain skimage dtype requirements that float data
         fall in [0, 1].  In all modes, data below 0 are set to 0.
@@ -71,11 +58,10 @@ class LinearUnmixing(FilterAlgorithm):
     def __init__(
             self,
             coeff_mat: np.ndarray,
-            clip_method: Optional[Union[str, Clip]] = None,
-            level_method: Optional[Levels] = None
+            level_method: Levels = Levels.CLIP
     ) -> None:
         self.coeff_mat = coeff_mat
-        self.level_method = _reconcile_clip_and_level(clip_method, level_method)
+        self.level_method = level_method
 
     _DEFAULT_TESTING_PARAMETERS = {"coeff_mat": np.array([[1, -0.25], [-0.25, 1]])}
 

--- a/starfish/core/image/Filter/map.py
+++ b/starfish/core/image/Filter/map.py
@@ -5,8 +5,8 @@ from typing import (
     Union
 )
 
-from starfish.core.imagestack.imagestack import _reconcile_clip_and_level, ImageStack
-from starfish.core.types import Axes, Clip, FunctionSource, FunctionSourceBundle, Levels
+from starfish.core.imagestack.imagestack import ImageStack
+from starfish.core.types import Axes, FunctionSource, FunctionSourceBundle, Levels
 from ._base import FilterAlgorithm
 
 
@@ -41,19 +41,6 @@ class Map(FilterAlgorithm):
         Axes to split the data along.  For example, splitting a 2D array (axes: X, Y; size: 3, 4)
         by X results in 3 calls to the method, each with arrays of size 4.  (default {Axes.ROUND,
         Axes.CH, Axes.ZPLANE})
-    clip_method : Optional[Union[str, :py:class:`~starfish.types.Clip`]]
-        Deprecated method to control the way that data are scaled to retain skimage dtype
-        requirements that float data fall in [0, 1].  In all modes, data below 0 are set to 0.
-
-        - Clip.CLIP: data above 1 are set to 1.  This has been replaced with
-          level_method=Levels.CLIP.
-        - Clip.SCALE_BY_IMAGE: when any data in the entire ImageStack is greater than 1, the entire
-          ImageStack is scaled by the maximum value in the ImageStack.  This has been replaced with
-          level_method=Levels.SCALE_SATURATED_BY_IMAGE.
-        - Clip.SCALE_BY_CHUNK: when any data in any slice is greater than 1, each slice is scaled by
-          the maximum value found in that slice.  The slice shapes are determined by the
-          ``group_by`` parameters.  This has been replaced with
-          level_method=Levels.SCALE_SATURATED_BY_CHUNK.
     level_method : :py:class:`~starfish.types.Levels`
         Controls the way that data are scaled to retain skimage dtype requirements that float data
         fall in [0, 1].  In all modes, data below 0 are set to 0.
@@ -92,8 +79,7 @@ class Map(FilterAlgorithm):
             module: Optional[FunctionSource] = None,
             in_place: bool = False,
             group_by: Optional[Set[Union[Axes, str]]] = None,
-            clip_method: Optional[Clip] = None,
-            level_method: Optional[Levels] = None,
+            level_method: Levels = Levels.CLIP,
             **func_kwargs,
     ) -> None:
         if isinstance(func, str):
@@ -116,7 +102,7 @@ class Map(FilterAlgorithm):
         if group_by is None:
             group_by = {Axes.ROUND, Axes.CH, Axes.ZPLANE}
         self.group_by: Set[Axes] = {Axes(axis) for axis in group_by}
-        self.level_method = _reconcile_clip_and_level(clip_method, level_method)
+        self.level_method = level_method
         self.func_args = func_args
         self.func_kwargs = func_kwargs
 

--- a/starfish/core/image/Filter/mean_high_pass.py
+++ b/starfish/core/image/Filter/mean_high_pass.py
@@ -5,8 +5,8 @@ import numpy as np
 import xarray as xr
 from scipy.ndimage.filters import uniform_filter
 
-from starfish.core.imagestack.imagestack import _reconcile_clip_and_level, ImageStack
-from starfish.core.types import Clip, Levels, Number
+from starfish.core.imagestack.imagestack import ImageStack
+from starfish.core.types import Levels, Number
 from ._base import FilterAlgorithm
 from .util import (
     determine_axes_to_group_by, validate_and_broadcast_kernel_size
@@ -32,19 +32,6 @@ class MeanHighPass(FilterAlgorithm):
     is_volume : bool
         If True, 3d (z, y, x) volumes will be filtered, otherwise, filter 2d tiles
         independently.
-    clip_method : Optional[Union[str, :py:class:`~starfish.types.Clip`]]
-        Deprecated method to control the way that data are scaled to retain skimage dtype
-        requirements that float data fall in [0, 1].  In all modes, data below 0 are set to 0.
-
-        - Clip.CLIP: data above 1 are set to 1.  This has been replaced with
-          level_method=Levels.CLIP.
-        - Clip.SCALE_BY_IMAGE: when any data in the entire ImageStack is greater than 1, the entire
-          ImageStack is scaled by the maximum value in the ImageStack.  This has been replaced with
-          level_method=Levels.SCALE_SATURATED_BY_IMAGE.
-        - Clip.SCALE_BY_CHUNK: when any data in any slice is greater than 1, each slice is scaled by
-          the maximum value found in that slice.  The slice shapes are determined by the
-          ``group_by`` parameters.  This has been replaced with
-          level_method=Levels.SCALE_SATURATED_BY_CHUNK.
     level_method : :py:class:`~starfish.types.Levels`
         Controls the way that data are scaled to retain skimage dtype requirements that float data
         fall in [0, 1].  In all modes, data below 0 are set to 0.
@@ -65,13 +52,12 @@ class MeanHighPass(FilterAlgorithm):
             self,
             size: Union[Number, Tuple[Number]],
             is_volume: bool = False,
-            clip_method: Optional[Union[str, Clip]] = None,
-            level_method: Optional[Levels] = None
+            level_method: Levels = Levels.CLIP
     ) -> None:
 
         self.size = validate_and_broadcast_kernel_size(size, is_volume)
         self.is_volume = is_volume
-        self.level_method = _reconcile_clip_and_level(clip_method, level_method)
+        self.level_method = level_method
 
     _DEFAULT_TESTING_PARAMETERS = {"size": 1}
 

--- a/starfish/core/image/Filter/reduce.py
+++ b/starfish/core/image/Filter/reduce.py
@@ -8,11 +8,10 @@ from typing import (
 
 import numpy as np
 
-from starfish.core.imagestack.imagestack import _reconcile_clip_and_level, ImageStack
+from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import (
     ArrayLike,
     Axes,
-    Clip,
     Coordinates,
     FunctionSource,
     FunctionSourceBundle,
@@ -117,8 +116,7 @@ class Reduce(FilterAlgorithm):
             dims: Iterable[Union[Axes, str]],
             func: Union[str, FunctionSourceBundle] = "max",
             module: Optional[FunctionSource] = None,
-            clip_method: Optional[Clip] = None,
-            level_method: Optional[Levels] = None,
+            level_method: Levels = Levels.CLIP,
             **kwargs
     ) -> None:
         self.dims: Iterable[Axes] = set(Axes(dim) for dim in dims)
@@ -138,7 +136,7 @@ class Reduce(FilterAlgorithm):
                     f"be set."
                 )
             self.func = func
-        self.level_method = _reconcile_clip_and_level(clip_method, level_method)
+        self.level_method = level_method
         self.kwargs = kwargs
 
     _DEFAULT_TESTING_PARAMETERS = {"dims": ['r'], "func": 'max'}

--- a/starfish/core/image/Filter/richardson_lucy_deconvolution.py
+++ b/starfish/core/image/Filter/richardson_lucy_deconvolution.py
@@ -1,12 +1,12 @@
 from functools import partial
-from typing import Optional, Union
+from typing import Optional
 
 import numpy as np
 import xarray as xr
 from scipy.signal import convolve, fftconvolve
 
-from starfish.core.imagestack.imagestack import _reconcile_clip_and_level, ImageStack
-from starfish.core.types import Clip, Levels, Number
+from starfish.core.imagestack.imagestack import ImageStack
+from starfish.core.types import Levels, Number
 from ._base import FilterAlgorithm
 from .util import (
     determine_axes_to_group_by,
@@ -89,8 +89,7 @@ class DeconvolvePSF(FilterAlgorithm):
             num_iter: int,
             sigma: Number,
             is_volume: bool = False,
-            clip_method: Optional[Union[str, Clip]] = None,
-            level_method: Optional[Levels] = None
+            level_method: Levels = Levels.CLIP,
     ) -> None:
 
         self.num_iter = num_iter
@@ -101,7 +100,7 @@ class DeconvolvePSF(FilterAlgorithm):
             sigma=sigma
         )
         self.is_volume = is_volume
-        self.level_method = _reconcile_clip_and_level(clip_method, level_method)
+        self.level_method = level_method
 
     _DEFAULT_TESTING_PARAMETERS = {"num_iter": 2, "sigma": 1}
 

--- a/starfish/core/image/Filter/white_tophat.py
+++ b/starfish/core/image/Filter/white_tophat.py
@@ -1,10 +1,10 @@
-from typing import Optional, Union
+from typing import Optional
 
 import xarray as xr
 from skimage.morphology import ball, disk, white_tophat
 
-from starfish.core.imagestack.imagestack import _reconcile_clip_and_level, ImageStack
-from starfish.core.types import Clip, Levels
+from starfish.core.imagestack.imagestack import ImageStack
+from starfish.core.types import Levels
 from ._base import FilterAlgorithm
 from .util import determine_axes_to_group_by
 
@@ -61,12 +61,11 @@ class WhiteTophat(FilterAlgorithm):
             self,
             masking_radius: int,
             is_volume: bool = False,
-            clip_method: Optional[Union[str, Clip]] = None,
-            level_method: Optional[Levels] = None
+            level_method: Levels = Levels.CLIP,
     ) -> None:
         self.masking_radius = masking_radius
         self.is_volume = is_volume
-        self.level_method = _reconcile_clip_and_level(clip_method, level_method)
+        self.level_method = level_method
 
     _DEFAULT_TESTING_PARAMETERS = {"masking_radius": 3}
 

--- a/starfish/core/types/__init__.py
+++ b/starfish/core/types/__init__.py
@@ -5,7 +5,6 @@ import xarray as xr
 
 from ._constants import (
     Axes,
-    Clip,
     Coordinates,
     CORE_DEPENDENCIES,
     Features,

--- a/starfish/types.py
+++ b/starfish/types.py
@@ -2,7 +2,6 @@
 from starfish.core.types import (  # noqa: F401
     ArrayLike,
     Axes,
-    Clip,
     Coordinates,
     CoordinateValue,
     CORE_DEPENDENCIES,


### PR DESCRIPTION
It has been deprecated in favor of Clip.

Test plan: make -j fast

Depends on #1724
Fixes #1723