### PR TITLE
Add support for kwargs to peak_local_max

### DIFF
--- a/starfish/core/spots/FindSpots/local_max_peak_finder.py
+++ b/starfish/core/spots/FindSpots/local_max_peak_finder.py
@@ -50,6 +50,8 @@ class LocalMaxPeakFinder(FindSpotsAlgorithm):
     verbose : bool
         If True, report the percentage completed during processing
         (default = False)
+    kwargs :
+        Additional keyword arguments to pass to skimage.feature.peak_local_max
 
     Notes
     -----
@@ -63,6 +65,7 @@ class LocalMaxPeakFinder(FindSpotsAlgorithm):
         min_num_spots_detected: int = 3,
         is_volume: bool = True,
         verbose: bool = True,
+        **kwargs,
     ) -> None:
 
         self.min_distance = min_distance
@@ -76,6 +79,7 @@ class LocalMaxPeakFinder(FindSpotsAlgorithm):
 
         self.is_volume = is_volume
         self.verbose = verbose
+        self.kwargs = kwargs
 
     def _compute_num_spots_per_threshold(self, img: np.ndarray) -> Tuple[np.ndarray, List[int]]:
         """Computes the number of detected spots for each threshold
@@ -209,6 +213,7 @@ class LocalMaxPeakFinder(FindSpotsAlgorithm):
     def image_to_spots(
             self,
             data_image: xr.DataArray,
+            **kwargs
     ) -> PerImageSliceSpotResults:
         """measure attributes of spots detected by binarizing the image using the selected threshold
 
@@ -216,6 +221,8 @@ class LocalMaxPeakFinder(FindSpotsAlgorithm):
         ----------
         data_image : xr.DataArray
             image containing spots to be detected
+        kwargs :
+            Additional keyword arguments to pass to skimage.feature.peak_local_max
 
         Returns
         -------
@@ -252,7 +259,8 @@ class LocalMaxPeakFinder(FindSpotsAlgorithm):
             indices=True,
             num_peaks=np.inf,
             footprint=None,
-            labels=labels
+            labels=labels,
+            **kwargs
         )
 
         if data_image.ndim == 3:
@@ -309,7 +317,7 @@ class LocalMaxPeakFinder(FindSpotsAlgorithm):
         n_processes : Optional[int] = None,
             Number of processes to devote to spot finding.
         """
-        spot_finding_method = partial(self.image_to_spots, *args, **kwargs)
+        spot_finding_method = partial(self.image_to_spots, **self.kwargs)
         if reference_image:
             shape = reference_image.shape
             assert shape[Axes.ROUND] == 1

--- a/starfish/core/spots/FindSpots/test/test_local_max_peak_finder.py
+++ b/starfish/core/spots/FindSpots/test/test_local_max_peak_finder.py
@@ -1,0 +1,25 @@
+import sys
+
+import numpy as np
+
+from starfish import ImageStack
+from starfish.spots import FindSpots
+from starfish.types import Axes
+
+
+def test_lmpf_uniform_peak():
+    data_array = np.zeros(shape=(1, 1, 1, 100, 100), dtype=np.float32)
+    data_array[0, 0, 0, 45:55, 45:55] = 1
+    imagestack = ImageStack.from_numpy(data_array)
+
+    # standard local max peak finder, should find spots for all the evenly illuminated pixels.
+    lmpf_no_kwarg = FindSpots.LocalMaxPeakFinder(1, 1, 1, sys.maxsize)
+    peaks = lmpf_no_kwarg.run(imagestack)
+    results_no_kwarg = peaks[{Axes.ROUND: 0, Axes.CH: 0}]
+    assert len(results_no_kwarg.spot_attrs.data) == 100
+
+    # local max peak finder, capped at one peak per label.
+    lmpf_kwarg = FindSpots.LocalMaxPeakFinder(1, 1, 1, sys.maxsize, num_peaks_per_label=1)
+    peaks = lmpf_kwarg.run(imagestack)
+    results_kwarg = peaks[{Axes.ROUND: 0, Axes.CH: 0}]
+    assert len(results_kwarg.spot_attrs.data) == 1


### PR DESCRIPTION
Test plan: run spot detection on a spot that's uniformly illuminated.  Without the `num_peaks_per_label=1` kwarg, it finds a peak at each pixel.  With the kwarg, it finds only 1 peak.