### PR TITLE
Support old argument style for AreaFilter

### DIFF
--- a/starfish/core/morphology/Filter/areafilter.py
+++ b/starfish/core/morphology/Filter/areafilter.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import MutableSequence, Optional
 
 from starfish.core.morphology.binary_mask import BinaryMaskCollection, MaskData
@@ -19,7 +20,35 @@ class AreaFilter(FilterAlgorithm):
         collection.
     """
 
-    def __init__(self, *, min_area: Optional[int] = None, max_area: Optional[int] = None):
+    def __init__(
+            self,
+            min_area_DEPRECATED: Optional[int] = None,
+            max_area_DEPRECATED: Optional[int] = None,
+            *,
+            min_area: Optional[int] = None,
+            max_area: Optional[int] = None,
+    ):
+        if min_area_DEPRECATED is not None:
+            if min_area is not None:
+                raise ValueError(
+                    "Cannot specify both min_area as a positional argument and a keyword "
+                    "argument.  AreaFilter should be initialized only by "
+                    "`AreaFilter(min_area=xyz)`.")
+            warnings.warn(
+                "min_area should be provided as a keyword argument, i.e., "
+                "`AreaFilter(min_area=xyz)`.")
+            min_area = min_area_DEPRECATED
+        if max_area_DEPRECATED is not None:
+            if max_area is not None:
+                raise ValueError(
+                    "Cannot specify both max_area as a positional argument and a keyword "
+                    "argument.  AreaFilter should be initialized only by "
+                    "`AreaFilter(max_area=xyz)`.")
+            warnings.warn(
+                "max_area should be provided as a keyword argument, i.e., "
+                "`AreaFilter(max_area=xyz)`.")
+            max_area = max_area_DEPRECATED
+
         self._min_area = min_area
         self._max_area = max_area
 

--- a/starfish/core/morphology/Filter/test/test_areafilter.py
+++ b/starfish/core/morphology/Filter/test/test_areafilter.py
@@ -1,3 +1,5 @@
+from warnings import catch_warnings
+
 import pytest
 
 from starfish.core.morphology.binary_mask.test.factories import binary_mask_collection_2d
@@ -25,6 +27,32 @@ def test_max_area():
     input_mask_collection = binary_mask_collection_2d()
     output_mask_collection = AreaFilter(max_area=5).run(input_mask_collection)
     assert len(output_mask_collection) == 1
+
+
+def test_min_area_deprecated():
+    input_mask_collection = binary_mask_collection_2d()
+    with catch_warnings(record=True) as warnings:
+        output_mask_collection = AreaFilter(6).run(input_mask_collection)
+        assert len(warnings) == 1
+    assert len(output_mask_collection) == 1
+
+
+def test_max_area_deprecated():
+    input_mask_collection = binary_mask_collection_2d()
+    with catch_warnings(record=True) as warnings:
+        output_mask_collection = AreaFilter(None, 5).run(input_mask_collection)
+    assert len(warnings) == 1
+    assert len(output_mask_collection) == 1
+
+
+def test_min_area_both():
+    with pytest.raises(ValueError):
+        AreaFilter(6, min_area=6)
+
+
+def test_max_area_both():
+    with pytest.raises(ValueError):
+        AreaFilter(None, 6, max_area=6)
 
 
 def test_illegal_areas():


### PR DESCRIPTION
This re-adds the positional argument style for specifying AreaFilter, while displaying a warning that it's deprecated.

Fixes #1734
Test plan: Add tests to cover the old style and the illegal path of specifying both positional and keyword arguments