### PR TITLE
scikit-image version fix

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -16,7 +16,7 @@ semantic_version
 # 0.16.[012] are excluded because https://github.com/scikit-image/scikit-image/pull/3984 introduced
 # a bug into max peak finder.  0.16.3 presumably will have the fix from
 # https://github.com/scikit-image/scikit-image/pull/4263.
-scikit-image >= 0.14.0, != 0.16.0.*, != 0.16.1.*, != 0.16.2.*, != 0.17.1.*, != 0.17.2.*
+scikit-image >= 0.14.0, != 0.16.0.*, != 0.16.1.*, != 0.16.2.*, != 0.17.1.*, != 0.17.2.*, != 0.18.0.*, != 0.18.1.*
 scikit-learn
 scipy
 showit >= 1.1.4


### PR DESCRIPTION
scikit-image version 0.18.0 and 0.18.1 doesn't work. For example, if you run `register(imgs, dots, method = 'translation')`, it will throw error `AttributeError: 'DataArray' object has no attribute 'flags'`