### PR TITLE
Ignore requirements that are already satisfied

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,12 +159,12 @@ help-integration:
 ### INSTALL ##################################################
 #
 install-dev:
-	pip install --force-reinstall --upgrade pip==$(PIP_VERSION) -r requirements/REQUIREMENTS-CI.txt
+	pip install --upgrade pip==$(PIP_VERSION) -r requirements/REQUIREMENTS-CI.txt
 	pip install -e .
 	pip freeze
 
 install-src:
-	pip install --force-reinstall --upgrade pip==$(PIP_VERSION) -e .
+	pip install --upgrade pip==$(PIP_VERSION) -e .
 	pip freeze
 
 install-released-notebooks-support:


### PR DESCRIPTION
Don't force-reinstall as that can cause conflicts with environments with distutils-installed packages.

Fixes #1922