### PR TITLE
Fix the travis test where we pin the napari version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ jobs:
       dist: xenial
       before_install:
         - sudo apt-get install -y libgl1-mesa-glx libqt5x11extras5 xvfb
+        - pip install -U pip==20.0.2
         - pip install -r requirements/REQUIREMENTS-NAPARI-CI.txt
         - make install-dev
         - export DISPLAY=:99

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ DOCKER_IMAGE?=spacetx/starfish
 DOCKER_BUILD?=1
 
 VERSION=$(shell sh -c "git describe --exact --dirty 2> /dev/null")
+# if you update this, you will need to update the version pin for the "Install Napari & Test napari (pinned)" test in .travis.yml
 PIP_VERSION=20.0.2
 
 define print_help


### PR DESCRIPTION
To achieve the pin, we install based on requirements/REQUIREMENTS-NAPARI-CI.txt **before** we run make install-dev.  Unfortunately, install-dev is where we upgrade pip such that it doesn't choke on napari.  This should hopefully fix the issue where napari test is broken.

Test plan: branch name has napari, so it should run the napari test