### PR TITLE
Fix on-demand calculation of BinaryMaskCollection's regionprops

### DIFF
--- a/starfish/core/morphology/binary_mask/binary_mask.py
+++ b/starfish/core/morphology/binary_mask/binary_mask.py
@@ -211,7 +211,9 @@ class BinaryMaskCollection:
                 mask_id + 1,
                 image,
             )
-            mask_data.region_properties = regionprops(image.data)
+            measured_region_props = regionprops(image)
+            assert len(measured_region_props) == 1
+            mask_data.region_properties = measured_region_props[0]
         return mask_data.region_properties
 
     @property

--- a/starfish/core/morphology/binary_mask/test/test_from_binary_arrays_and_ticks.py
+++ b/starfish/core/morphology/binary_mask/test/test_from_binary_arrays_and_ticks.py
@@ -44,6 +44,12 @@ def test_2d():
     assert np.array_equal(region_1[Coordinates.X.value],
                           physical_ticks[Coordinates.X][3:6])
 
+    # verify that we can lazy-calculate the regionprops correctly.
+    region_0_props = binary_mask_collection.mask_regionprops(0)
+    region_1_props = binary_mask_collection.mask_regionprops(1)
+    assert region_0_props.area == 6
+    assert region_1_props.area == 5
+
 
 def test_3d():
     """Simple case of BinaryMaskCollection.from_binary_arrays_and_ticks with 3D data.  Pixel ticks
@@ -88,6 +94,12 @@ def test_3d():
                           physical_ticks[Coordinates.Y][3:5])
     assert np.array_equal(region_1[Coordinates.X.value],
                           physical_ticks[Coordinates.X][3:6])
+
+    # verify that we can lazy-calculate the regionprops correctly.
+    region_0_props = binary_mask_collection.mask_regionprops(0)
+    region_1_props = binary_mask_collection.mask_regionprops(1)
+    assert region_0_props.area == 6
+    assert region_1_props.area == 11
 
 
 def test_no_mask():


### PR DESCRIPTION
Through most ways of constructing BinaryMaskCollections, we calculate region properties and store them with our BinaryMaskCollection.  However, on a few code paths (notably `from_binary_arrays_and_ticks` and `from_fiji_roi_set`), we calculate the regionprops on demand.

This code path was not properly tested and we were not generating the regionprops correctly.  This fixes the problem and adds a quick sanity test.

Test plan: test passes with changes, does not otherwise.