### PR TITLE
Create a TileFetcher-based constructor for ImageStack

### DIFF
--- a/starfish/core/imagestack/parser/tilefetcher/__init__.py
+++ b/starfish/core/imagestack/parser/tilefetcher/__init__.py
@@ -1,0 +1,1 @@
+from ._parser import TileFetcherData

--- a/starfish/core/imagestack/parser/tilefetcher/_parser.py
+++ b/starfish/core/imagestack/parser/tilefetcher/_parser.py
@@ -1,0 +1,129 @@
+"""
+This module wraps a TileFetcher to provide the data to instantiate an ImageStack.
+"""
+from typing import Collection, Mapping, MutableMapping, Optional, Sequence
+
+import numpy as np
+
+from starfish.core.experiment.builder.orderediterator import join_axes_labels, ordered_iterator
+from starfish.core.experiment.builder.providers import FetchedTile, TileFetcher
+from starfish.core.imagestack.parser import TileCollectionData, TileData, TileKey
+from starfish.core.imagestack.physical_coordinates import _get_physical_coordinates_of_z_plane
+from starfish.core.types import ArrayLike, Axes, Coordinates, Number
+
+
+class TileFetcherImageTile(TileData):
+    """
+    This wraps a :py:class:`TileFetcher`.
+    """
+    def __init__(
+            self,
+            tile: FetchedTile,
+            r: int,
+            ch: int,
+            zplane: int,
+    ) -> None:
+        self._tile = tile
+        self._r = r
+        self._ch = ch
+        self._zplane = zplane
+
+    @property
+    def tile_shape(self) -> Mapping[Axes, int]:
+        return self._tile.shape
+
+    @property
+    def numpy_array(self) -> np.ndarray:
+        return self._tile.tile_data()
+
+    @property
+    def coordinates(self) -> Mapping[Coordinates, ArrayLike[Number]]:
+        return_coords: MutableMapping[Coordinates, ArrayLike[Number]] = dict()
+        for axis, coord in ((Axes.X, Coordinates.X), (Axes.Y, Coordinates.Y)):
+            coordinate_range = self._tile.coordinates[coord]
+            if not isinstance(coordinate_range, tuple):
+                raise ValueError("x-y coordinates for a tile must be a range expressed as a tuple.")
+            return_coords[coord] = np.linspace(
+                coordinate_range[0], coordinate_range[1], self.tile_shape[axis])
+
+        if Coordinates.Z in self._tile.coordinates:
+            zrange = self._tile.coordinates[Coordinates.Z]
+            if isinstance(zrange, tuple):
+                zplane_coord = _get_physical_coordinates_of_z_plane(zrange)
+                return_coords[Coordinates.Z] = [zplane_coord]
+            else:
+                return_coords[Coordinates.Z] = zrange
+
+        return return_coords
+
+    @property
+    def selector(self) -> Mapping[Axes, int]:
+        return {
+            Axes.ROUND: self._r,
+            Axes.CH: self._ch,
+            Axes.ZPLANE: self._zplane,
+        }
+
+
+class TileFetcherData(TileCollectionData):
+    """
+    This class wraps a TileFetcher along with the axes labels to provide a 5D tensor suitable for
+    loading as an ImageStack.
+    """
+    def __init__(
+            self,
+            tile_fetcher: TileFetcher,
+            tile_shape: Mapping[Axes, int],
+            fov: int,
+            rounds: Sequence[int],
+            chs: Sequence[int],
+            zplanes: Sequence[int],
+            axes_order: Optional[Sequence[Axes]] = None,
+    ) -> None:
+        self._tile_fetcher = tile_fetcher
+        self._tile_shape = tile_shape
+        self._fov = fov
+        self._rounds = rounds
+        self._chs = chs
+        self._zplanes = zplanes
+        if axes_order is None:
+            axes_order = Axes.ZPLANE, Axes.ROUND, Axes.CH
+        self._axes_order = axes_order
+
+    def __getitem__(self, tilekey: TileKey) -> dict:
+        """Returns the extras metadata for a given tile, addressed by its TileKey"""
+        return {}
+
+    def keys(self) -> Collection[TileKey]:
+        """Returns a Collection of the TileKey's for all the tiles."""
+        axes_sizes = join_axes_labels(
+            self._axes_order, rounds=self._rounds, chs=self._chs, zplanes=self._zplanes)
+        return [
+            TileKey(round=selector[Axes.ROUND], ch=selector[Axes.CH], zplane=selector[Axes.ZPLANE])
+            for selector in ordered_iterator(axes_sizes)
+        ]
+
+    @property
+    def tile_shape(self) -> Mapping[Axes, int]:
+        return self._tile_shape
+
+    @property
+    def extras(self) -> dict:
+        """Returns the extras metadata for the TileSet."""
+        return {}
+
+    def get_tile_by_key(self, tilekey: TileKey) -> TileData:
+        return TileFetcherImageTile(
+            self._tile_fetcher.get_tile(self._fov, tilekey.round, tilekey.ch, tilekey.z),
+            tilekey.round,
+            tilekey.ch,
+            tilekey.z,
+        )
+
+    def get_tile(self, r: int, ch: int, z: int) -> TileData:
+        return TileFetcherImageTile(
+            self._tile_fetcher.get_tile(self._fov, r, ch, z),
+            r,
+            ch,
+            z,
+        )

