### PR TITLE
[easy] Clearer exception for when n_codes does not match the number of target names

### DIFF
--- a/starfish/core/codebook/codebook.py
+++ b/starfish/core/codebook/codebook.py
@@ -775,7 +775,9 @@ class Codebook(xr.DataArray):
         if target_names is None:
             # use a reverse-sorted list of integers as codewords
             target_names = [uuid.uuid4() for _ in range(n_codes)]
-        assert n_codes == len(target_names)
+        if n_codes != len(target_names):
+            raise ValueError(
+                f"n_codes ({n_codes} does not match the number of targets ({len(target_names)})")
 
         codebook = [{Features.CODEWORD: w, Features.TARGET: g}
                     for w, g in zip(codewords, target_names)]

--- a/starfish/core/codebook/test/test_synthetic_one_hot_codebook.py
+++ b/starfish/core/codebook/test/test_synthetic_one_hot_codebook.py
@@ -36,10 +36,9 @@ def test_target_names_are_incorporated_into_synthetic_codebook():
     assert np.array_equal(codebook[Features.TARGET], list('ab'))
 
 
-# TODO ambrosejcarr: This should probably be clearer than an AssertionError
 def test_wrong_number_of_target_names_raises_error():
     """here we request 3 codes but provide only two names, which should raise an error"""
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         Codebook.synthetic_one_hot_codebook(
             n_round=2,
             n_channel=2,


### PR DESCRIPTION
Fixes #1775