### PR TITLE
link to image.sc/tag/starfish

### DIFF
--- a/docs/source/contributing/index.rst
+++ b/docs/source/contributing/index.rst
@@ -131,7 +131,3 @@ sending us the output of ``pip freeze``:
 
 Whenever possible, please also include a brief, self-contained code example that demonstrates the
 problem, including a full traceback.
-
-We can also be contacted on the SpaceTx slack in the ``#starfish-users`` channel. If you'd like an
-invitation, please feel free to email us. We can usually respond to bug reports same-day, and
-are very appreciative of the time you take to submit them to us.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,11 +35,10 @@ starfish. Finally, advanced users can examine the :ref:`Data Structures <data st
 :ref:`Help & Reference <help and reference>` sections to learn more details about _starfish_ and its
 object models.
 
-Starfish is moving user support from `the #starfish-users channel on the CZI Science Slack
-<https://join-cziscience-slack.herokuapp.com/>`_ to the `image.sc forum <https://forum.image
-.sc/>`_. We hope this forum will be a continually expanding resource for starfish users. Please
+Starfish user support is hosted on the `image.sc forum <https://forum.image.sc/>`_ where questions
+and discussion will serve as a continually expanding resource for starfish users. Please
 post any help or support requests on `image.sc <https://forum.image.sc/>`_ with the ``starfish``
-tag or `email the starfish team directly <mailto:starfish@chanzuckerberg.com>`_
+tag.
 
 To see the code or report a bug, please visit the `github repository
 <https://github.com/spacetx/starfish>`_.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,9 +35,11 @@ starfish. Finally, advanced users can examine the :ref:`Data Structures <data st
 :ref:`Help & Reference <help and reference>` sections to learn more details about _starfish_ and its
 object models.
 
-For questions, suggestions, or accolades, `join the #starfish-users channel on the CZI Science Slack
-<https://join-cziscience-slack.herokuapp.com/>`_ and say “hi!” or
-`email the starfish team directly <mailto:starfish@chanzuckerberg.com>`_
+Starfish is moving user support from `the #starfish-users channel on the CZI Science Slack
+<https://join-cziscience-slack.herokuapp.com/>`_ to the `image.sc forum <https://forum.image
+.sc/>`_. We hope this forum will be a continually expanding resource for starfish users. Please
+post any help or support requests on `image.sc <https://forum.image.sc/>`_ with the ``starfish``
+tag or `email the starfish team directly <mailto:starfish@chanzuckerberg.com>`_
 
 To see the code or report a bug, please visit the `github repository
 <https://github.com/spacetx/starfish>`_.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,10 +35,10 @@ starfish. Finally, advanced users can examine the :ref:`Data Structures <data st
 :ref:`Help & Reference <help and reference>` sections to learn more details about _starfish_ and its
 object models.
 
-Starfish user support is hosted on the `image.sc forum <https://forum.image.sc/>`_ where questions
-and discussion will serve as a continually expanding resource for starfish users. Please
-post any help or support requests on `image.sc <https://forum.image.sc/>`_ with the ``starfish``
-tag.
+Starfish user support is hosted on the `image.sc forum <https://forum.image.sc/tag/starfish>`_ where
+questions and discussion will serve as a continually expanding resource for starfish users. Please
+post any help or support requests on `image.sc <https://forum.image.sc/tag/starfish>`_ with the
+``starfish`` tag.
 
 To see the code or report a bug, please visit the `github repository
 <https://github.com/spacetx/starfish>`_.


### PR DESCRIPTION
Now that we're officially a community partner on image.sc we can link directly to the starfish tag feed.