### PR TITLE
Bump napari to 0.3.4

### DIFF
--- a/requirements/REQUIREMENTS-NAPARI-CI.txt
+++ b/requirements/REQUIREMENTS-NAPARI-CI.txt
@@ -7,6 +7,7 @@ backcall==0.1.0
 bleach==3.1.4
 boto3==1.12.32
 botocore==1.15.32
+cachey==0.2.1
 certifi==2019.11.28
 chardet==3.0.4
 click==7.1.1
@@ -21,6 +22,7 @@ entrypoints==0.3
 freetype-py==2.1.0.post1
 fsspec==0.7.1
 h5py==2.10.0
+HeapDict==1.0.1
 idna==2.9
 imageio==2.8.0
 imagesize==1.2.0
@@ -42,7 +44,9 @@ matplotlib==3.2.1
 mistune==0.8.4
 more-itertools==8.2.0
 mpmath==1.1.0
-napari==0.2.12
+napari==0.3.4
+napari-plugin-engine==0.1.6
+napari-svg==0.1.3
 nbconvert==5.6.1
 nbformat==5.0.4
 networkx==2.4
@@ -59,6 +63,7 @@ Pillow==7.0.0
 pluggy==0.13.1
 prometheus-client==0.7.1
 prompt-toolkit==3.0.5
+psutil==5.7.0
 ptyprocess==0.6.0
 py==1.8.1
 Pygments==2.6.1
@@ -99,6 +104,7 @@ sphinxcontrib-serializinghtml==1.1.4
 sympy==1.5.1
 terminado==0.8.3
 testpath==0.4.4
+tifffile==2020.6.3
 toolz==0.10.0
 tornado==6.0.4
 tqdm==4.44.1

--- a/requirements/REQUIREMENTS-NAPARI-CI.txt.in
+++ b/requirements/REQUIREMENTS-NAPARI-CI.txt.in
@@ -1,2 +1,2 @@
-napari >= 0.2.8
+napari >= 0.3.4
 pytest-qt

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=install_requires,
     extras_require={
-        'napari': [f"napari>={napari_version}"],
+        'napari': [f"napari[all]>={napari_version}"],
     },
     entry_points={
         'console_scripts': [

--- a/starfish/core/_display.py
+++ b/starfish/core/_display.py
@@ -18,7 +18,7 @@ except ImportError:
     Viewer = None
 
 
-NAPARI_VERSION = "0.2.6"  # when changing this, update docs in display
+NAPARI_VERSION = "0.3.4"  # when changing this, update docs in display
 INTERACTIVE = not hasattr(__main__, "__file__")
 
 
@@ -197,7 +197,7 @@ def display(
     -----
     - To use in ipython, use the `%gui qt` magic.
     - napari axes are labeled with the ImageStack axis names
-    - Requires napari 0.2.6: use `pip install starfish[napari]`
+    - Requires napari 0.3.4: use `pip install starfish[napari]`
       to install all necessary requirements
     """
     if stack is None and spots is None and masks is None:

--- a/starfish/core/test/test_display.py
+++ b/starfish/core/test/test_display.py
@@ -46,5 +46,3 @@ def test_display(qtbot, stack, spots, masks):
             display(stack, spots, masks, viewer=viewer)
     else:
         display(stack, spots, masks, viewer=viewer)
-
-    view.shutdown()


### PR DESCRIPTION
Napari installation will by default not install a backend.  This selects the default napari backend (PyQt5)