### PR TITLE
Upgrade to a consistent version of pip in all workflows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ jobs:
         - sudo apt-get install -y libgl1-mesa-glx libqt5x11extras5 xvfb
         - make install-dev
         - pip install .[napari] pytest-qt
+        - pip freeze
         - export DISPLAY=:99
         - Xvfb $DISPLAY -ac -screen 0 1024x768x24 &
         - sleep 10
@@ -78,6 +79,7 @@ jobs:
         - pip install -U pip==21.0.1
         - pip install -r requirements/REQUIREMENTS-NAPARI-CI.txt
         - make install-dev
+        - pip freeze
         - export DISPLAY=:99
         - Xvfb $DISPLAY -ac -screen 0 1024x768x24 &
         - sleep 10

--- a/Makefile
+++ b/Makefile
@@ -102,21 +102,23 @@ pin-all-requirements:
 starfish/REQUIREMENTS-STRICT.txt : REQUIREMENTS.txt
 	[ ! -e .$<-env ] || exit 1
 	$(call create_venv, .$<-env)
+	.$<-env/bin/pip install --upgrade pip==$(PIP_VERSION)
 	.$<-env/bin/pip install -r $@
 	.$<-env/bin/pip install -r $<
 	echo "# You should not edit this file directly.  Instead, you should edit one of the following files ($^) and run make $@" >| $@
-	.$<-env/bin/pip freeze >> $@
+	.$<-env/bin/pip freeze --all | grep -v "pip==$(PIP_VERSION)" >> $@
 	rm -rf .$<-env
 
 requirements/REQUIREMENTS-%.txt : requirements/REQUIREMENTS-%.txt.in REQUIREMENTS.txt
 	[ ! -e .$<-env ] || exit 1
 	$(call create_venv, .$<-env)
+	.$<-env/bin/pip install --upgrade pip==$(PIP_VERSION)
 	.$<-env/bin/pip install -r $@
 	for src in $^; do \
 		.$<-env/bin/pip install -r $$src; \
 	done
 	echo "# You should not edit this file directly.  Instead, you should edit one of the following files ($<) and run make $@" >| $@
-	.$<-env/bin/pip freeze >> $@
+	.$<-env/bin/pip freeze --all | grep -v "pip==$(PIP_VERSION)" >> $@
 	rm -rf .$<-env
 
 check-requirements:


### PR DESCRIPTION
Always upgrade to $PIP_VERSION.

A couple minor changes:
1. Add a pip freeze to the test workflows to ensure we know what's being installed.
2. Do not include pip in requirements.txt because windows freaks out if it's asked to install pip in a requirements.txt file.