### PR TITLE
[easy] Validate iss experiment.json file

### DIFF
--- a/examples/pipelines/iss_pipeline.py
+++ b/examples/pipelines/iss_pipeline.py
@@ -79,11 +79,8 @@ def process_experiment(experiment: starfish.Experiment):
 
 # run the script
 if test:
-    # TODO: (ttung) Pending a fix for https://github.com/spacetx/starfish/issues/700, it's not
-    # possible to validate the schema for this experiment.
-    with starfish.config.environ(VALIDATION_STRICT="false"):
-        exp = starfish.Experiment.from_json(
-            "https://d2nhj9g34unfro.cloudfront.net/browse/formatted/20180926/iss_breast/experiment.json")
+    exp = starfish.Experiment.from_json(
+        "https://d2nhj9g34unfro.cloudfront.net/browse/formatted/20180926/iss_breast/experiment.json")
 else:
     exp = starfish.Experiment.from_json("iss/formatted/experiment.json")
 decoded_intensities, regions = process_experiment(exp)


### PR DESCRIPTION
Now that #700 has landed, we no longer need to disable validation.

Depends on #1792
Fixes #1779