### PR TITLE
Import match_histograms from skimage.exposure

### DIFF
--- a/starfish/core/compat.py
+++ b/starfish/core/compat.py
@@ -1,7 +1,10 @@
 import skimage
 from packaging import version
 
-if version.parse(skimage.__version__) > version.parse("0.14.2"):
+if version.parse(skimage.__version__) >= version.parse("0.16.0"):
+    import skimage.exposure
+    match_histograms = skimage.exposure.match_histograms
+elif version.parse("0.16.0") > version.parse(skimage.__version__) > version.parse("0.14.2"):
     import skimage.transform
     match_histograms = skimage.transform.match_histograms
 else:


### PR DESCRIPTION
It was [moved to skimage.exposure @ 0.16.0](https://scikit-image.org/docs/0.16.x/release_notes_and_installation.html#deprecations)

Fixes: #1932

Test plan: Travis