### PR TITLE
[easy] Fix documentation for ImageStack.export

### DIFF
--- a/starfish/core/imagestack/imagestack.py
+++ b/starfish/core/imagestack/imagestack.py
@@ -5,10 +5,11 @@ from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from functools import partial
 from itertools import product
-from pathlib import Path
+from pathlib import PurePath
 from threading import Lock
 from typing import (
     Any,
+    BinaryIO,
     Callable,
     Hashable,
     Iterable,
@@ -1123,7 +1124,7 @@ class ImageStack:
 
     def export(self,
                filepath: str,
-               tile_opener=None,
+               tile_opener: Optional[Callable[[PurePath, Tile, str], BinaryIO]] = None,
                tile_format: ImageFormat=ImageFormat.NUMPY) -> None:
         """write the image tensor to disk in spaceTx format
 
@@ -1131,7 +1132,10 @@ class ImageStack:
         ----------
         filepath : str
             Path + prefix for the images and primary_images.json written by this function
-        tile_opener : TODO ttung: doc me.
+        tile_opener : Optional[Callable[[PurePath, Tile, str], BinaryIO]]
+            A callable responsible for opening the file that a tile's data is to be written to. The
+            callable should accept three arguments -- the path of the tileset, the tile data, and
+            the expected file extension. If this is not specified, a reasonable default is provided.
         tile_format : ImageFormat
             Format in which each 2D plane should be written.
 
@@ -1183,7 +1187,7 @@ class ImageStack:
             tileset.add_tile(tile)
 
         if tile_opener is None:
-            def tile_opener(tileset_path: Path, tile, ext):
+            def tile_opener(tileset_path: PurePath, tile: Tile, ext: str):
                 base = tileset_path.parent / tileset_path.stem
                 if Axes.ZPLANE in tile.indices:
                     zval = tile.indices[Axes.ZPLANE]

--- a/starfish/core/morphology/Binarize/threshold.py
+++ b/starfish/core/morphology/Binarize/threshold.py
@@ -39,14 +39,6 @@ class ThresholdBinarize(BinarizeAlgorithm):
             ],
             dtype=np.bool)
 
-        # TODO: (ttung) This could theoretically be done with ImageStack.transform, but
-        # ImageStack.transform doesn't provide the selectors to the worker method.  In this case,
-        # we need the selectors to select the correct region of the output array.  The alternative
-        # is for each worker thread to create a new array, and then merge them at the end, but that
-        # effectively doubles our memory consumption.
-        #
-        # For now, we will just do it in-process, because it's not a particularly compute-intensive
-        # task.
         self._binarize(result_array, image.xarray[0, 0])
 
         pixel_ticks: Mapping[Axes, ArrayLike[int]] = {


### PR DESCRIPTION
Added the documentation for the `tile_opener` argument.

Fixes #1786