### PR TITLE
Ensure that LocalMaxPeakFinder works in 3D

### DIFF
--- a/starfish/core/types/_spot_attributes.py
+++ b/starfish/core/types/_spot_attributes.py
@@ -1,5 +1,5 @@
 import json
-from typing import Collection
+from typing import Collection, Sequence
 
 import numpy as np
 import pandas as pd
@@ -33,6 +33,13 @@ class SpotAttributes(ValidatedTable):
         extra_dtypes = list(zip(extra_fields, [np.object] * len(extra_fields)))
         dtype = cls.required_fields + extra_dtypes
         return cls(pd.DataFrame(np.array([], dtype=dtype)))
+
+    @classmethod
+    def combine(cls, spot_attribute_tables: Sequence["SpotAttributes"]) -> "SpotAttributes":
+        return cls(pd.concat([
+            spot_attribute_table.data
+            for spot_attribute_table in spot_attribute_tables
+        ]))
 
     def save_geojson(self, output_file_name: str) -> None:
         """Save to geojson for web visualization

--- a/starfish/core/types/_spot_finding_results.py
+++ b/starfish/core/types/_spot_finding_results.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Hashable, List, Mapping, MutableMapping, Optional, Tuple
+from typing import Any, Hashable, Mapping, MutableMapping, Optional, Sequence, Tuple
 
 import xarray as xr
 
@@ -31,7 +31,8 @@ class SpotFindingResults:
             self,
             imagestack_coords,
             log: Log,
-            spot_attributes_list: Optional[List[Tuple]] = None,
+            spot_attributes_list: Optional[
+                Sequence[Tuple[PerImageSliceSpotResults, Mapping[Axes, int]]]] = None,
     ):
         """
         Construct a SpotFindingResults instance
@@ -42,10 +43,12 @@ class SpotFindingResults:
             The physical coordinate ranges of the ImageStack spots were found in
         log : Log
             The provenance log information from the ImageStack spots were found in.
-        spot_attributes_list : Optional[List[Tuple]]
+        spot_attributes_list : Optional[
+        Sequence[Tuple[PerImageSliceSpotResults, Mapping[Axes, int]]]]
             If spots were found using ImageStack.transform() the result is a list of
-            tuples ((r, channel), PerImageSpotResults). Instantiating SpotFindingResults with
-            this list will convert the information to a dictionary.
+            tuples (PerImageSliceSpotResults, indices).  Indices should be a mapping from axes to
+            axis value.  Instantiating SpotFindingResults with this list will convert the
+            information to a dictionary.
         """
         spot_attributes_list = spot_attributes_list or []
         self._results: MutableMapping[Tuple, PerImageSliceSpotResults] = {


### PR DESCRIPTION
1. Thread the `is_volume` parameter through, and use that to determine which axes to group by.
2. `image_to_spots` now takes an xarray, and uses the `Z` data on the xarray coordinate to record the z data in cases where we group by 2d slices.
3. Call spot detection on the reference image using `ImageStack.transform` so we can use axes grouping.
4. Add the ability to combine spot attributes by R/C.  This is because `SpotFindingResults` is organized by R/C and not by R/C/Z.

Test plan: Added spot detection tests with 2D spot detectors.  Because the spots on the different zplanes are now considered separate, we see a lot more spots.

Fixes #1815