### PR TITLE
Add necessary coords for IntensityTable when using Nearest Neighbors strategy

### DIFF
--- a/starfish/core/spots/DecodeSpots/trace_builders.py
+++ b/starfish/core/spots/DecodeSpots/trace_builders.py
@@ -75,7 +75,7 @@ def build_traces_sequential(spot_results: SpotFindingResults, **kwargs) -> Inten
     return intensity_table
 
 
-def build_traces_nearest_neighbors(spot_results: SpotFindingResults, anchor_round: int=1,
+def build_traces_nearest_neighbors(spot_results: SpotFindingResults, anchor_round: int=0,
                                    search_radius: int=3):
     """
     Combine spots found across round and channels of an ImageStack using a nearest neighbors

--- a/starfish/core/spots/DecodeSpots/util.py
+++ b/starfish/core/spots/DecodeSpots/util.py
@@ -95,6 +95,7 @@ def _build_intensity_table(
         Axes.ZPLANE.value: (Features.AXIS, anchor_df[Axes.ZPLANE]),
         Axes.Y.value: (Features.AXIS, anchor_df[Axes.Y]),
         Axes.X.value: (Features.AXIS, anchor_df[Axes.X]),
+        Features.AXIS: (Features.AXIS, np.arange(len(anchor_df))),
         Axes.ROUND.value: (Axes.ROUND.value, rounds),
         Axes.CH.value: (Axes.CH.value, channels)
     }

--- a/starfish/core/spots/DecodeSpots/util.py
+++ b/starfish/core/spots/DecodeSpots/util.py
@@ -95,6 +95,7 @@ def _build_intensity_table(
         Axes.ZPLANE.value: (Features.AXIS, anchor_df[Axes.ZPLANE]),
         Axes.Y.value: (Features.AXIS, anchor_df[Axes.Y]),
         Axes.X.value: (Features.AXIS, anchor_df[Axes.X]),
+        Features.SPOT_ID: (Features.AXIS, np.arange(len(anchor_df))),
         Features.AXIS: (Features.AXIS, np.arange(len(anchor_df))),
         Axes.ROUND.value: (Axes.ROUND.value, rounds),
         Axes.CH.value: (Axes.CH.value, channels)


### PR DESCRIPTION
A starfish user wants to try the Nearest Neighbor Trace Builder but had issues because the `IntensityTable` was [missing the `spot_id` coord and `features` dim](https://forum.image.sc/t/unable-to-retrieve-values-from-decodedintensitytable/44913). This pull request adds those to the `IntensityTable` so a full starfish pipeline (as demonstrated in the [Quick Start tutorial](https://spacetx-starfish.readthedocs.io/en/latest/gallery/quick_start/plot_quick_start.html)) can be built and run. This does not necessarily mean the Nearest Neighbor Trace Builder will give satisfactory results when tested on real data.