### PR TITLE
[easy] add h5py to pinned requirements

### DIFF
--- a/requirements/REQUIREMENTS-CI.txt
+++ b/requirements/REQUIREMENTS-CI.txt
@@ -23,6 +23,7 @@ entrypoints==0.3
 execnet==1.7.1
 flake8==3.7.9
 flake8-import-order==0.18.1
+h5py==2.10.0
 idna==2.8
 imageio==2.6.1
 imagesize==1.2.0

--- a/requirements/REQUIREMENTS-NAPARI-CI.txt
+++ b/requirements/REQUIREMENTS-NAPARI-CI.txt
@@ -20,6 +20,7 @@ docutils==0.15.2
 entrypoints==0.3
 freetype-py==2.1.0.post1
 fsspec==0.6.2
+h5py==2.10.0
 idna==2.8
 imageio==2.6.1
 imagesize==1.2.0

--- a/starfish/REQUIREMENTS-STRICT.txt
+++ b/starfish/REQUIREMENTS-STRICT.txt
@@ -15,6 +15,7 @@ defusedxml==0.6.0
 diskcache==4.1.0
 docutils==0.15.2
 entrypoints==0.3
+h5py==2.10.0
 idna==2.8
 imageio==2.6.1
 importlib-metadata==1.4.0


### PR DESCRIPTION
#1740 added h5py but not to the pinned requirements files.  That resulted in unhappy travis runs (e.g., https://travis-ci.com/spacetx/starfish/builds/146897038)

Test plan: none