### PR TITLE
[easy] Remove # type: ignore for get_versions

### DIFF
--- a/starfish/core/__init__.py
+++ b/starfish/core/__init__.py
@@ -6,8 +6,7 @@ warnings.filterwarnings("ignore", message="numpy.dtype size changed")  # noqa
 warnings.filterwarnings("ignore", message="numpy.ufunc size changed")  # noqa
 
 # generated version number and commit hash
-# TODO: (ttung) the type: ignore is required to satisfy the new semantic analyzer in mypy 0.710.
-from ._version import get_versions  # type: ignore
+from ._version import get_versions
 
 
 # NOTE: if we move to python 3.7, we can produce this value at call time via __getattr__

--- a/starfish/core/_version.py
+++ b/starfish/core/_version.py
@@ -1,4 +1,4 @@
-# type: ignore
+
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build


### PR DESCRIPTION
By removing the type: ignore at the top of starfish/core/_version.py, it now behaves correctly.

Test plan: `make -j lint mypy`
Fixes #1766