### PR TITLE
improve from_code_array validation

### DIFF
--- a/starfish/core/codebook/codebook.py
+++ b/starfish/core/codebook/codebook.py
@@ -251,6 +251,31 @@ class Codebook(xr.DataArray):
         # guess the max round and channel if not provided, otherwise check provided values are valid
         max_round, max_ch = 0, 0
 
+        # verify codebook structure and fields
+        for code in code_array:
+
+            if not isinstance(code, dict):
+                raise ValueError(f'codebook must be an array of dictionary codes. Found: {code}.')
+
+            # verify all necessary fields are present
+            required_fields = {Features.CODEWORD, Features.TARGET}
+            missing_fields = required_fields.difference(code)
+            if missing_fields:
+                raise ValueError(
+                    f'Each entry of codebook must contain {required_fields}. Missing fields: '
+                    f'{missing_fields}')
+
+            for entry in code[Features.CODEWORD]:
+                if not isinstance(entry, dict):
+                    raise TypeError(f"codeword entries should be dictionaries")
+
+                required_codeword_fields = {Axes.ROUND.value, Axes.CH.value, Features.CODE_VALUE}
+                missing_codeword_fields = required_codeword_fields.difference(entry)
+                if missing_codeword_fields:
+                    raise ValueError(
+                        f"Each codeword entry must contain {required_codeword_fields}. Missing "
+                        f"fields: {missing_codeword_fields}")
+
         for code in code_array:
             for entry in code[Features.CODEWORD]:
                 max_round = max(max_round, entry[Axes.ROUND])
@@ -269,20 +294,6 @@ class Codebook(xr.DataArray):
             raise ValueError(
                 f'code detected that requires a channel value ({max_ch + 1}) that is greater '
                 f'than provided n_channel: {n_channel}')
-
-        # verify codebook structure and fields
-        for code in code_array:
-
-            if not isinstance(code, dict):
-                raise ValueError(f'codebook must be an array of dictionary codes. Found: {code}.')
-
-            # verify all necessary fields are present
-            required_fields = {Features.CODEWORD, Features.TARGET}
-            missing_fields = required_fields.difference(code)
-            if missing_fields:
-                raise ValueError(
-                    f'Each entry of codebook must contain {required_fields}. Missing fields: '
-                    f'{missing_fields}')
 
         target_names = [w[Features.TARGET] for w in code_array]
 

--- a/starfish/core/codebook/test/test_from_code_array.py
+++ b/starfish/core/codebook/test/test_from_code_array.py
@@ -62,25 +62,25 @@ def test_from_code_array_has_three_channels_two_rounds_and_two_codes():
     assert_sizes(codebook)
 
 
-# TODO ambrosejcarr: this should be a ValueError, not a KeyError,
-# and the message should be clearer to the user
 def test_from_code_array_throws_key_error_with_missing_channel_round_or_value():
     """Tests that from_code_array throws errors when it encounters malformed codes"""
     code_array: List = codebook_array_factory()
 
-    # codebook is now missing a channel
+    # codebook is now missing a round
     del code_array[0][Features.CODEWORD][0][Axes.ROUND.value]
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         Codebook.from_code_array(code_array)
 
+    # codebook is now missing a ch
     code_array: List = codebook_array_factory()
     del code_array[0][Features.CODEWORD][0][Axes.CH.value]
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         Codebook.from_code_array(code_array)
 
+    # codebook is now missing a value
     code_array: List = codebook_array_factory()
     del code_array[0][Features.CODEWORD][0][Features.CODE_VALUE]
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         Codebook.from_code_array(code_array)
 
 


### PR DESCRIPTION
1. Explicitly check for the codeword entry not being a dictionary.
2. Explicitly check for the required fields in a codeword entry.
3. Improve comments in test.

Fixes #1777