### PR TITLE
Update registration module to be compatible with current scikit-image 0.18 and Python 3.9

### DIFF
--- a/starfish/core/image/_registration/LearnTransform/translation.py
+++ b/starfish/core/image/_registration/LearnTransform/translation.py
@@ -63,9 +63,11 @@ class Translation(LearnTransformAlgorithm):
                     f"please use the MaxProj filter."
                 )
 
-            shift, error, phasediff = phase_cross_correlation(reference_image=target_image,
-                                                              moving_image=reference_image,
-                                                              upsample_factor=self.upsampling)
+            shift, error, phasediff = phase_cross_correlation(
+                reference_image=target_image,
+                moving_image=reference_image,
+                upsample_factor=self.upsampling,
+            )
             if verbose:
                 print(f"For {self.axes}: {a}, Shift: {shift}, Error: {error}")
             selectors = {self.axes: a}

--- a/starfish/core/image/_registration/LearnTransform/translation.py
+++ b/starfish/core/image/_registration/LearnTransform/translation.py
@@ -54,9 +54,9 @@ class Translation(LearnTransformAlgorithm):
         """
 
         transforms = TransformsList()
-        reference_image = np.squeeze(self.reference_stack.xarray)
+        reference_image = np.squeeze(self.reference_stack.xarray.data)
         for a in stack.axis_labels(self.axes):
-            target_image = np.squeeze(stack.sel({self.axes: a}).xarray)
+            target_image = np.squeeze(stack.sel({self.axes: a}).xarray.data)
             if len(target_image.shape) != 2:
                 raise ValueError(
                     f"Only axes: {self.axes.value} can have a length > 1, "

--- a/starfish/core/image/_registration/LearnTransform/translation.py
+++ b/starfish/core/image/_registration/LearnTransform/translation.py
@@ -68,6 +68,7 @@ class Translation(LearnTransformAlgorithm):
                 moving_image=reference_image,
                 upsample_factor=self.upsampling,
             )
+            
             if verbose:
                 print(f"For {self.axes}: {a}, Shift: {shift}, Error: {error}")
             selectors = {self.axes: a}

--- a/starfish/core/image/_registration/LearnTransform/translation.py
+++ b/starfish/core/image/_registration/LearnTransform/translation.py
@@ -56,9 +56,8 @@ class Translation(LearnTransformAlgorithm):
         transforms = TransformsList()
         reference_image = np.squeeze(self.reference_stack.xarray.data)
         for a in stack.axis_labels(self.axes):
-            
-            target_image = np.squeeze(stack.sel({self.axes: a}).xarray.data)3
-            
+
+            target_image = np.squeeze(stack.sel({self.axes: a}).xarray.data)
             if len(target_image.shape) != 2:
                 raise ValueError(
                     f"Only axes: {self.axes.value} can have a length > 1, "
@@ -70,7 +69,7 @@ class Translation(LearnTransformAlgorithm):
                 moving_image=reference_image,
                 upsample_factor=self.upsampling,
             )
-            
+
             if verbose:
                 print(f"For {self.axes}: {a}, Shift: {shift}, Error: {error}")
             selectors = {self.axes: a}

--- a/starfish/core/image/_registration/LearnTransform/translation.py
+++ b/starfish/core/image/_registration/LearnTransform/translation.py
@@ -1,5 +1,5 @@
 import numpy as np
-from skimage.feature import register_translation
+from skimage.registration import phase_cross_correlation
 from skimage.transform._geometric import SimilarityTransform
 
 from starfish.core.image._registration.transforms_list import TransformsList
@@ -19,7 +19,7 @@ class Translation(LearnTransformAlgorithm):
     axes : Axes
         The axes {r, ch, zplane} to iterate over
     reference_stack : ImageStack
-        The target image used in :py:func:`skimage.feature.register_translation`
+        The target image used in :py:func:`skimage.registration.phase_cross_correlation`
     upsampling : int
         upsampling factor (default=1). See :py:func:`~skimage.registration.phase_cross_correlation`
         for an explanation of this parameter. In brief, this parameter determines the resolution of
@@ -63,8 +63,8 @@ class Translation(LearnTransformAlgorithm):
                     f"please use the MaxProj filter."
                 )
 
-            shift, error, phasediff = register_translation(src_image=target_image,
-                                                           target_image=reference_image,
+            shift, error, phasediff = phase_cross_correlation(reference_image=target_image,
+                                                           moving_image=reference_image,
                                                            upsample_factor=self.upsampling)
             if verbose:
                 print(f"For {self.axes}: {a}, Shift: {shift}, Error: {error}")

--- a/starfish/core/image/_registration/LearnTransform/translation.py
+++ b/starfish/core/image/_registration/LearnTransform/translation.py
@@ -64,8 +64,8 @@ class Translation(LearnTransformAlgorithm):
                 )
 
             shift, error, phasediff = phase_cross_correlation(reference_image=target_image,
-                                                           moving_image=reference_image,
-                                                           upsample_factor=self.upsampling)
+                                                              moving_image=reference_image,
+                                                              upsample_factor=self.upsampling)
             if verbose:
                 print(f"For {self.axes}: {a}, Shift: {shift}, Error: {error}")
             selectors = {self.axes: a}

--- a/starfish/core/image/_registration/LearnTransform/translation.py
+++ b/starfish/core/image/_registration/LearnTransform/translation.py
@@ -56,7 +56,9 @@ class Translation(LearnTransformAlgorithm):
         transforms = TransformsList()
         reference_image = np.squeeze(self.reference_stack.xarray.data)
         for a in stack.axis_labels(self.axes):
-            target_image = np.squeeze(stack.sel({self.axes: a}).xarray.data)
+            
+            target_image = np.squeeze(stack.sel({self.axes: a}).xarray.data)3
+            
             if len(target_image.shape) != 2:
                 raise ValueError(
                     f"Only axes: {self.axes.value} can have a length > 1, "


### PR DESCRIPTION
As scikit-image and Python versions continue to be updated, it is no longer feasible to use scikit-image 0.15.0 to get around . This pull request will make starfish compatible with scikit-image 0.18.*

Closes #1887 and #1950

Also means PR #1946 can be closed