--- a/starfish/core/imagestack/test/test_from_tilefetcher.py
+++ b/starfish/core/imagestack/test/test_from_tilefetcher.py
@@ -1,0 +1,73 @@
+from typing import Mapping, Union
+
+import numpy as np
+
+from starfish.core.experiment.builder.builder import tile_fetcher_factory
+from starfish.core.experiment.builder.test.factories.unique_tiles import unique_data, UniqueTiles
+from starfish.core.types import Axes, Coordinates, CoordinateValue
+from ..imagestack import ImageStack
+
+
+class UniqueTilesWithCoordinates(UniqueTiles):
+    @property
+    def coordinates(self) -> Mapping[Union[str, Coordinates], CoordinateValue]:
+        return {
+            Coordinates.X: (0.0, 0.0001),
+            Coordinates.Y: (0.0, 0.0001),
+            Coordinates.Z: (0.0, 0.0001),
+        }
+
+
+def test_from_tilefetcher(
+        rounds=(0, 1, 2, 3),
+        chs=(0, 1, 3),
+        zplanes=(0, 1),
+        tile_height=400,
+        tile_width=500,
+):
+    tile_fetcher = tile_fetcher_factory(
+        UniqueTilesWithCoordinates,
+        pass_tile_indices=True,
+        fovs=[0],
+        rounds=rounds,
+        chs=chs,
+        zplanes=zplanes,
+        tile_height=tile_height,
+        tile_width=tile_width,
+    )
+    stack = ImageStack.from_tilefetcher(
+        tile_fetcher,
+        tile_shape={Axes.Y: tile_height, Axes.X: tile_width},
+        fov=0,
+        rounds=rounds,
+        chs=chs,
+        zplanes=zplanes,
+    )
+
+    assert stack.shape == {
+        Axes.ROUND: len(rounds),
+        Axes.CH: len(chs),
+        Axes.ZPLANE: len(zplanes),
+        Axes.Y.value: tile_height,
+        Axes.X.value: tile_width,
+    }
+
+    for round_label in rounds:
+        for ch_label in chs:
+            for zplane_label in zplanes:
+                expected_data = unique_data(
+                    0,
+                    rounds.index(round_label),
+                    chs.index(ch_label),
+                    zplanes.index(zplane_label),
+                    1,
+                    len(rounds),
+                    len(chs),
+                    len(zplanes),
+                    tile_height,
+                    tile_width,
+                )
+                actual_data = stack.get_slice(
+                    {Axes.ROUND: round_label, Axes.CH: ch_label, Axes.ZPLANE: zplane_label})[0]
+
+                assert np.all(expected_data == actual_data)


### PR DESCRIPTION
1. Add a parser from TileFetcher to the TileCollectionData.
2. Add a top-level classmethod to wrap a TileFetcher and produce an ImageStack.
3. Add a test to verify this functionality.

Test plan: Tests pass.

Fixes: #1603
Depends on #1736, #1738 