### PR TITLE
fix how spot_ids are handled by build_traces_sequential and Label._assign()

### DIFF
--- a/starfish/core/spots/AssignTargets/label.py
+++ b/starfish/core/spots/AssignTargets/label.py
@@ -61,7 +61,8 @@ class Label(AssignTargetsAlgorithm):
                 selectors['z'] = in_bbox.z
             in_mask = mask.sel(**selectors)
             spot_ids = in_bbox[Features.SPOT_ID][in_mask.values]
-            decoded_intensities[Features.CELL_ID].loc[spot_ids] = mask.name
+            decoded_intensities[Features.CELL_ID].loc[
+                decoded_intensities[Features.SPOT_ID].isin(spot_ids)] = mask.name
 
         return decoded_intensities
 

--- a/starfish/core/spots/DecodeSpots/trace_builders.py
+++ b/starfish/core/spots/DecodeSpots/trace_builders.py
@@ -55,7 +55,9 @@ def build_traces_sequential(spot_results: SpotFindingResults, **kwargs) -> Inten
 
     """
 
-    all_spots = pd.concat([sa.spot_attrs.data for sa in spot_results.values()], sort=True)
+    all_spots = pd.concat([sa.spot_attrs.data for sa in spot_results.values()], ignore_index=True, sort=True)
+    # reassign spot_ids to index number so they are unique
+    all_spots['spot_id'] = all_spots.index
 
     intensity_table = IntensityTable.zeros(
         spot_attributes=SpotAttributes(all_spots),

--- a/starfish/core/spots/DecodeSpots/trace_builders.py
+++ b/starfish/core/spots/DecodeSpots/trace_builders.py
@@ -55,7 +55,8 @@ def build_traces_sequential(spot_results: SpotFindingResults, **kwargs) -> Inten
 
     """
 
-    all_spots = pd.concat([sa.spot_attrs.data for sa in spot_results.values()], ignore_index=True, sort=True)
+    all_spots = pd.concat([sa.spot_attrs.data for sa in spot_results.values()],
+                          ignore_index=True, sort=True)
     # reassign spot_ids to index number so they are unique
     all_spots['spot_id'] = all_spots.index
 


### PR DESCRIPTION
Two bug fixes:

1. Made `build_traces_sequential` reassign unique `spot_id`s to every feature after concatenating `PerImageSliceResults`.
2. Made `Label._assign()` explicitly label features by `spot_id` instead of row number, ensuring that labeling is accurate even when `spot_id`s do not match row numbers in an `IntensityTable`. `Spot_id`s must still be unique for accurate labeling though.