### PR TITLE
New seqFISH Decoding Method

### DIFF
--- a/starfish/core/intensity_table/decoded_intensity_table.py
+++ b/starfish/core/intensity_table/decoded_intensity_table.py
@@ -17,22 +17,18 @@ class DecodedIntensityTable(IntensityTable):
     """
     DecodedIntensityTable is a container for spot or pixel features extracted from image data
     that have been decoded. It is the primary output from starfish :py:class:`Decode` methods.
-
     An IntensityTable records the numeric intensity of a set of features in each
     :code:`(round, channel)` tile in which the feature is identified.
     The :py:class:`IntensityTable` has shape
     :code:`(n_feature, n_channel, n_round)`.
-
     Some :py:class:`SpotFinder` methods identify a position and search for Gaussian blobs in a
     small radius, only recording intensities if they are found in a given tile. Other
     :py:class:SpotFinder: approaches find blobs in a max-projection and measure them everywhere.
     As a result, some IntensityTables will be dense, and others will contain :code:`np.nan`
     entries where no feature was detected.
-
     Examples
     --------
     Create an IntensityTable using the ``synthetic_intensities`` method::
-
         >>> from starfish.core.test.factories import SyntheticData
         >>> sd = SyntheticData(n_ch=3, n_round=4, n_codes=2)
         >>> codes = sd.codebook()
@@ -41,7 +37,6 @@ class DecodedIntensityTable(IntensityTable):
         array([[[    0.,     0.,     0.,     0.],
                 [    0.,     0.,  8022., 12412.],
                 [11160.,  9546.,     0.,     0.]],
-
                [[    0.,     0.,     0.,     0.],
                 [    0.,     0., 10506., 10830.],
                 [11172., 12331.,     0.,     0.]]])
@@ -54,7 +49,6 @@ class DecodedIntensityTable(IntensityTable):
         * c          (c) int64 0 1 2
         * h          (h) int64 0 1 2 3
          target     (features) object 08b1a822-a1b4-4e06-81ea-8a4bd2b004a9 ...
-
         """
 
     __slots__ = ()
@@ -65,10 +59,10 @@ class DecodedIntensityTable(IntensityTable):
             intensities: IntensityTable,
             targets: Tuple[str, np.ndarray],
             distances: Optional[Tuple[str, np.ndarray]] = None,
-            passes_threshold: Optional[Tuple[str, np.ndarray]] = None):
+            passes_threshold: Optional[Tuple[str, np.ndarray]] = None,
+            filter_tally: Optional[Tuple[str, np.ndarray]] = None):
         """
         Assign target values to intensities.
-
         Parameters
         ----------
         intensities : IntensityTable
@@ -80,7 +74,9 @@ class DecodedIntensityTable(IntensityTable):
         passes_threshold : Optional[Tuple[str, np.ndarray]]
             Corresponding array of boolean values indicating if each itensity passed
             given thresholds.
-
+        filter_tally: Optional[Tuple[str, np.ndarray]]
+            Corresponding array of integers indicated the number of rounds this 
+            decoded intensity was found in
         Returns
         -------
         DecodedIntensityTable
@@ -92,6 +88,8 @@ class DecodedIntensityTable(IntensityTable):
             intensities[Features.DISTANCE] = distances
         if passes_threshold:
             intensities[Features.PASSES_THRESHOLDS] = passes_threshold
+        if filter_tally:
+            intensities['filter_tally'] = filter_tally
         return intensities
 
     def to_decoded_dataframe(self) -> DecodedSpots:
@@ -108,19 +106,15 @@ class DecodedIntensityTable(IntensityTable):
         """
         Writes a .csv.gz file in columnar format that is readable by MERMAID visualization
         software.
-
         To run MERMAID, follow the installation instructions for that repository and simply
         replace the data.csv.gz file with the output of this function.
-
         Parameters
         ----------
         filename : str
             Name for compressed-gzipped MERMAID data file. Should end in '.csv.gz'.
-
         Notes
         ------
         See also https://github.com/JEFworks/MERmaid
-
         """
         # construct the MERMAID dataframe. As MERMAID adds support for non-categorical variables,
         # additional columns can be added here
@@ -139,9 +133,7 @@ class DecodedIntensityTable(IntensityTable):
     def to_expression_matrix(self) -> ExpressionMatrix:
         """
         Generates a cell x gene count matrix where each cell is annotated with spatial metadata.
-
         Requires that spots in the IntensityTable have been assigned to cells.
-
         Returns
         -------
         ExpressionMatrix :

--- a/starfish/core/intensity_table/decoded_intensity_table.py
+++ b/starfish/core/intensity_table/decoded_intensity_table.py
@@ -60,7 +60,7 @@ class DecodedIntensityTable(IntensityTable):
             targets: Tuple[str, np.ndarray],
             distances: Optional[Tuple[str, np.ndarray]] = None,
             passes_threshold: Optional[Tuple[str, np.ndarray]] = None,
-            filter_tally: Optional[Tuple[str, np.ndarray]] = None):
+            rounds_used: Optional[Tuple[str, np.ndarray]] = None):
         """
         Assign target values to intensities.
         Parameters
@@ -74,7 +74,7 @@ class DecodedIntensityTable(IntensityTable):
         passes_threshold : Optional[Tuple[str, np.ndarray]]
             Corresponding array of boolean values indicating if each itensity passed
             given thresholds.
-        filter_tally: Optional[Tuple[str, np.ndarray]]
+        rounds_used: Optional[Tuple[str, np.ndarray]]
             Corresponding array of integers indicated the number of rounds this 
             decoded intensity was found in
         Returns
@@ -89,7 +89,7 @@ class DecodedIntensityTable(IntensityTable):
         if passes_threshold:
             intensities[Features.PASSES_THRESHOLDS] = passes_threshold
         if filter_tally:
-            intensities['filter_tally'] = filter_tally
+            intensities['rounds_used'] = rounds_used
         return intensities
 
     def to_decoded_dataframe(self) -> DecodedSpots:

--- a/starfish/core/intensity_table/decoded_intensity_table.py
+++ b/starfish/core/intensity_table/decoded_intensity_table.py
@@ -75,7 +75,7 @@ class DecodedIntensityTable(IntensityTable):
             Corresponding array of boolean values indicating if each itensity passed
             given thresholds.
         rounds_used: Optional[Tuple[str, np.ndarray]]
-            Corresponding array of integers indicated the number of rounds this 
+            Corresponding array of integers indicated the number of rounds this
             decoded intensity was found in
         Returns
         -------
@@ -88,7 +88,7 @@ class DecodedIntensityTable(IntensityTable):
             intensities[Features.DISTANCE] = distances
         if passes_threshold:
             intensities[Features.PASSES_THRESHOLDS] = passes_threshold
-        if filter_tally:
+        if rounds_used:
             intensities['rounds_used'] = rounds_used
         return intensities
 

--- a/starfish/core/spots/DecodeSpots/__init__.py
+++ b/starfish/core/spots/DecodeSpots/__init__.py
@@ -2,6 +2,7 @@ from ._base import DecodeSpotsAlgorithm
 from .metric_decoder import MetricDistance
 from .per_round_max_channel_decoder import PerRoundMaxChannel
 from .simple_lookup_decoder import SimpleLookupDecoder
+from .check_all_decoder import CheckAll
 
 # autodoc's automodule directive only captures the modules explicitly listed in __all__.
 __all__ = list(set(

--- a/starfish/core/spots/DecodeSpots/check_all_decoder.py
+++ b/starfish/core/spots/DecodeSpots/check_all_decoder.py
@@ -203,7 +203,7 @@ class CheckAll(DecodeSpotsAlgorithm):
             targets=(Features.AXIS, allCodes['best_targets'].astype('U')),
             distances=(Features.AXIS, allCodes["best_distances"]),
             passes_threshold=(Features.AXIS, np.full(len(allCodes), True)),
-            filter_tally=(Features.AXIS, allCodes['rounds_used']))
+            rounds_used=(Features.AXIS, allCodes['rounds_used']))
 
 
         return result

--- a/starfish/core/spots/DecodeSpots/check_all_decoder.py
+++ b/starfish/core/spots/DecodeSpots/check_all_decoder.py
@@ -1,0 +1,190 @@
+from typing import Callable, Optional
+import ray
+import pandas as pd
+import numpy as np
+from copy import deepcopy
+
+from starfish.core.codebook.codebook import Codebook
+from starfish.core.intensity_table.decoded_intensity_table import DecodedIntensityTable
+from starfish.core.intensity_table.intensity_table_coordinates import \
+    transfer_physical_coords_to_intensity_table
+from starfish.core.intensity_table.intensity_table import IntensityTable
+from starfish.core.types import SpotFindingResults
+from starfish.types import Axes, Features
+from ._base import DecodeSpotsAlgorithm
+
+
+from .check_all_funcs import findNeighbors, buildBarcodes, decoder, distanceFilter, cleanup, removeUsedSpots
+from .util import _merge_spots_by_round
+
+
+class CheckAll(DecodeSpotsAlgorithm):
+    """
+    Decode spots by selecting the max-valued channel in each sequencing round.
+
+    Note that this assumes that the codebook contains only one "on" channel per sequencing round,
+    a common pattern in experiments that assign one fluorophore to each DNA nucleotide and
+    read DNA sequentially. It is also a characteristic of single-molecule FISH and RNAscope
+    codebooks.
+
+    Parameters
+    ----------
+    codebook : Codebook
+        Contains codes to decode IntensityTable
+    trace_building_strategy: TraceBuildingStrategies
+        Defines the strategy for building spot traces to decode across rounds and chs of spot
+        finding results.
+    search_radius : Optional[int]
+        Only applicable if trace_building_strategy is TraceBuildingStrategies.NEAREST_NEIGHBORS.
+        Number of pixels over which to search for spots in other rounds and channels.
+    anchor_round : Optional[int]
+        Only applicable if trace_building_strategy is TraceBuildingStrategies.NEAREST_NEIGHBORS.
+        The imaging round against which other rounds will be checked for spots in the same
+        approximate pixel location.
+    """
+
+    def __init__(
+            self,
+            codebook: Codebook,
+            filter_rounds: Optional[int]=None,
+            search_radius: Optional[float]=3,
+            round_omit_num: Optional[int]=0):
+        self.codebook = codebook
+        self.filterRounds = filter_rounds
+        self.searchRadius = search_radius
+        self.roundOmitNum = round_omit_num
+
+    def run(self, spots: SpotFindingResults, n_processes: int=1, *args) -> DecodedIntensityTable:
+        """Decode spots by selecting the max-valued channel in each sequencing round
+
+        Parameters
+        ----------
+        spots: SpotFindingResults
+            A Dict of tile indices and their corresponding measured spots
+
+        Returns
+        -------
+        DecodedIntensityTable :
+            IntensityTable decoded and appended with Features.TARGET and Features.QUALITY values.
+
+        """
+
+        # Rename n_processes (trying to stay consistent between starFISH's _ variables and my camel case ones)
+        numJobs = n_processes
+
+        # If using an search radius exactly equal to a possible distance between two pixels (ex: 1), some 
+        # distances will be calculated as slightly less than their exact distance (either due to rounding or
+        # precision) so search radius needs to be slightly increased to ensure this doesn't happen
+        self.searchRadius += 0.001
+
+        # Initialize ray for multi_processing
+        ray.init(num_cpus=numJobs)
+        
+        # Create dictionary where keys are round labels and the values are pandas dataframes containing information on
+        # the spots found in that round
+        spotTables = _merge_spots_by_round(spots)
+        
+        # If user did not specify the filterRounds variable (it will have default value -1) change it to either one less
+        # than the number of rounds if roundOmitNum is 0 or the number of rounds minus the roundOmitNum if roundOmitNum > 0
+        if self.filterRounds == None:
+            if self.roundOmitNum == 0:
+                self.filterRounds = len(spotTables) - 1
+            else:
+                self.filterRounds = len(spotTables) - self.roundOmitNum
+        
+
+        # Create dictionary of neighbors (within the search radius) in other rounds for each spot
+        neighborDict = findNeighbors(spotTables, self.searchRadius)
+        
+        # Create dictionary with mapping from spot id in spotTables to channel number and one with spot
+        # coordinates for fast access
+        channelDict = {}
+        spotCoords = {}
+        for r in [*spotTables]:
+            channelDict[r] = spotTables[r]['c'].to_dict()
+            spotCoords[r] = spotTables[r][['z','y','x']].T.to_dict()            
+        
+        # Set list of round omission numbers to loop through
+        roundOmits = range(self.roundOmitNum+1)
+        
+        # Decode for each round omission number 
+        allCodes = pd.DataFrame()
+        for currentRoundOmitNum in roundOmits:
+            decodedTables = {}
+            for r in range(len(spotTables)):
+                roundData = deepcopy(spotTables[r])
+                
+                # Create dictionary of dataframes (based on perRoundSpotTables data) that contains additional columns for each spot
+                # containing all the possible barcodes that could be constructed from the neighbors of that spot
+                roundData = buildBarcodes(roundData, neighborDict, currentRoundOmitNum, channelDict, r, numJobs)
+                
+                # Match possible barcodes to codebook and add new columns with info about barcodes that had a codebook match
+                roundData = decoder(roundData, self.codebook, currentRoundOmitNum, r, numJobs)
+
+                # Choose most likely barcode for each spot in each round by find the possible decodable barcode with the least
+                # spatial variance between the spots that made up the barcode
+                roundData = distanceFilter(roundData, spotCoords, r, numJobs)
+                
+                # Assign to DecodedTables dictionary
+                decodedTables[r] = roundData
+
+            # Turn spot table dictionary into single table, filter barcodes by round frequency, add additional information,
+            # and choose between barcodes that use the same spot(s)
+            finalCodes = cleanup(decodedTables, spotCoords, self.filterRounds)
+            
+            # If this is not the last round omission number to run, remove spots that have just been found to be in
+            # passing barcodes from neighborDict so they are not used for the next round omission number
+            if currentRoundOmitNum != roundOmits[-1]:
+                neighborDict = removeUsedSpots(finalCodes, neighborDict)
+            
+            # Append found codes to allCodes table
+            allCodes = allCodes.append(finalCodes).reset_index(drop=True)
+        
+        # Shutdown ray
+        ray.shutdown()
+
+
+        # Create and fill in intensity table
+        channels=spots.ch_labels
+        rounds=spots.round_labels    
+
+        # create empty IntensityTable filled with np.nan
+        data = np.full((len(allCodes), len(channels), len(rounds)), fill_value=np.nan)
+        dims = (Features.AXIS, Axes.CH.value, Axes.ROUND.value)
+        centers = allCodes['center']
+        coords: Mapping[Hashable, Tuple[str, Any]] = {
+            Features.SPOT_RADIUS: (Features.AXIS, np.full(len(allCodes), 1)),
+            Axes.ZPLANE.value: (Features.AXIS, np.asarray([round(c[2]) for c in centers])),
+            Axes.Y.value: (Features.AXIS, np.asarray([round(c[1]) for c in centers])),
+            Axes.X.value: (Features.AXIS, np.asarray([round(c[0]) for c in centers])),
+            Features.SPOT_ID: (Features.AXIS, np.arange(len(allCodes))),
+            Features.AXIS: (Features.AXIS, np.arange(len(allCodes))),
+            Axes.ROUND.value: (Axes.ROUND.value, rounds),
+            Axes.CH.value: (Axes.CH.value, channels)
+        }
+        intensity_table = IntensityTable(data=data, dims=dims, coords=coords)
+
+        # Fill in data values
+        table_codes = []
+        for i in range(len(allCodes)):
+            code = []
+            for ch in allCodes.loc[i, 'best_barcodes']:
+                # If a round is not used, row will be all zeros
+                code.append(np.asarray([0 if j != ch else 1 for j in range(len(channels))]))
+            table_codes.append(np.asarray(code).T)
+        intensity_table.values = np.asarray(table_codes)
+        intensity_table = transfer_physical_coords_to_intensity_table(intensity_table=intensity_table, spots=spots)
+        intensities = intensity_table.transpose('features', 'r', 'c')
+
+        self.codebook._validate_decode_intensity_input_matches_codebook_shape(intensities)
+
+        # Create DecodedIntensityTable
+        result=DecodedIntensityTable.from_intensity_table(
+            intensities,
+            targets=(Features.AXIS, allCodes['best_targets'].astype('U')),
+            distances=(Features.AXIS, allCodes["best_distances"]),
+            passes_threshold=(Features.AXIS, np.full(len(allCodes), True)),
+            filter_tally=(Features.AXIS, allCodes['rounds_used']))
+
+
+        return result

--- a/starfish/core/spots/DecodeSpots/check_all_decoder.py
+++ b/starfish/core/spots/DecodeSpots/check_all_decoder.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from typing import Mapping, Hashable, Tuple, Any
 import ray
 import pandas as pd
 import numpy as np
@@ -14,67 +14,79 @@ from starfish.types import Axes, Features
 from ._base import DecodeSpotsAlgorithm
 
 
-from .check_all_funcs import findNeighbors, buildBarcodes, decoder, distanceFilter, cleanup, removeUsedSpots
+from .check_all_funcs import findNeighbors, buildBarcodes, decoder, distanceFilter, cleanup, \
+    removeUsedSpots
 from .util import _merge_spots_by_round
 
 
 class CheckAll(DecodeSpotsAlgorithm):
     """
-    Decode spots by generating all possible combinations of spots to form barcodes given a radius distance that 
-    spots must be from each other in order to form a barcode. Then chooses the best set of nonoverlapping spot
-    combinations by choosing the ones with the least spatial variance of their spot coordinates and are also found
-    to be best for multiple spots in the barcode (see algorithm below). Allows for error correction rounds.
+    Decode spots by generating all possible combinations of spots to form barcodes given a radius
+    distance that spots must be from each other in order to form a barcode. Then chooses the best
+    set of nonoverlapping spot combinations by choosing the ones with the least spatial variance
+    of their spot coordinates and are also found to be best for multiple spots in the barcode
+    (see algorithm below). Allows for error correction rounds.
 
     (see input parmeters below)
-    1. For each spot in each round, find all neighbors in other rounds that are within the search radius
-	2. For each spot in each round, build all possible full length barcodes based on the channel labels of the spot's 
-	neighbors and itself
-	3. Drop barcodes that don't have a matching target in the codebook
-	4. Choose the "best" barcode of each spot's possible target matching barcodes by calculating the sum of variances 
-	for each of the spatial coordinates of the spots that make up each barcode and choosing the minimum distance barcode 
-	(if there is a tie, they are all dropped as ambiguous). Each spot is assigned a "best" barcode in this way.
-	5. Only keep barcodes/targets that were found as "best" in a certain number of the rounds (determined by filter_rounds
-	parameter)
-	6. If a specific spot is used in more than one of the remaining barcodes, the barcode with the higher spatial variance
-	between it's spots is dropped (ensures each spot is only used once)
-	(End here if number of error_rounds = 0)
-	7. Remove all spots used in decoded targets that passed the previous filtering steps from the original set of spots
-	8. Rerun steps 2-5 for barcodes that use less than the full set of rounds for codebook matching (how many rounds can be
-	dropped determined by error_rounds parameter)
+    1. For each spot in each round, find all neighbors in other rounds that are within the search
+    radius
+    2. For each spot in each round, build all possible full length barcodes based on the channel
+    labels of the spot's neighbors and itself
+    3. Drop barcodes that don't have a matching target in the codebook
+    4. Choose the "best" barcode of each spot's possible target matching barcodes by calculating
+    the sum of variances for each of the spatial coordinates of the spots that make up each barcode
+    and choosing the minimum distance barcode (if there is a tie, they are all dropped as
+    ambiguous). Each spot is assigned a "best" barcode in this way.
+    5. Only keep barcodes/targets that were found as "best" in a certain number of the rounds
+    (determined by filter_rounds parameter)
+    6. If a specific spot is used in more than one of the remaining barcodes, the barcode with the
+    higher spatial variance between it's spots is dropped (ensures each spot is only used once)
+    (End here if number of error_rounds = 0)
+    7. Remove all spots used in decoded targets that passed the previous filtering steps from the
+    original set of spots
+    8. Rerun steps 2-5 for barcodes that use less than the full set of rounds for codebook
+    matching (how many rounds can be dropped determined by error_rounds parameter)
 
     Parameters
     ----------
     codebook : Codebook
         Contains codes to decode IntensityTable
-    search_radius : Optional[float]
+    search_radius : float
         Number of pixels over which to search for spots in other rounds and channels.
-    filterRounds : Optional[int]
-        Number of rounds that a barcode must be identified in to pass filters (higher = more stringent filtering),
-        default = #rounds - 1  or #rounds - error_rounds if error_rounds > 0
-    error_rounds : Optional[int]
-        Maximum hamming distance a barcode can be from it's target in the codebook and still be uniquely identified
-        (i.e. number of error correction rounds in each the experiment)
+    filterRounds : int
+        Number of rounds that a barcode must be identified in to pass filters (higher = more
+        stringent filtering), default = #rounds - 1  or #rounds - error_rounds if error_rounds > 0
+    error_rounds : int
+        Maximum hamming distance a barcode can be from it's target in the codebook and still be
+        uniquely identified (i.e. number of error correction rounds in each the experiment)
     """
 
     def __init__(
             self,
             codebook: Codebook,
-            filter_rounds: Optional[int]=None,
-            search_radius: Optional[float]=3,
-            error_rounds: Optional[int]=0):
+            filter_rounds: int=None,
+            search_radius: float=3,
+            error_rounds: int=0):
         self.codebook = codebook
         self.filterRounds = filter_rounds
         self.searchRadius = search_radius
         self.errorRounds = error_rounds
 
-    def run(self, spots: SpotFindingResults, n_processes: Optional[int]=1, *args) -> DecodedIntensityTable:
+    def run(self,
+            spots: SpotFindingResults,
+            n_processes: int=1,
+            *args) -> DecodedIntensityTable:
         """
-        Decode spots by finding the set of nonoverlapping barcodes that have the minimum spatial variance within each barcode
+        Decode spots by finding the set of nonoverlapping barcodes that have the minimum spatial
+        variance within each barcode
 
         Parameters
         ----------
         spots: SpotFindingResults
             A Dict of tile indices and their corresponding measured spots
+
+        n_processes: int
+            Number of threads to run decoder in parallel with
 
         Returns
         -------
@@ -83,88 +95,95 @@ class CheckAll(DecodeSpotsAlgorithm):
 
         """
 
-        # Rename n_processes (trying to stay consistent between starFISH's _ variables and my camel case ones)
+        # Rename n_processes (trying to stay consistent between starFISH's _ variables and my
+        # camel case ones)
         numJobs = n_processes
 
-        # If using an search radius exactly equal to a possible distance between two pixels (ex: 1), some 
-        # distances will be calculated as slightly less than their exact distance (either due to rounding or
-        # precision errors) so search radius needs to be slightly increased to ensure this doesn't happen
+        # If using an search radius exactly equal to a possible distance between two pixels
+        # (ex: 1), some distances will be calculated as slightly less than their exact distance
+        # (either due to rounding or precision errors) so search radius needs to be slightly
+        # increased to ensure this doesn't happen
         self.searchRadius += 0.001
 
         # Initialize ray for multi_processing
         ray.init(num_cpus=numJobs)
-        
-        # Create dictionary where keys are round labels and the values are pandas dataframes containing information on
-        # the spots found in that round
+
+        # Create dictionary where keys are round labels and the values are pandas dataframes
+        # containing information on the spots found in that round
         spotTables = _merge_spots_by_round(spots)
-        
-        # If user did not specify the filterRounds variable (it will have default value None), change it to either one less
-        # than the number of rounds if roundOmitNum is 0 or the number of rounds minus the roundOmitNum if roundOmitNum > 0
-        if self.filterRounds == None:
-            if self.roundOmitNum == 0:
+
+        # If user did not specify the filterRounds variable (it will have default value None),
+        # change it to either one less than the number of rounds if errorRounds is 0 or the
+        # number of rounds minus the errorRounds if errorRounds > 0
+        if self.filterRounds is None:
+            if self.errorRounds == 0:
                 self.filterRounds = len(spotTables) - 1
             else:
                 self.filterRounds = len(spotTables) - self.errorRounds
-        
 
         # Create dictionary of neighbors (within the search radius) in other rounds for each spot
         neighborDict = findNeighbors(spotTables, self.searchRadius)
-        
-        # Create dictionaries with mapping from spot id (row index) in spotTables to channel number and one with spot
-        # coordinates for fast access
+
+        # Create dictionaries with mapping from spot id (row index) in spotTables to channel
+        # number and one with spot coordinates for fast access
         channelDict = {}
         spotCoords = {}
         for r in [*spotTables]:
             channelDict[r] = spotTables[r]['c'].to_dict()
-            spotCoords[r] = spotTables[r][['z','y','x']].T.to_dict()            
-        
+            spotCoords[r] = spotTables[r][['z', 'y', 'x']].T.to_dict()
+
         # Set list of round omission numbers to loop through
-        roundOmits = range(self.errorRounds+1)
-        
+        roundOmits = range(self.errorRounds + 1)
+
         # Decode for each round omission number, store results in allCodes table
         allCodes = pd.DataFrame()
         for currentRoundOmitNum in roundOmits:
 
-        	# Chooses best barcode for all spots in each round sequentially (possible barcode space can become quite large which 
-        	# can increase memory needs so I do it this way so we only need to store all potential barcodes that originate from 
-        	# one round at a time)
+            # Chooses best barcode for all spots in each round sequentially (possible barcode
+            # space can become quite large which can increase memory needs so I do it this way so
+            # we only need to store all potential barcodes that originate from one round at a
+            # time)
             decodedTables = {}
             for r in range(len(spotTables)):
                 roundData = deepcopy(spotTables[r])
-                
-                # Create dictionary of dataframes (based on spotTables data) that contains additional columns for each spot
-                # containing all the possible barcodes that could be constructed from the neighbors of that spot
-                roundData = buildBarcodes(roundData, neighborDict, currentRoundOmitNum, channelDict, r, numJobs)
-                
-                # Match possible barcodes to codebook and add new columns with info about barcodes that had a codebook match
+
+                # Create dictionary of dataframes (based on spotTables data) that contains
+                # additional columns for each spot containing all the possible barcodes that
+                # could be constructed from the neighbors of that spot
+                roundData = buildBarcodes(roundData, neighborDict, currentRoundOmitNum,
+                                          channelDict, r, numJobs)
+
+                # Match possible barcodes to codebook and add new columns with info about barcodes
+                # that had a codebook match
                 roundData = decoder(roundData, self.codebook, currentRoundOmitNum, r, numJobs)
 
-                # Choose most likely barcode for each spot in each round by find the possible decodable barcode with the least
-                # spatial variance between the spots that made up the barcode
+                # Choose most likely barcode for each spot in each round by find the possible
+                # decodable barcode with the least spatial variance between the spots that made up
+                # the barcode
                 roundData = distanceFilter(roundData, spotCoords, r, numJobs)
-                
+
                 # Assign to DecodedTables dictionary
                 decodedTables[r] = roundData
 
-            # Turn spot table dictionary into single table, filter barcodes by round frequency, add additional information,
-            # and choose between barcodes that have overlapping spots
+            # Turn spot table dictionary into single table, filter barcodes by round frequency, add
+            # additional information, and choose between barcodes that have overlapping spots
             finalCodes = cleanup(decodedTables, spotCoords, self.filterRounds)
-            
-            # If this is not the last round omission number to run, remove spots that have just been found to be in
-            # passing barcodes from neighborDict so they are not used for the next round omission number
+
+            # If this is not the last round omission number to run, remove spots that have just
+            # been found to be in passing barcodes from neighborDict so they are not used for the
+            # next round omission number
             if currentRoundOmitNum != roundOmits[-1]:
                 neighborDict = removeUsedSpots(finalCodes, neighborDict)
-            
+
             # Append found codes to allCodes table
             allCodes = allCodes.append(finalCodes).reset_index(drop=True)
-        
+
         # Shutdown ray
         ray.shutdown()
 
-
         # Create and fill in intensity table
-        channels=spots.ch_labels
-        rounds=spots.round_labels    
+        channels = spots.ch_labels
+        rounds = spots.round_labels
 
         # create empty IntensityTable filled with np.nan
         data = np.full((len(allCodes), len(channels), len(rounds)), fill_value=np.nan)
@@ -180,7 +199,7 @@ class CheckAll(DecodeSpotsAlgorithm):
             Axes.ROUND.value: (Axes.ROUND.value, rounds),
             Axes.CH.value: (Axes.CH.value, channels)
         }
-        intensity_table = IntensityTable(data=data, dims=dims, coords=coords)
+        int_table = IntensityTable(data=data, dims=dims, coords=coords)
 
         # Fill in data values
         table_codes = []
@@ -190,20 +209,20 @@ class CheckAll(DecodeSpotsAlgorithm):
                 # If a round is not used, row will be all zeros
                 code.append(np.asarray([0 if j != ch else 1 for j in range(len(channels))]))
             table_codes.append(np.asarray(code).T)
-        intensity_table.values = np.asarray(table_codes)
-        intensity_table = transfer_physical_coords_to_intensity_table(intensity_table=intensity_table, spots=spots)
-        intensities = intensity_table.transpose('features', 'r', 'c')
+        int_table.values = np.asarray(table_codes)
+        int_table = transfer_physical_coords_to_intensity_table(intensity_table=int_table,
+                                                                spots=spots)
+        intensities = int_table.transpose('features', 'r', 'c')
 
         # Validate results are correct shape
         self.codebook._validate_decode_intensity_input_matches_codebook_shape(intensities)
 
         # Create DecodedIntensityTable
-        result=DecodedIntensityTable.from_intensity_table(
+        result = DecodedIntensityTable.from_intensity_table(
             intensities,
             targets=(Features.AXIS, allCodes['best_targets'].astype('U')),
             distances=(Features.AXIS, allCodes["best_distances"]),
             passes_threshold=(Features.AXIS, np.full(len(allCodes), True)),
             rounds_used=(Features.AXIS, allCodes['rounds_used']))
-
 
         return result

--- a/starfish/core/spots/DecodeSpots/check_all_funcs.py
+++ b/starfish/core/spots/DecodeSpots/check_all_funcs.py
@@ -213,7 +213,7 @@ def decoder(roundData: pd.DataFrame,
             codebook: Codebook,
             roundOmitNum: int,
             currentRound: int,
-            numJobs: int) -> pd.DataFrane:
+            numJobs: int) -> pd.DataFrame:
 
     '''
     Function that takes spots tables with possible barcodes added and matches each to the codebook

--- a/starfish/core/spots/DecodeSpots/check_all_funcs.py
+++ b/starfish/core/spots/DecodeSpots/check_all_funcs.py
@@ -1,0 +1,695 @@
+# General modules
+import time # TODO: delete for final version
+import pickle # TODO: delete for final version
+from collections import Counter
+from scipy.spatial import cKDTree
+from copy import deepcopy
+from itertools import product, chain, permutations, combinations
+import math
+from collections import defaultdict
+from typing import Any, Hashable, Mapping, Tuple
+import ray
+import numpy as np
+import pandas as pd
+import xarray as xr
+import warnings
+warnings.filterwarnings('ignore')
+
+# starFISH stuff
+from starfish.types import Axes, Coordinates, CoordinateValue, Features
+from starfish.core.codebook.codebook import Codebook
+
+
+def findNeighbors(spotTables: pd.DataFrame,
+                  searchRadius: float) -> dict:
+    
+    '''
+    Function that takes spatial information from the spot tables from each round and creates a dictionary that contains
+    all the neighbors for each spot in other rounds that are within the search radius.
+    
+    Parameters
+    ----------
+        spotTables : pd.DataFrame
+            Dictionary with round labels as keys and pandas dataframes containing spot information for its key round
+            as values (result of _merge_spots_by_round function)
+        
+        searchRadius : float
+            Distance that spots can be from each other and still form a barcode
+        
+        roundLabels : list
+            List of round index labels (can extract using .round_lables on a SpotFindingResults object)
+
+    Returns
+    -------
+        dict: a dictionary with the following structure:
+            {round: {
+                spotID in round: {
+                    neighborRound:
+                        [list of spotIDs in neighborRound within searchRadius of spotID in round]  
+                    }
+                }
+            }
+    '''
+
+    # Create empty neighbor dictionary
+    neighborDict = {}
+    for r in spotTables:
+        neighborDict[r] = {i: defaultdict(list, {r: [i]}) for i in range(len(spotTables[r]))}
+
+    # For each pairing of rounds, find all mutual neighbors within the search radius for each spot and assigns them
+    # in the neighborDict dictionary
+    # Number assigned each spot in neighborDict is the index of it's original location in spotTables (also its spot_id)
+    # and is used to track each spot uniquely throughout
+    for i,r1 in enumerate(range((len(spotTables)))):
+        tree = cKDTree(spotTables[r1][['z', 'y', 'x']])
+        for r2 in list(range((len(spotTables))))[i+1:]:
+            allNeighbors = tree.query_ball_point(spotTables[r2][['z', 'y', 'x']], searchRadius)
+            for j,neighbors in enumerate(allNeighbors):
+                if neighbors != []:
+                    for neighbor in neighbors:
+                        neighborDict[r1][neighbor][r2].append(j)
+                        neighborDict[r2][j][r1].append(neighbor)
+
+    return neighborDict
+    
+
+def buildBarcodes(roundData: dict,
+                  neighborDict: dict,
+                  roundOmitNum: int,
+                  channelDict: dict,
+                  currentRound: int,
+                  numJobs: int) -> dict:
+    
+    '''
+    Function that creates a copy of the spotTables dictionary and adds to it's tables all the possible barcodes
+    that could be formed using the neighbors of each spot, spots without enough neighbors to form a barcode are
+    dropped.
+    
+    Parameters
+    ----------
+        spotTables : dict
+            Dictionary with round labels as keys and pandas dataframes containing spot information for its key round
+            as values (result of _merge_spots_by_round function)
+        
+        neighborDict : dict
+            Dictionary that contains all the neighbors for each spot in other rounds that are within the search radius
+        
+        roundOmitNum : int
+            Maximum hamming distance a barcode can be from it's target in the codebook and still be uniquely identified
+            (i.e. number of error correction rounds in each the experiment)
+        
+        numJobs : int
+            Number of CPU threads to use in parallel
+            
+    Returns
+    -------
+        dict : Copy of spotTables with additional columns in each table which lists all possible barcodes
+                       that could be made from each spot's neighbors
+    
+    '''
+    
+    
+    @ray.remote
+    def barcodeBuildFunc(data: pd.DataFrame,
+                         channelDict: dict,
+                         rang: tuple,
+                         roundOmitNum: int,
+                         roundNum: int):
+        '''
+        Subfunction to buildBarcodes that allows it to run in parallel chunks using ray
+        
+        Parameters
+        ----------
+            data : pd.DataFrame
+                Spot table from barcodeTables for the current round
+                
+            channelDict : dict
+                Dictionary mapping spot IDs to their channels labels
+            
+            rang : tuple
+                Range of indices to build barcodes for in the current data object
+            
+            roundOmitNum : int
+                Maximum hamming distance a barcode can be from it's target in the codebook and still be uniquely
+                identified (i.e. number of error correction rounds in each the experiment)
+            
+        Returns
+        -------
+            tuple : First element is a list of the possible spot codes while the second element is a list of the
+                    possible barcodes
+        '''
+
+         # Build barcodes from neighbors
+        # spotCodes are the ordered spot IDs of the spots making up each barcode while barcodes are the corresponding
+        # channel labels, need spotCodes so each barcode can have a unique identifier
+        allSpotCodes = []
+        allBarcodes = []
+        allNeighbors = list(data['neighbors'])[rang[0]: rang[1]]
+        for i in range(len(allNeighbors)):
+            neighbors = deepcopy(allNeighbors[i])
+            neighborLists = []    
+            for rnd in range(roundNum):
+                # Adds a -1 to each round of the neighbors dictionary (allows barcodes with dropped rounds to
+                # be created)
+                if roundOmitNum > 0:
+                    neighbors[rnd].append(-1)
+                neighborLists.append(neighbors[rnd])
+            # Creates all possible spot code combinations from neighbors
+            codes = list(product(*neighborLists))
+            # Only save the ones with the correct number of dropped rounds
+            spotCodes = [code for code in codes if Counter(code)[-1] == roundOmitNum]
+            # Create barcodes from spot codes using the mapping from spot ID to channel
+            barcodes = []
+            for spotCode in spotCodes:
+                barcode = []
+                for spotInd in range(len(spotCode)):
+                    if spotCode[spotInd] == -1:
+                        barcode.append(-1)
+                    else:
+                        barcode.append(channelDict[spotInd][spotCode[spotInd]])
+                barcodes.append(tuple(barcode))
+
+            allBarcodes.append(barcodes)
+            allSpotCodes.append(spotCodes)
+
+        return (allSpotCodes, allBarcodes)
+
+    # Only keep spots that have enough neighbors to form a barcode (determined by the total number of round and the
+    # number of rounds that can be omitted from each code)
+    passingSpots = {}
+    roundNum = len(neighborDict)
+    for key in neighborDict[currentRound]:
+        if len(neighborDict[currentRound][key]) >= roundNum-roundOmitNum:
+            passingSpots[key] = neighborDict[currentRound][key]
+    passed = list(passingSpots.keys())
+    roundData = roundData.iloc[passed]
+    roundData['neighbors'] = [passingSpots[i] for i in roundData.index]
+    roundData = roundData.reset_index(drop=True)
+
+
+    # Find all possible barcodes for the spots in each round by splitting each round's spots into numJob chunks and
+    # constructing each chunks barcodes in parallel
+
+
+    # Save the current round's data table and the channelDict to ray memory
+    dataID = ray.put(roundData)
+    channelDictID = ray.put(channelDict)
+
+    # Calculates index ranges to chunk data by
+    ranges = [0]
+    for i in range(1, numJobs+1):
+        ranges.append(int((len(roundData)/numJobs)*i))
+
+    # Run in parallel
+    results = [barcodeBuildFunc.remote(dataID, channelDictID, (ranges[i], ranges[i+1]), roundOmitNum, roundNum) for i in range(len(ranges[:-1]))]
+    rayResults = ray.get(results)
+
+    # Add possible barcodes and spot codes (same order) to spot dictionary (must chain results rom different jobs
+    # together)
+    roundData['spot_codes'] = list(chain(*[job[0] for job in rayResults]))
+    roundData['barcodes'] = list(chain(*[job[1] for job in rayResults]))
+    
+    return roundData
+
+def decoder(roundData: dict,
+            codebook: Codebook,
+            roundOmitNum: int,
+            currentRound: int,
+            numJobs: int):
+    
+    '''
+    Function that takes spots tables with possible barcodes added and matches each to the codebook to identify any
+    matches. Matches are added to the spot tables and spots without any matches are dropped
+    
+    Parameters
+    ----------
+        barcodeTables : dict
+            Dictionary with modified spot tables containing all possible barcodes that can be made from each spot
+        
+        codebook : Codebook
+            starFISH Codebook object containg the barcode information for the experiment
+            
+        roundOmitNum : int
+            Number of rounds that can be dropped from each barcode
+            
+        numJobs : int
+            Number of CPU threads to use in parallel
+            
+    Returns
+    -------
+        dict : barcodeTables dictionary with added columns with information on decodable barcodes
+    '''
+
+    def generateRoundPermutations(size: int, roundOmitNum: int) -> list:
+        '''
+        Creates list of lists of logicals detailing the rounds to be used for decoding based on the current roundOmitNum
+        
+        Parameters
+        ----------
+            size : int
+                Number of rounds in experiment
+                
+            roundOmitNum: int
+                Number of rounds that can be dropped from each barcode
+                
+        Returns
+        -------
+            list : list of lists of logicals detailing the rounds to be used for decoding based on the current roundOmitNum
+        '''
+        if roundOmitNum == 0:
+            return [tuple([True]*size)]
+        else:
+            return sorted(set(list(permutations([False]*roundOmitNum + [True]*(size-roundOmitNum)))))
+
+
+    @ray.remote
+    def decodeFunc(data: pd.DataFrame,
+                   roundPermutations: list,
+                   permutationCodes: dict,
+                   rnd: int) -> tuple:
+        
+        '''
+        Subfunction for decoder that allows it to run in parallel chunks using ray
+        
+        Parameters
+        ----------
+            data : pd.DataFrame
+                Spot table from barcodeTables for the current round
+                
+            roundPermutations : list
+                List of logicals from generateRoundPermutations that details the rounds to use in decoding
+                
+            permutationCodes : dict
+                Dictionary containing barcode information for each roundPermutation
+            
+            rang : tuple
+                Range of indices to decode barcodes for in the current data object
+                
+            rnd : int
+                Current round being decoded
+                
+        Returns
+        -------
+            tuple : First element is a list of all decoded targets, second element is a list of all decoded barcodes,
+                    third element is a list of all decoded spot codes, and the fourth element is a list of rounds
+                    that were omitted for each decoded barcode
+        '''
+
+        # Goes through all possible decodings of each spot (ensures each spot is only looked up once)
+        allTargets = []
+        allDecodedBarcodes = []
+        allDecodedSpotCodes = []
+        allRoundOmit = []
+        allBarcodes = list(data['barcodes'])
+        allSpotCodes = list(data['spot_codes'])
+        for i in range(len(allBarcodes)):
+            targets = []
+            decodedBarcodes = []
+            decodedSpotCodes = []
+            roundOmit = []
+            fullBarcodes = allBarcodes[i]
+            fullSpotCodes = allSpotCodes[i]
+            
+            for currentRounds in roundPermutations:
+
+                # Set omittedRound to the round being dropped, if no round is dropped omittedRound becomes -1
+                if 0 in currentRounds:
+                    omittedRound = np.argwhere([not cr for cr in currentRounds])[0][0]
+                else:
+                    omittedRound = -1
+
+                # Only try to decode barcodes for this spot if the current round is being omitted from the barcodes, we 
+                # don't want to try to assign barcodes for spots from that round 
+                if rnd != omittedRound:
+                    # Modify spot codes and barcodes so that they match the current set of rounds being used for decoding
+                    if omittedRound != -1:
+                        spotCodes = [code for code in np.asarray([np.asarray(spotCode)[list(currentRounds)] for spotCode in fullSpotCodes]) if -1 not in code]
+                        barcodes = [code for code in np.asarray([np.asarray(barcode)[list(currentRounds)] for barcode in fullBarcodes]) if -1 not in code]
+                    else:
+                        spotCodes = fullSpotCodes
+                        barcodes = fullBarcodes
+                    # If all barcodes omit a round other than omittedRound, barcodes will be empty
+                    if len(barcodes) > 0:
+                        # Tries to find a match to each possible barcode from the spot
+                        for j,barcode in enumerate(barcodes):
+                            try:
+                                # Try to assign target by using barcode as key in permutationsCodes dictionary for
+                                # current set of rounds. If there is no barcode match, it will error and go to the except
+                                # and if it succeeds it will add the data to the other lists for this barcode
+                                targets.append(permutationCodes[currentRounds][tuple(barcode)])
+                                decodedBarcodes.append(barcode)
+                                decodedSpotCodes.append(list(spotCodes[j]))
+                                roundOmit.append(omittedRound)
+                            except:
+                                pass
+            allTargets.append(targets)
+            allDecodedBarcodes.append(decodedBarcodes)
+            allDecodedSpotCodes.append(decodedSpotCodes)
+            allRoundOmit.append(roundOmit)
+
+        return (allTargets, allDecodedBarcodes, allDecodedSpotCodes, allRoundOmit)
+
+    # Create list of logical arrays corresponding to the round sets being used to decode
+    roundPermutations = generateRoundPermutations(codebook.sizes[Axes.ROUND], roundOmitNum) 
+
+
+    # Create dictionary where the keys are the different round sets that can be used for decoding and the values
+    # are the modified codebooks corresponding to the rounds used
+    permCodeDict = {}
+    for currentRounds in roundPermutations:
+        codes = codebook.argmax(Axes.CH.value)
+        currentCodes = codes.sel(r=list(currentRounds)) 
+        currentCodes.values = np.ascontiguousarray(currentCodes.values)
+        permCodeDict[currentRounds] = dict(zip([tuple(code) for code in currentCodes.data], currentCodes['target'].data))
+
+
+    # Goes through each round in filtered_prsr and tries to decode each spot's barcodes
+    roundNum = len(codebook['r'])
+
+
+    # Put data table and permutations codes dictionary in ray storage
+    permutationCodesID = ray.put(permCodeDict)
+
+    # Calculates index ranges to chunk data by
+    ranges = [0]
+    for i in range(1, numJobs+1):
+        ranges.append(int((len(roundData)/numJobs)*i))
+    chunkedData = []
+    for i in range(len(ranges[:-1])):
+        chunkedData.append(deepcopy(roundData[ranges[i]:ranges[i+1]]))
+
+    # Run in parallel
+    results = [decodeFunc.remote(chunkedData[i], roundPermutations, permutationCodesID, currentRound) for i in range(len(ranges[:-1]))]
+    rayResults = ray.get(results)
+
+    # Update table
+    roundData['targets'] = list(chain(*[job[0] for job in rayResults]))
+    roundData['decoded_barcodes'] = list(chain(*[job[1] for job in rayResults]))
+    roundData['decoded_spot_codes'] = list(chain(*[job[2] for job in rayResults]))
+    roundData['omitted_round'] = list(chain(*[job[3] for job in rayResults]))
+
+    # Drop barcodes and spot_codes column (saves memory)
+    roundData = roundData.drop(['neighbors', 'spot_codes', 'barcodes'], axis=1)
+
+        
+    # Remove rows that have no decoded barcodes and add -1 spacer back into partial barcodes/spot codes so we can
+    # easily tell which round each spot ID is from
+    keep = []
+    allBarcodes = []
+    allSpotCodes = []
+    roundData = roundData[roundData['targets'].astype(bool)].reset_index(drop=True)
+    dataBarcodes = roundData['decoded_barcodes']
+    dataSpotCodes = roundData['decoded_spot_codes']
+    dataOmittedRounds = roundData['omitted_round']
+    for i in range(len(roundData)):
+        barcodes = [list(code) for code in dataBarcodes[i]]
+        spotCodes = [list(code) for code in dataSpotCodes[i]]
+        omittedRounds = dataOmittedRounds[i]
+        if omittedRounds[0] != -1:
+            barcodes = [barcodes[j][:omittedRounds[j]] + [-1] + barcodes[j][omittedRounds[j]:] for j in range(len(barcodes))]
+            spotCodes = [spotCodes[j][:omittedRounds[j]] + [-1] + spotCodes[j][omittedRounds[j]:] for j in range(len(barcodes))]
+        allBarcodes.append(barcodes)
+        allSpotCodes.append(spotCodes)
+    roundData['decoded_barcodes'] = allBarcodes
+    roundData['decoded_spot_codes'] = allSpotCodes
+    
+    return roundData
+
+def distanceFilter(roundData: dict,
+                   spotCoords: dict,
+                   currentRound: int,
+                   numJobs: int) -> tuple:
+    '''
+    Function that chooses between the best barcode for each spot from the set of decodable barcodes. Does this by
+    choosing the barcode with the least spatial variance among the spots that make it up. If there is a tie, the spot
+    is dropped as ambiguous
+    
+    Parameters
+    ----------
+        decodedTables : dict
+            Dictionary containing modified spot tables with decoded barcode information
+            
+        spotTables : dict
+            Original spot tables dictionary without any added columns
+        
+        numJobs : int
+            Number of CPU threads to use in parallel
+    
+    Returns
+    -------
+        tuple : First element is a modified version of decodedTables with added columns to tables with info on the 
+                "best" barcode found for each spot and the second element is a dictionary containing spatial locations
+                for spots by their IDs in the original spotTables object    
+    '''
+    
+    @ray.remote
+    def distanceFunc(subSpotCodes: list, spotCoords: dict) -> list:
+        '''
+        Subfunction for distanceFilter to allow it to run in parallel using ray
+        
+        Parameters
+        ----------
+            subSpotCodes : list
+                Chunk of full list of spot codes for the current round to calculate the spatial variance for
+            
+            spotCoords : dict
+                Dictionary containing spatial locations for spots by their IDs in the original spotTables object
+        
+        
+        Returns
+        -------
+            list: list of spatial variances for the current chunk of spot codes
+        
+        '''
+        
+        # Calculate spatial variances for current chunk of spot codes
+        allDistances = []
+        for spotCodes in subSpotCodes: 
+            distances = []
+            for s,spotCode in enumerate(spotCodes):
+                coords = []
+                for j,spot in enumerate(spotCode):
+                    if spot != -1:
+                        # Extract spot coordinates from spotCoords
+                        z = spotCoords[j][spot]['z']
+                        y = spotCoords[j][spot]['y']
+                        x = spotCoords[j][spot]['x']
+                        coords.append([z, y, x])
+                coords = np.asarray(coords)
+                # Distance is calculate as the sum of variances of the coordinates along each axis
+                distances.append(sum(np.var(coords, axis = 0)))
+            allDistances.append(distances)
+        return allDistances
+
+
+    # Calculate the spatial variance for each decodable barcode for each spot in each round
+    allSpotCodes = roundData['decoded_spot_codes']
+
+
+    # Put spotCoords dictionary into ray memory
+    spotCoordsID = ray.put(spotCoords)
+
+    # Calculates index ranges to chunk data by
+    ranges = [0]
+    for i in range(1, numJobs):
+        ranges.append(int((len(roundData)/numJobs)*i))
+    ranges.append(len(roundData))
+    chunkedSpotCodes = [allSpotCodes[ranges[i]:ranges[i+1]] for i in range(len(ranges[:-1]))]
+
+    # Run in parallel using ray
+    results = [distanceFunc.remote(subSpotCodes, spotCoordsID) for subSpotCodes in chunkedSpotCodes]
+    rayResults = ray.get(results)
+
+    # Add distances to decodedTables as new column
+    roundData['distance'] = list(chain(*[job for job in rayResults]))
+        
+            
+
+    # Pick minimum distance barcode(s) for each spot
+    bestSpotCodes = []
+    bestBarcodes = []
+    bestTargets = []
+    bestDistances = []
+    dataSpotCodes = list(roundData['decoded_spot_codes'])
+    dataBarcodes = list(roundData['decoded_barcodes'])
+    dataDistances = list(roundData['distance'])
+    dataTargets = list(roundData['targets'])
+    for i in range(len(roundData)):
+        spotCodes = dataSpotCodes[i]
+        barcodes = dataBarcodes[i]
+        distances = dataDistances[i]
+        targets = dataTargets[i]
+        # If only one barcode to choose from, that one is picked as best
+        if len(distances) == 1:
+            bestSpotCodes.append(spotCodes)
+            bestBarcodes.append(barcodes)
+            bestTargets.append(targets)
+            bestDistances.append(distances)
+        # Otherwise find the minimum, and if there are multiple minimums
+        else:
+            minDist = 100
+            minCount = 0
+            for d,distance in enumerate(distances):
+                if distance < minDist:
+                    minDist = distance
+                    minCount = 1
+                    minInds = []
+                    minInds.append(d)
+                elif distance == minDist:
+                    minCount += 1
+                    minInds.append(d)
+            bestSpotCodes.append([spotCodes[i] for i in range(len(spotCodes)) if i in minInds])
+            bestBarcodes.append([barcodes[i] for i in range(len(barcodes)) if i in minInds])
+            bestTargets.append([targets[i] for i in range(len(targets)) if i in minInds])
+            bestDistances.append([distances[i] for i in range(len(distances)) if i in minInds])
+    # Create new columns with minimum distance barcode information
+    roundData['best_spot_codes'] = bestSpotCodes
+    roundData['best_barcodes'] = bestBarcodes
+    roundData['best_targets'] = bestTargets
+    roundData['best_distances'] = bestDistances
+
+    # Drop old columns
+    roundData = roundData.drop(['targets', 'decoded_barcodes', 'decoded_spot_codes', 'omitted_round'], axis=1)
+
+
+    # Only keep barcodes with only one minimum distance
+    keep = []
+    barcodes = roundData['best_barcodes']
+    for i in range(len(roundData)):
+        if len(barcodes[i]) == 1:
+            keep.append(i)
+    roundData = roundData.iloc[keep]
+    
+    return roundData
+    
+
+def cleanup(bestPerSpotTables: dict,
+            spotCoords: dict,
+            filterRounds: int) -> pd.DataFrame:
+    
+    '''
+    Function that combines all "best" codes for each spot in each round into a single table, filters them by their
+    frequency (with a user-defined threshold), chooses between overlapping codes (using the same distance function
+    as used earlier), and finally adds some additional information to the final set of barcodes
+    
+    Parameters
+    ----------
+        bestPerSpotTables : dict
+            Spot tables dictionary containing columns with information on the "best" barcode found for each spot
+        
+        spotCoords : dict
+            Dictionary containing spatial locations of spots
+        
+        filterRounds : int
+            Number of rounds that a barcode must be identified in to pass filters (higher = more stringent filtering),
+            default = 1 - #rounds  or 1 - roundOmitNum if roundOmitNum > 0
+            
+    Returns
+    -------
+        pd.DataFrame : Dataframe containing final set of codes that have passed all filters
+    
+    '''
+
+    # Create merged spot results dataframe containing the passing barcodes found in all the rounds
+    mergedCodes = pd.DataFrame()
+    roundNum = len(bestPerSpotTables)
+    for r in range(roundNum):
+        barcodes = bestPerSpotTables[r]['best_barcodes']
+        spotCodes = bestPerSpotTables[r]['best_spot_codes']
+        targets = bestPerSpotTables[r]['best_targets']
+        distances = bestPerSpotTables[r]['best_distances']
+        # Turn each barcode and spot code into a tuple so they can be used as dictionary keys
+        bestPerSpotTables[r]['best_barcodes'] = [tuple(barcode[0]) for barcode in barcodes]
+        bestPerSpotTables[r]['best_spot_codes'] = [tuple(spotCode[0]) for spotCode in spotCodes]
+        bestPerSpotTables[r]['best_targets'] = [target[0] for target in targets]
+        bestPerSpotTables[r]['best_distances'] = [distance[0] for distance in distances]
+        mergedCodes = mergedCodes.append(bestPerSpotTables[r])
+    mergedCodes = mergedCodes.reset_index(drop=True)
+
+    # Only use codes that were found in >= filterRounds rounds
+    spotCodes = mergedCodes['best_spot_codes']
+    counts = defaultdict(int)
+    for code in spotCodes:
+        counts[code] += 1
+    passing = list(set(code for code in counts if counts[code] >= filterRounds))
+    finalCodes = mergedCodes[mergedCodes['best_spot_codes'].isin(passing)].reset_index(drop=True)
+    finalCodes = finalCodes.iloc[finalCodes['best_spot_codes'].drop_duplicates().index].reset_index(drop=True)
+    
+    # Choose between overlapping spot codes based on which has the smaller spatial variance
+    for r in range(roundNum):
+        roundSpots = [code[r] for code in finalCodes['best_spot_codes'] if code[r] != -1]
+        dupSpots = set([spot for spot in roundSpots if Counter(roundSpots)[spot] > 1])
+        nonDupSpots = [spot for spot in roundSpots if spot not in dupSpots]
+        drop = []
+        for spot in dupSpots:
+            locs = np.where(np.asarray(roundSpots) == spot)[0]
+            distances = [finalCodes.loc[loc, 'best_distances'] for loc in locs]
+            minInd = np.where(distances == min(distances))[0]
+            if len(minInd) > 1:
+                drop.extend([ind for ind in minInd])
+            else:
+                drop.extend([locs[i] for i in range(len(locs)) if i != minInd])
+        finalCodes = finalCodes.iloc[[i for i in range(len(finalCodes)) if i not in drop]].reset_index(drop=True)
+
+    # Add spot coordinates, barcode center coordinates, and number of rounds used for each barcode to table
+    allCoords = []
+    centers = []
+    distance = []
+    roundsUsed = []
+    for i in range(len(finalCodes)):
+        coords = []
+        spotCode = finalCodes.iloc[i]['best_spot_codes']
+        roundsUsed.append(roundNum-Counter(spotCode)[-1])
+        for r in range(roundNum):
+            if spotCode[r] != -1:
+                z = spotCoords[r][spotCode[r]]['z']
+                y = spotCoords[r][spotCode[r]]['y']
+                x = spotCoords[r][spotCode[r]]['x']
+                coords.append((x,y,z))
+            else:
+                coords.append(-1)
+        allCoords.append(coords)
+        coords = np.asarray([coord for coord in coords if coord != -1])
+        center = np.asarray(coords).mean(axis=0)
+        centers.append(center)
+    finalCodes['coords'] = allCoords
+    finalCodes['center'] = centers
+    finalCodes['rounds_used'] = roundsUsed
+        
+    return finalCodes
+
+def removeUsedSpots(finalCodes: pd.DataFrame, neighborDict: dict) -> dict:
+    '''
+    Remove spots found to be in barcodes for the current round omission number so they are not used for the next
+    
+    Parameters
+    ----------
+        finalCodes : pd.DataFrame
+            Dataframe containing final set of codes that have passed all filters
+            
+        neighborDict : dict
+            Dictionary that contains all the neighbors for each spot in other rounds that are within the search radius
+    
+    Returns
+    -------
+        dict : Modified version of neighborDict with spots that have been used in the current round omission removed
+    '''
+
+    # Remove used spots
+    roundNum = len(neighborDict)
+    for r in range(roundNum):
+        usedSpots = list(set([passed[r] for passed in finalCodes['best_spot_codes'] if passed[r] != -1]))
+        for spot in usedSpots:
+            for key in neighborDict[r][spot]:
+                for neighbor in neighborDict[r][spot][key]:
+                    neighborDict[key][neighbor][r] = [i for i in neighborDict[key][neighbor][r] if i != spot]
+            del neighborDict[r][spot]
+
+    # Remove empty lists
+    for r in range(roundNum):
+        for spot in neighborDict[r]:
+            for key in [*neighborDict[r][spot]]:
+                if neighborDict[r][spot][key] == []:
+                    del neighborDict[r][spot][key]
+    
+    return neighborDict

--- a/starfish/core/spots/DecodeSpots/check_all_funcs.py
+++ b/starfish/core/spots/DecodeSpots/check_all_funcs.py
@@ -1,37 +1,29 @@
-# General modules
-import time # TODO: delete for final version
-import pickle # TODO: delete for final version
 from collections import Counter
 from scipy.spatial import cKDTree
 from copy import deepcopy
-from itertools import product, chain, permutations, combinations
-import math
+from itertools import product, chain, permutations
 from collections import defaultdict
-from typing import Any, Hashable, Mapping, Tuple
 import ray
 import numpy as np
 import pandas as pd
-import xarray as xr
 import warnings
+from starfish.types import Axes
+from starfish.core.codebook.codebook import Codebook
 warnings.filterwarnings('ignore')
 
-# starFISH stuff
-from starfish.types import Axes, Coordinates, CoordinateValue, Features
-from starfish.core.codebook.codebook import Codebook
-
-
 def findNeighbors(spotTables: dict, searchRadius: float) -> dict:
-    
+
     '''
-    Function that takes spatial information from the spot tables from each round and creates a dictionary that contains
-    all the neighbors for each spot in other rounds that are within the search radius.
-    
+    Function that takes spatial information from the spot tables from each round and creates a
+    dictionary that contains all the neighbors for each spot in other rounds that are within the
+    search radius.
+
     Parameters
     ----------
         spotTables : dict
-            Dictionary with round labels as keys and pandas dataframes containing spot information for its key round
-            as values (result of _merge_spots_by_round function)
-        
+            Dictionary with round labels as keys and pandas dataframes containing spot information
+            for its key round as values (result of _merge_spots_by_round function)
+
         searchRadius : float
             Distance that spots can be from each other and still form a barcode
 
@@ -41,7 +33,7 @@ def findNeighbors(spotTables: dict, searchRadius: float) -> dict:
             {round: {
                 spotID in round: {
                     neighborRound:
-                        [list of spotIDs in neighborRound within searchRadius of spotID in round]  
+                        [list of spotIDs in neighborRound within searchRadius of spotID in round]
                     }
                 }
             }
@@ -52,22 +44,22 @@ def findNeighbors(spotTables: dict, searchRadius: float) -> dict:
     for r in spotTables:
         neighborDict[r] = {i: defaultdict(list, {r: [i]}) for i in range(len(spotTables[r]))}
 
-    # For each pairing of rounds, find all mutual neighbors within the search radius for each spot and assigns them
-    # in the neighborDict dictionary
-    # Number assigned each spot in neighborDict is the index of it's original location in spotTables
-    # and is used to track each spot uniquely throughout
-    for i,r1 in enumerate(range((len(spotTables)))):
+    # For each pairing of rounds, find all mutual neighbors within the search radius for each spot
+    # and assigns them in the neighborDict dictionary
+    # Number assigned each spot in neighborDict is the index of it's original location in
+    # spotTables and is used to track each spot uniquely throughout
+    for i, r1 in enumerate(range((len(spotTables)))):
         tree = cKDTree(spotTables[r1][['z', 'y', 'x']])
-        for r2 in list(range((len(spotTables))))[i+1:]:
+        for r2 in list(range((len(spotTables))))[i + 1:]:
             allNeighbors = tree.query_ball_point(spotTables[r2][['z', 'y', 'x']], searchRadius)
-            for j,neighbors in enumerate(allNeighbors):
+            for j, neighbors in enumerate(allNeighbors):
                 if neighbors != []:
                     for neighbor in neighbors:
                         neighborDict[r1][neighbor][r2].append(j)
                         neighborDict[r2][j][r1].append(neighbor)
 
     return neighborDict
-    
+
 
 def buildBarcodes(roundData: pd.DataFrame,
                   neighborDict: dict,
@@ -75,39 +67,41 @@ def buildBarcodes(roundData: pd.DataFrame,
                   channelDict: dict,
                   currentRound: int,
                   numJobs: int) -> pd.DataFrame:
-    
+
     '''
-    Function that adds to the current rounds spot table all the possible barcodes that could be formed using the neighbors
-    of each spot, spots without enough neighbors to form a barcode are dropped.
-    
+    Function that adds to the current rounds spot table all the possible barcodes that could be
+    formed using the neighbors of each spot, spots without enough neighbors to form a barcode
+    # are dropped.
+
     Parameters
     ----------
         roundData : dict
             Spot data table for the current round
-        
+
         neighborDict : dict
-            Dictionary that contains all the neighbors for each spot in other rounds that are within the search radius
-        
+            Dictionary that contains all the neighbors for each spot in other rounds that are
+            within the search radius
+
         roundOmitNum : int
-            Maximum hamming distance a barcode can be from it's target in the codebook and still be uniquely identified
-            (i.e. number of error correction rounds in each the experiment
+            Maximum hamming distance a barcode can be from it's target in the codebook and still
+            be uniquely identified (i.e. number of error correction rounds in each the experiment
 
         channelDict : dict
             Dictionary with mappings between spot IDs and their channel labels
 
         currentRound : int
             Current round to build barcodes for (same round that roundData is from)
-        
+
         numJobs : int
             Number of CPU threads to use in parallel
-            
+
     Returns
     -------
         pd.DataFrame : Copy of roundData with additional columns which list all possible barcodes
                        that could be made from each spot's neighbors
-    
+
     '''
-    
+
     @ray.remote
     def barcodeBuildFunc(data: pd.DataFrame,
                          channelDict: dict,
@@ -116,43 +110,45 @@ def buildBarcodes(roundData: pd.DataFrame,
                          roundNum: int) -> tuple:
         '''
         Subfunction to buildBarcodes that allows it to run in parallel chunks using ray
-        
+
         Parameters
         ----------
             data : pd.DataFrame
                 Spot table for the current round
-                
+
             channelDict : dict
                 Dictionary mapping spot IDs to their channels labels
-            
+
             rang : tuple
                 Range of indices to build barcodes for in the current data object
-            
+
             roundOmitNum : int
-                Maximum hamming distance a barcode can be from it's target in the codebook and still be uniquely
-                identified (i.e. number of error correction rounds in each the experiment)
+                Maximum hamming distance a barcode can be from it's target in the codebook and
+                still be uniquely identified (i.e. number of error correction rounds in each the
+                experiment)
 
             roundNum : int
                 Current round
-            
+
         Returns
         -------
-            tuple : First element is a list of the possible spot codes while the second element is a list of the
-                    possible barcodes
+            tuple : First element is a list of the possible spot codes while the second element is
+                    a list of the possible barcodes
         '''
 
         # Build barcodes from neighbors
-        # spotCodes are the ordered spot IDs of the spots making up each barcode while barcodes are the corresponding
-        # channel labels, need spotCodes so each barcode can have a unique identifier
+        # spotCodes are the ordered spot IDs of the spots making up each barcode while barcodes are
+        # the corresponding channel labels, need spotCodes so each barcode can have a unique
+        # identifier
         allSpotCodes = []
         allBarcodes = []
         allNeighbors = list(data['neighbors'])[rang[0]: rang[1]]
         for i in range(len(allNeighbors)):
             neighbors = deepcopy(allNeighbors[i])
-            neighborLists = []    
+            neighborLists = []
             for rnd in range(roundNum):
-                # Adds a -1 to each round of the neighbors dictionary (allows barcodes with dropped rounds to
-                # be created)
+                # Adds a -1 to each round of the neighbors dictionary (allows barcodes with dropped
+                # rounds to be created)
                 if roundOmitNum > 0:
                     neighbors[rnd].append(-1)
                 neighborLists.append(neighbors[rnd])
@@ -176,23 +172,20 @@ def buildBarcodes(roundData: pd.DataFrame,
 
         return (allSpotCodes, allBarcodes)
 
-
-    # Only keep spots that have enough neighbors to form a barcode (determined by the total number of rounds and the
-    # number of rounds that can be omitted from each code)
+    # Only keep spots that have enough neighbors to form a barcode (determined by the total number
+    # of rounds and the number of rounds that can be omitted from each code)
     passingSpots = {}
     roundNum = len(neighborDict)
     for key in neighborDict[currentRound]:
-        if len(neighborDict[currentRound][key]) >= roundNum-roundOmitNum:
+        if len(neighborDict[currentRound][key]) >= roundNum - roundOmitNum:
             passingSpots[key] = neighborDict[currentRound][key]
     passed = list(passingSpots.keys())
     roundData = roundData.iloc[passed]
     roundData['neighbors'] = [passingSpots[i] for i in roundData.index]
     roundData = roundData.reset_index(drop=True)
 
-
-    # Find all possible barcodes for the spots in each round by splitting each round's spots into numJob chunks and
-    # constructing each chunks barcodes in parallel
-
+    # Find all possible barcodes for the spots in each round by splitting each round's spots into
+    # numJob chunks and constructing each chunks barcodes in parallel
 
     # Save the current round's data table and the channelDict to ray memory
     dataID = ray.put(roundData)
@@ -200,106 +193,114 @@ def buildBarcodes(roundData: pd.DataFrame,
 
     # Calculates index ranges to chunk data by
     ranges = [0]
-    for i in range(1, numJobs+1):
-        ranges.append(int((len(roundData)/numJobs)*i))
+    for i in range(1, numJobs + 1):
+        ranges.append(int((len(roundData) / numJobs) * i))
 
     # Run in parallel
-    results = [barcodeBuildFunc.remote(dataID, channelDictID, (ranges[i], ranges[i+1]), roundOmitNum, roundNum) for i in range(len(ranges[:-1]))]
+    results = [barcodeBuildFunc.remote(dataID, channelDictID, (ranges[i], ranges[i + 1]),
+                                       roundOmitNum, roundNum)
+               for i in range(len(ranges[:-1]))]
     rayResults = ray.get(results)
 
-    # Add possible barcodes and spot codes (same order) to spot table (must chain results rom different jobs
-    # together)
+    # Add possible barcodes and spot codes (same order) to spot table (must chain results from
+    # different jobs together)
     roundData['spot_codes'] = list(chain(*[job[0] for job in rayResults]))
     roundData['barcodes'] = list(chain(*[job[1] for job in rayResults]))
-    
-    return roundData
 
+    return roundData
 
 def decoder(roundData: pd.DataFrame,
             codebook: Codebook,
             roundOmitNum: int,
             currentRound: int,
             numJobs: int) -> pd.DataFrane:
-    
+
     '''
-    Function that takes spots tables with possible barcodes added and matches each to the codebook to identify any
-    matches. Matches are added to the spot tables and spots without any matches are dropped
-    
+    Function that takes spots tables with possible barcodes added and matches each to the codebook
+    to identify any matches. Matches are added to the spot tables and spots without any matches are
+    dropped
+
     Parameters
     ----------
         roundData : pd.DataFrane
-            Modified spot table containing all possible barcodes that can be made from each spot for the current round
-        
+            Modified spot table containing all possible barcodes that can be made from each spot
+            for the current round
+
         codebook : Codebook
             starFISH Codebook object containg the barcode information for the experiment
-            
+
         roundOmitNum : int
             Number of rounds that can be dropped from each barcode
 
         currentRound : int
             Current round being for which spots are being decoded
-            
+
         numJobs : int
             Number of CPU threads to use in parallel
-            
+
     Returns
     -------
-        pd.DataFrane : Modified spot table with added columns with information on decodable barcodes
+        pd.DataFrane : Modified spot table with added columns with information on decodable
+                       barcodes
     '''
 
     def generateRoundPermutations(size: int, roundOmitNum: int) -> list:
         '''
-        Creates list of lists of logicals detailing the rounds to be used for decoding based on the current roundOmitNum
-        
+        Creates list of lists of logicals detailing the rounds to be used for decoding based on the
+        current roundOmitNum
+
         Parameters
         ----------
             size : int
                 Number of rounds in experiment
-                
+
             roundOmitNum: int
                 Number of rounds that can be dropped from each barcode
-                
+
         Returns
         -------
-            list : list of lists of logicals detailing the rounds to be used for decoding based on the current roundOmitNum
+            list : list of lists of logicals detailing the rounds to be used for decoding based on
+                   the current roundOmitNum
         '''
         if roundOmitNum == 0:
-            return [tuple([True]*size)]
+            return [tuple([True] * size)]
         else:
-            return sorted(set(list(permutations([False]*roundOmitNum + [True]*(size-roundOmitNum)))))
-
+            return sorted(set(list(permutations([*([False] * roundOmitNum),
+                                                *([True] * (size - roundOmitNum))]))))
 
     @ray.remote
     def decodeFunc(data: pd.DataFrame,
                    roundPermutations: list,
                    permutationCodes: dict,
                    rnd: int) -> tuple:
-        
+
         '''
         Subfunction for decoder that allows it to run in parallel chunks using ray
-        
+
         Parameters
         ----------
             data : pd.DataFrame
                 Spot table for the current round
-                
+
             roundPermutations : list
-                List of logicals from generateRoundPermutations that details the rounds to use in decoding
-                
+                List of logicals from generateRoundPermutations that details the rounds to use in
+                decoding
+
             permutationCodes : dict
                 Dictionary containing barcode information for each roundPermutation
-                
+
             rnd : int
                 Current round being decoded
-                
+
         Returns
         -------
-            tuple : First element is a list of all decoded targets, second element is a list of all decoded barcodes,
-                    third element is a list of all decoded spot codes, and the fourth element is a list of rounds
-                    that were omitted for each decoded barcode
+            tuple : First element is a list of all decoded targets, second element is a list of all
+                    decoded barcodes,third element is a list of all decoded spot codes, and the
+                    fourth element is a list of rounds that were omitted for each decoded barcode
         '''
 
-        # Goes through all possible decodings of each spot (ensures each spot is only looked up once)
+        # Goes through all possible decodings of each spot (ensures each spot is only looked up
+        # once)
         allTargets = []
         allDecodedBarcodes = []
         allDecodedSpotCodes = []
@@ -313,37 +314,45 @@ def decoder(roundData: pd.DataFrame,
             roundOmit = []
             fullBarcodes = allBarcodes[i]
             fullSpotCodes = allSpotCodes[i]
-            
+
             for currentRounds in roundPermutations:
 
-                # Set omittedRound to the round being dropped, if no round is dropped omittedRound becomes -1
+                # Set omittedRound to the round being dropped, if no round is dropped omittedRound
+                # becomes -1
                 if 0 in currentRounds:
                     omittedRound = np.argwhere([not cr for cr in currentRounds])[0][0]
                 else:
                     omittedRound = -1
 
-                # Only try to decode barcodes for this spot if the current round is not the omitted round 
+                # Only try to decode barcodes for this spot if the current round is not the omitted
+                # round
                 if rnd != omittedRound:
-                    # Modify spot codes and barcodes so that they match the current set of rounds being used for decoding
+                    # Modify spot codes and barcodes so that they match the current set of rounds
+                    # being used for decoding
                     if omittedRound != -1:
-                        spotCodes = [code for code in np.asarray([np.asarray(spotCode)[list(currentRounds)] for spotCode in fullSpotCodes]) if -1 not in code]
-                        barcodes = [code for code in np.asarray([np.asarray(barcode)[list(currentRounds)] for barcode in fullBarcodes]) if -1 not in code]
+                        spotCodes = [code for code in
+                                     np.asarray([np.asarray(spotCode)[list(currentRounds)]
+                                                 for spotCode in fullSpotCodes]) if -1 not in code]
+                        barcodes = [code for code in
+                                    np.asarray([np.asarray(barcode)[list(currentRounds)]
+                                                for barcode in fullBarcodes]) if -1 not in code]
                     else:
                         spotCodes = fullSpotCodes
                         barcodes = fullBarcodes
                     # If all barcodes omit a round other than omittedRound, barcodes will be empty
                     if len(barcodes) > 0:
                         # Tries to find a match to each possible barcode from the spot
-                        for j,barcode in enumerate(barcodes):
+                        for j, barcode in enumerate(barcodes):
                             try:
-                                # Try to assign target by using barcode as key in permutationsCodes dictionary for
-                                # current set of rounds. If there is no barcode match, it will error and go to the except
-                                # and if it succeeds it will add the data to the other lists for this barcode
+                                # Try to assign target by using barcode as key in permutationsCodes
+                                # dictionary for current set of rounds. If there is no barcode
+                                # match, it will error and go to the except and if it succeeds it
+                                # will add the data to the other lists for this barcode
                                 targets.append(permutationCodes[currentRounds][tuple(barcode)])
                                 decodedBarcodes.append(barcode)
                                 decodedSpotCodes.append(list(spotCodes[j]))
                                 roundOmit.append(omittedRound)
-                            except:
+                            except Exception:
                                 pass
             allTargets.append(targets)
             allDecodedBarcodes.append(decodedBarcodes)
@@ -352,18 +361,18 @@ def decoder(roundData: pd.DataFrame,
 
         return (allTargets, allDecodedBarcodes, allDecodedSpotCodes, allRoundOmit)
 
-
     # Create list of logical arrays corresponding to the round sets being used to decode
-    roundPermutations = generateRoundPermutations(codebook.sizes[Axes.ROUND], roundOmitNum) 
+    roundPermutations = generateRoundPermutations(codebook.sizes[Axes.ROUND], roundOmitNum)
 
-    # Create dictionary where the keys are the different round sets that can be used for decoding and the values
-    # are the modified codebooks corresponding to the rounds used
+    # Create dictionary where the keys are the different round sets that can be used for decoding
+    # and the values are the modified codebooks corresponding to the rounds used
     permCodeDict = {}
     for currentRounds in roundPermutations:
         codes = codebook.argmax(Axes.CH.value)
-        currentCodes = codes.sel(r=list(currentRounds)) 
+        currentCodes = codes.sel(r=list(currentRounds))
         currentCodes.values = np.ascontiguousarray(currentCodes.values)
-        permCodeDict[currentRounds] = dict(zip([tuple(code) for code in currentCodes.data], currentCodes['target'].data))
+        permCodeDict[currentRounds] = dict(zip([tuple(code) for code in currentCodes.data],
+                                               currentCodes['target'].data))
 
     # Goes through each round in filtered_prsr and tries to decode each spot's barcodes
 
@@ -372,14 +381,15 @@ def decoder(roundData: pd.DataFrame,
 
     # Calculates index ranges to chunk data by and creates list of chunked data to loop through
     ranges = [0]
-    for i in range(1, numJobs+1):
-        ranges.append(int((len(roundData)/numJobs)*i))
+    for i in range(1, numJobs + 1):
+        ranges.append(int((len(roundData) / numJobs) * i))
     chunkedData = []
     for i in range(len(ranges[:-1])):
-        chunkedData.append(deepcopy(roundData[ranges[i]:ranges[i+1]]))
+        chunkedData.append(deepcopy(roundData[ranges[i]:ranges[i + 1]]))
 
     # Run in parallel
-    results = [decodeFunc.remote(chunkedData[i], roundPermutations, permutationCodesID, currentRound) for i in range(len(ranges[:-1]))]
+    results = [decodeFunc.remote(chunkedData[i], roundPermutations, permutationCodesID,
+                                 currentRound) for i in range(len(ranges[:-1]))]
     rayResults = ray.get(results)
 
     # Update table
@@ -391,11 +401,11 @@ def decoder(roundData: pd.DataFrame,
     # Drop barcodes and spot_codes column (saves memory)
     roundData = roundData.drop(['neighbors', 'spot_codes', 'barcodes'], axis=1)
 
-        
-    # Remove rows that have no decoded barcodes 
+    # Remove rows that have no decoded barcodes
     roundData = roundData[roundData['targets'].astype(bool)].reset_index(drop=True)
 
-    # Add -1 spacer back into partial barcodes/spot codes so we can easily tell which round each spot ID is from
+    # Add -1 spacer back into partial barcodes/spot codes so we can easily tell which round each
+    # spot ID is from
     if roundOmitNum > 0:
         allBarcodes = []
         allSpotCodes = []
@@ -406,71 +416,75 @@ def decoder(roundData: pd.DataFrame,
             barcodes = [list(code) for code in dataBarcodes[i]]
             spotCodes = [list(code) for code in dataSpotCodes[i]]
             omittedRounds = dataOmittedRounds[i]
-            barcodes = [barcodes[j][:omittedRounds[j]] + [-1] + barcodes[j][omittedRounds[j]:] for j in range(len(barcodes))]
-            spotCodes = [spotCodes[j][:omittedRounds[j]] + [-1] + spotCodes[j][omittedRounds[j]:] for j in range(len(barcodes))]
+            barcodes = [barcodes[j][:omittedRounds[j]] + [-1] + barcodes[j][omittedRounds[j]:]
+                        for j in range(len(barcodes))]
+            spotCodes = [spotCodes[j][:omittedRounds[j]] + [-1] + spotCodes[j][omittedRounds[j]:]
+                         for j in range(len(barcodes))]
             allBarcodes.append(barcodes)
             allSpotCodes.append(spotCodes)
         roundData['decoded_barcodes'] = allBarcodes
         roundData['decoded_spot_codes'] = allSpotCodes
-    
-    return roundData
 
+    return roundData
 
 def distanceFilter(roundData: pd.DataFrame,
                    spotCoords: dict,
                    currentRound: int,
                    numJobs: int) -> pd.DataFrame:
     '''
-    Function that chooses between the best barcode for each spot from the set of decodable barcodes. Does this by
-    choosing the barcode with the least spatial variance among the spots that make it up. If there is a tie, the spot
-    is dropped as ambiguous
-    
+    Function that chooses between the best barcode for each spot from the set of decodable barcodes.
+    Does this by choosing the barcode with the least spatial variance among the spots that make it
+    up. If there is a tie, the spot is dropped as ambiguous.
+
     Parameters
     ----------
         roundData : pd.DataFrame
-            Modified spot table containing info on decodable barcodes for the spots in the current round
+            Modified spot table containing info on decodable barcodes for the spots in the current
+            round
 
         spotCoords : dict
             Dictionary containing spatial coordinates of spots in each round indexed by their IDs
-            
+
         currentRound : int
             Current round number to calculate distances for
-        
+
         numJobs : int
             Number of CPU threads to use in parallel
-    
+
     Returns
     -------
-        pd.DataFrame : Modified spot table with added columns to with info on the "best" barcode found for each spot
+        pd.DataFrame : Modified spot table with added columns to with info on the "best" barcode
+                       found for each spot
     '''
-    
+
     @ray.remote
     def distanceFunc(subSpotCodes: list, spotCoords: dict) -> list:
         '''
         Subfunction for distanceFilter to allow it to run in parallel using ray
-        
+
         Parameters
         ----------
             subSpotCodes : list
-                Chunk of full list of spot codes for the current round to calculate the spatial variance for
-            
+                Chunk of full list of spot codes for the current round to calculate the spatial
+                variance for
+
             spotCoords : dict
-                Dictionary containing spatial locations for spots by their IDs in the original spotTables object
-        
-        
+                Dictionary containing spatial locations for spots by their IDs in the original
+                spotTables object
+
         Returns
         -------
             list: list of spatial variances for the current chunk of spot codes
-        
+
         '''
-        
+
         # Calculate spatial variances for current chunk of spot codes
         allDistances = []
-        for spotCodes in subSpotCodes: 
+        for spotCodes in subSpotCodes:
             distances = []
-            for s,spotCode in enumerate(spotCodes):
+            for s, spotCode in enumerate(spotCodes):
                 coords = []
-                for j,spot in enumerate(spotCode):
+                for j, spot in enumerate(spotCode):
                     if spot != -1:
                         # Extract spot coordinates from spotCoords
                         z = spotCoords[j][spot]['z']
@@ -479,10 +493,9 @@ def distanceFilter(roundData: pd.DataFrame,
                         coords.append([z, y, x])
                 coords = np.asarray(coords)
                 # Distance is calculate as the sum of variances of the coordinates along each axis
-                distances.append(sum(np.var(coords, axis = 0)))
+                distances.append(sum(np.var(coords, axis=0)))
             allDistances.append(distances)
         return allDistances
-
 
     # Calculate the spatial variance for each decodable barcode for each spot in each round
     allSpotCodes = roundData['decoded_spot_codes']
@@ -493,17 +506,18 @@ def distanceFilter(roundData: pd.DataFrame,
     # Calculates index ranges to chunk data by
     ranges = [0]
     for i in range(1, numJobs):
-        ranges.append(int((len(roundData)/numJobs)*i))
+        ranges.append(int((len(roundData) / numJobs) * i))
     ranges.append(len(roundData))
-    chunkedSpotCodes = [allSpotCodes[ranges[i]:ranges[i+1]] for i in range(len(ranges[:-1]))]
+    chunkedSpotCodes = [allSpotCodes[ranges[i]:ranges[i + 1]] for i in range(len(ranges[:-1]))]
 
     # Run in parallel using ray
-    results = [distanceFunc.remote(subSpotCodes, spotCoordsID) for subSpotCodes in chunkedSpotCodes]
+    results = [distanceFunc.remote(subSpotCodes, spotCoordsID) for subSpotCodes
+               in chunkedSpotCodes]
     rayResults = ray.get(results)
 
     # Add distances to decodedTables as new column
     roundData['distance'] = list(chain(*[job for job in rayResults]))
-        
+
     # Pick minimum distance barcode(s) for each spot
     bestSpotCodes = []
     bestBarcodes = []
@@ -528,7 +542,7 @@ def distanceFilter(roundData: pd.DataFrame,
         else:
             minDist = 100
             minCount = 0
-            for d,distance in enumerate(distances):
+            for d, distance in enumerate(distances):
                 if distance < minDist:
                     minDist = distance
                     minCount = 1
@@ -548,7 +562,8 @@ def distanceFilter(roundData: pd.DataFrame,
     roundData['best_distances'] = bestDistances
 
     # Drop old columns
-    roundData = roundData.drop(['targets', 'decoded_barcodes', 'decoded_spot_codes', 'omitted_round'], axis=1)
+    roundData = roundData.drop(['targets', 'decoded_barcodes', 'decoded_spot_codes',
+                                'omitted_round'], axis=1)
 
     # Only keep barcodes with only one minimum distance
     keep = []
@@ -557,35 +572,36 @@ def distanceFilter(roundData: pd.DataFrame,
         if len(barcodes[i]) == 1:
             keep.append(i)
     roundData = roundData.iloc[keep]
-    
+
     return roundData
-    
 
 def cleanup(bestPerSpotTables: dict,
             spotCoords: dict,
             filterRounds: int) -> pd.DataFrame:
-    
+
     '''
-    Function that combines all "best" codes for each spot in each round into a single table, filters them by their
-    frequency (with a user-defined threshold), chooses between overlapping codes (using the same distance function
-    as used earlier), and finally adds some additional information to the final set of barcodes
-    
+    Function that combines all "best" codes for each spot in each round into a single table,
+    filters them by their frequency (with a user-defined threshold), chooses between overlapping
+    codes (using the same distance function as used earlier), and finally adds some additional
+    information to the final set of barcodes
+
     Parameters
     ----------
         bestPerSpotTables : dict
-            Spot tables dictionary containing columns with information on the "best" barcode found for each spot
-        
+            Spot tables dictionary containing columns with information on the "best" barcode found
+            for each spot
+
         spotCoords : dict
             Dictionary containing spatial locations of spots
-        
+
         filterRounds : int
-            Number of rounds that a barcode must be identified in to pass filters (higher = more stringent filtering),
-            default = 1 - #rounds  or 1 - roundOmitNum if roundOmitNum > 0
-            
+            Number of rounds that a barcode must be identified in to pass filters (higher = more
+            stringent filtering), default = 1 - #rounds  or 1 - roundOmitNum if roundOmitNum > 0
+
     Returns
     -------
         pd.DataFrame : Dataframe containing final set of codes that have passed all filters
-    
+
     '''
 
     # Create merged spot results dataframe containing the passing barcodes found in all the rounds
@@ -606,18 +622,18 @@ def cleanup(bestPerSpotTables: dict,
 
     # Only use codes that were found in >= filterRounds rounds
     spotCodes = mergedCodes['best_spot_codes']
-    counts = defaultdict(int)
+    counts = defaultdict(int)  # type: dict
     for code in spotCodes:
         counts[code] += 1
     passing = list(set(code for code in counts if counts[code] >= filterRounds))
     finalCodes = mergedCodes[mergedCodes['best_spot_codes'].isin(passing)].reset_index(drop=True)
-    finalCodes = finalCodes.iloc[finalCodes['best_spot_codes'].drop_duplicates().index].reset_index(drop=True)
-    
+    finalCodes = finalCodes.iloc[finalCodes['best_spot_codes'].drop_duplicates().index]
+    finalCodes = finalCodes.reset_index(drop=True)
+
     # Choose between overlapping spot codes based on which has the smaller spatial variance
     for r in range(roundNum):
         roundSpots = [code[r] for code in finalCodes['best_spot_codes'] if code[r] != -1]
         dupSpots = set([spot for spot in roundSpots if Counter(roundSpots)[spot] > 1])
-        nonDupSpots = [spot for spot in roundSpots if spot not in dupSpots]
         drop = []
         for spot in dupSpots:
             locs = np.where(np.asarray(roundSpots) == spot)[0]
@@ -627,61 +643,64 @@ def cleanup(bestPerSpotTables: dict,
                 drop.extend([ind for ind in minInd])
             else:
                 drop.extend([locs[i] for i in range(len(locs)) if i != minInd])
-        finalCodes = finalCodes.iloc[[i for i in range(len(finalCodes)) if i not in drop]].reset_index(drop=True)
+        finalCodes = finalCodes.iloc[[i for i in range(len(finalCodes)) if i not in drop]]
+        finalCodes = finalCodes.reset_index(drop=True)
 
-    # Add spot coordinates, barcode center coordinates, and number of rounds used for each barcode to table
+    # Add spot coordinates, barcode center coordinates, and number of rounds used for each barcode
+    # to table
     allCoords = []
     centers = []
-    distance = []
     roundsUsed = []
     for i in range(len(finalCodes)):
         coords = []
         spotCode = finalCodes.iloc[i]['best_spot_codes']
-        roundsUsed.append(roundNum-Counter(spotCode)[-1])
+        roundsUsed.append(roundNum - Counter(spotCode)[-1])
         for r in range(roundNum):
             if spotCode[r] != -1:
                 z = spotCoords[r][spotCode[r]]['z']
                 y = spotCoords[r][spotCode[r]]['y']
                 x = spotCoords[r][spotCode[r]]['x']
-                coords.append((x,y,z))
-            else:
-                coords.append(-1)
+                coords.append((x, y, z))
         allCoords.append(coords)
-        coords = np.asarray([coord for coord in coords if coord != -1])
+        coords = np.asarray([coord for coord in coords])
         center = np.asarray(coords).mean(axis=0)
         centers.append(center)
     finalCodes['coords'] = allCoords
     finalCodes['center'] = centers
     finalCodes['rounds_used'] = roundsUsed
-        
-    return finalCodes
 
+    return finalCodes
 
 def removeUsedSpots(finalCodes: pd.DataFrame, neighborDict: dict) -> dict:
     '''
-    Remove spots found to be in barcodes for the current round omission number so they are not used for the next
-    
+    Remove spots found to be in barcodes for the current round omission number so they are not used
+    for the next
+
     Parameters
     ----------
         finalCodes : pd.DataFrame
             Dataframe containing final set of codes that have passed all filters
-            
+
         neighborDict : dict
-            Dictionary that contains all the neighbors for each spot in other rounds that are within the search radius
-    
+            Dictionary that contains all the neighbors for each spot in other rounds that are
+            within the search radius
+
     Returns
     -------
-        dict : Modified version of neighborDict with spots that have been used in the current round omission removed
+        dict : Modified version of neighborDict with spots that have been used in the current round
+               omission removed
     '''
 
     # Remove used spots
     roundNum = len(neighborDict)
     for r in range(roundNum):
-        usedSpots = list(set([passed[r] for passed in finalCodes['best_spot_codes'] if passed[r] != -1]))
+        usedSpots = list(set([passed[r] for passed in finalCodes['best_spot_codes']
+                              if passed[r] != -1]))
         for spot in usedSpots:
             for key in neighborDict[r][spot]:
                 for neighbor in neighborDict[r][spot][key]:
-                    neighborDict[key][neighbor][r] = [i for i in neighborDict[key][neighbor][r] if i != spot]
+                    neighborDict[key][neighbor][r] = [i for i in neighborDict[key][neighbor][r]
+                                                      if i != spot]
             del neighborDict[r][spot]
 
     # Remove empty lists
@@ -690,5 +709,5 @@ def removeUsedSpots(finalCodes: pd.DataFrame, neighborDict: dict) -> dict:
             for key in [*neighborDict[r][spot]]:
                 if neighborDict[r][spot][key] == []:
                     del neighborDict[r][spot][key]
-    
+
     return neighborDict

--- a/starfish/core/spots/DecodeSpots/test/test_check_all.py
+++ b/starfish/core/spots/DecodeSpots/test/test_check_all.py
@@ -1,0 +1,167 @@
+import numpy as np
+import random
+from scipy.ndimage.filters import gaussian_filter
+
+from starfish import ImageStack
+from starfish.core.spots.DecodeSpots.check_all_decoder import CheckAll
+from starfish.core.codebook.codebook import Codebook
+from starfish.core.spots.FindSpots import BlobDetector
+
+def syntheticSeqfish(x, y, z, codebook, nSpots, jitter, error):
+    nRound = codebook.shape[1]
+    nChannel = codebook.shape[2]
+    img = np.zeros((nRound, nChannel, z, y, x), dtype=np.float32)
+
+    intCodes = np.argmax(codebook.data, axis=2)
+
+    targets = []
+    for _ in range(nSpots):
+        randx = random.choice(range(5, x - 5))
+        randy = random.choice(range(5, y - 5))
+        randz = random.choice(range(2, z - 2))
+        randCode = random.choice(range(len(codebook)))
+        targets.append((randCode, (randx, randy, randz)))
+        if jitter > 0:
+            randx += random.choice(range(jitter + 1)) * random.choice([1, -1])
+            randy += random.choice(range(jitter + 1)) * random.choice([1, -1])
+        if error:
+            skip = random.choice(range(nRound))
+        else:
+            skip = 100
+        for r, ch in enumerate(intCodes[randCode]):
+            if r != skip:
+                img[r, ch, randz, randy, randx] = 10
+
+    gaussian_filter(img, (0, 0, 0.5, 1.5, 1.5), output=img)
+
+    return ImageStack.from_numpy(img / img.max()), targets
+
+
+def seqfishCodebook(nRound, nChannel, nCodes):
+
+    def barcodeConv(lis, chs):
+        barcode = np.zeros((len(lis), chs))
+        for i in range(len(lis)):
+            barcode[i][lis[i]] = 1
+        return barcode
+
+    def incrBarcode(lis, chs):
+        currInd = len(lis) - 1
+        lis[currInd] += 1
+        while lis[currInd] == chs:
+            lis[currInd] = 0
+            currInd -= 1
+            lis[currInd] += 1
+        return lis
+
+    allCombo = np.zeros((nChannel ** nRound, nRound, nChannel))
+
+    barcode = [0] * nRound
+    for i in range(np.shape(allCombo)[0]):
+        allCombo[i] = barcodeConv(barcode, nChannel)
+        barcode = incrBarcode(barcode, nChannel)
+
+    hammingDistance = 1
+    blanks = []
+    i = 0
+    while i < len(allCombo):
+        blanks.append(allCombo[i])
+        j = i + 1
+        while j < len(allCombo):
+            if np.count_nonzero(~(allCombo[i] == allCombo[j])) / 2 <= hammingDistance:
+                allCombo = allCombo[[k for k in range(len(allCombo)) if k != j]]
+            else:
+                j += 1
+        i += 1
+
+    data = np.asarray(blanks)[random.sample(range(len(blanks)), nCodes)]
+
+    return Codebook.from_numpy(code_names=range(len(data)), n_round=nRound,
+                               n_channel=nChannel, data=data)
+
+def testExactMatches():
+
+    codebook = seqfishCodebook(5, 3, 20)
+
+    img, trueTargets = syntheticSeqfish(100, 100, 20, codebook, 20, 0, False)
+
+    bd = BlobDetector(min_sigma=1, max_sigma=4, num_sigma=30, threshold=.1, exclude_border=False)
+    spots = bd.run(image_stack=img)
+    assert spots.count_total_spots() == 5 * 20, 'Spot detector did not find all spots'
+
+    decoder = CheckAll(codebook=codebook, search_radius=1, error_rounds=0)
+    hits = decoder.run(spots=spots, n_processes=4)
+
+    testTargets = []
+    for i in range(len(hits)):
+        testTargets.append((int(hits[i]['target'].data),
+                           (int(hits[i]['x'].data), int(hits[i]['y'].data),
+                            int(hits[i]['z'].data))))
+
+    matches = 0
+    for true in trueTargets:
+        for test in testTargets:
+            if true[0] == test[0]:
+                if test[1][0] + 1 >= true[1][0] >= test[1][0] - 1 and \
+                   test[1][1] + 1 >= true[1][1] >= test[1][1] - 1:
+                    matches += 1
+
+    assert matches == len(trueTargets)
+
+def testJitteredMatches():
+
+    codebook = seqfishCodebook(5, 3, 20)
+
+    img, trueTargets = syntheticSeqfish(100, 100, 20, codebook, 20, 2, False)
+
+    bd = BlobDetector(min_sigma=1, max_sigma=4, num_sigma=30, threshold=.1, exclude_border=False)
+    spots = bd.run(image_stack=img)
+    assert spots.count_total_spots() == 5 * 20, 'Spot detector did not find all spots'
+
+    decoder = CheckAll(codebook=codebook, search_radius=3, error_rounds=0)
+    hits = decoder.run(spots=spots, n_processes=4)
+
+    testTargets = []
+    for i in range(len(hits)):
+        testTargets.append((int(hits[i]['target'].data),
+                           (int(hits[i]['x'].data), int(hits[i]['y'].data),
+                            int(hits[i]['z'].data))))
+
+    matches = 0
+    for true in trueTargets:
+        for test in testTargets:
+            if true[0] == test[0]:
+                if test[1][0] + 3 >= true[1][0] >= test[1][0] - 3 and \
+                   test[1][1] + 3 >= true[1][1] >= test[1][1] - 3:
+                    matches += 1
+
+    assert matches == len(trueTargets)
+
+def testErrorCorrection():
+
+    codebook = seqfishCodebook(5, 3, 20)
+
+    img, trueTargets = syntheticSeqfish(100, 100, 20, codebook, 20, 0, True)
+
+    bd = BlobDetector(min_sigma=1, max_sigma=4, num_sigma=30, threshold=.1, exclude_border=False)
+    spots = bd.run(image_stack=img)
+    assert spots.count_total_spots() == 4 * 20, 'Spot detector did not find all spots'
+
+    decoder = CheckAll(codebook=codebook, search_radius=1, error_rounds=1)
+    hits = decoder.run(spots=spots, n_processes=4)
+
+    testTargets = []
+    for i in range(len(hits)):
+        testTargets.append((int(str(hits[i]['target'].data).split('.')[0]),
+                           (int(hits[i]['x'].data), int(hits[i]['y'].data),
+                            int(hits[i]['z'].data))))
+
+    matches = 0
+    for true in trueTargets:
+        for test in testTargets:
+            if true[0] == test[0]:
+                if test[1][0] + 1 >= true[1][0] >= test[1][0] - 1 and \
+                   test[1][1] + 1 >= true[1][1] >= test[1][1] - 1:
+                    matches += 1
+
+    assert matches == len(trueTargets)


### PR DESCRIPTION
This PR adds a new spot-based decoding method, the CheckAll decoder, based on the method described here (https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6046268/). It is capable of detecting several times more true targets from seqFISH image data than current spot-based methods in starFISH (PerRoundMaxChannel) as barcodes are not restricted to exactly matching spots or only nearest neighbor spots and because it tries to put together barcodes based on spots from every round instead of a single arbitrary anchor round. It is also capable of utilizing error correction rounds in the codebook which current starFISH methods do not consider.

Summary of algorithm:

Inputs:
	spots - starFISH SpotFindingResults object
	codebook - starFISH Codebook object
	filter_rounds - Number of rounds that a barcode must be identified in to pass filters
	error_rounds - Number of error-correction rounds built into the codebook (ie number of rounds that can be dropped from a barcode and still be able to uniquely match to a single target in the codebook)

	1. For each spot in each round, find all neighbors in other rounds that are within the search radius
	2. For each spot in each round, build all possible full length barcodes based on the channel labels of the spot's 
	neighbors and itself
	3. Drop barcodes that don't have a matching target in the codebook
	4. Choose the "best" barcode of each spot's possible target matching barcodes by calculating the sum of variances 
	for each of the spatial coordinates of the spots that make up each barcode and choosing the minimum distance barcode 
	(if there is a tie, they are all dropped as ambiguous). Each spot is assigned a "best" barcode in this way.
        sum( var(x1,x2,...,xn), var(y1,y2,...,yn), var(z1,z2,...,zn) ), where n = # spots in barcode
	5. Only keep barcodes/targets that were found as "best" in a certain number of the rounds (determined by filter_rounds
	parameter)
	6. If a specific spot is used in more than one of the remaining barcodes, the barcode with the higher spatial variance
	between it's spots is dropped (ensures each spot is only used once)
	(End here if number of error_rounds = 0)
	7. Remove all spots used in decoded targets that passed the previous filtering steps from the original set of spots
	8. Rerun steps 2-5 for barcodes that use less than the full set of rounds for codebook matching (how many rounds can be
	dropped determined by error_rounds parameter)

Tests of the CheckAll decoder vs starFISH's PerRoundMaxChannel method (w/ nearest neighbor trace building strategy) show improved performance with the CheckAll decoder. All the following tests used seqfISH image data from https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6046268/.

![image](https://user-images.githubusercontent.com/36525811/137047233-e2d0acc1-76fb-4341-96bd-882d715c4e9b.png)

Note PRMC NN = PerRoundMaxChannel Nearest Neighbor

The x-axis for each of the above images marks the value for the search radius parameter used in either decoding method (the distance that spots can be from a reference spot and be allowed to form a potential barcode). It is marked in increments of increasing symmetric neighborhood size (in 3D). The left figure shows the total number of decoded transcripts that are assigned to a cell for each method (note: for the CheckAll decoder this includes partial barcodes (codes that did not use all rounds in decoding) which the PerRoundMaxChannel method does not consider). Depending on the search radius, there is as much as a 442% increase in the total number of decoded barcodes for the CheckAll decoder vs PerRoundMaxChannel.

To assess the accuracy of either decoding method, I used orthologous smFISH data that was available from the same samples for several dozen of the same genes as were probed in the seqFISH experiment. Using this data, I calculated the Pearson correlation coefficient for the correlation between the smFISH data and the results from decoding the seqFISH data with either method (note: because the targets in this dataset were introns (see paper) the values that were correlated were the calculated burst frequencies for each gene (how often/fast transcription is cycled on/off) instead of counts). The results of this are shown in the center figure above with the right-hand figure showing the same data but zoomed out to a 0-1 range. The starFISH PerRoundMaxChannel method does achieve a higher accuracy using this test but it is not significant and comes at the cost of detecting far fewer barcodes. (Note: missing values on lower end of x-axis are due to not having enough results to calculate the burst frequency of the transcripts).

Unlike current starFISH methods, the CheckAll decoder is capable of taking advantage of error correction rounds built into the codebook. As an example, say a experiment is designed with a codebook that has 5 rounds, but the codes are designed in such a way that only any 4 of those rounds are needed to uniquely match a barcode to a target, the additional round would be considered an error correction round because you may be able to uniquely identify a barcode as a specific target with only 4 rounds, but if you can also use that fifth round you can be extra confident that the spot combination making up a barcode is correct. This method is based on a previous pull request made by a colleague of mine (https://github.com/ctcisar/starfish/pull/1).

![image](https://user-images.githubusercontent.com/36525811/137047313-c3763935-60bd-42bd-9f9b-01739632dc08.png)

The above figures show similar results to the first figure except the results of the CheckAll decoder have been split between barcodes that were made using spots in all rounds (error correction) and those that only had a partial match (no correction). Even without considering error correction, the CheckAll decoder detects as much as 181% more barcodes than the PerRoundMaxChannel method. The smFISH correlation are as expected with error corrected barcodes achieving a higher correlation score with the smFISH data than those that were not corrected. Whether a barcode in the final DecodedIntensityTable uses an error correction round or not can be extracted from the new "rounds_used" field which shows the number of rounds used to make a barcode for each barcode in the table. This allows easy separation of data into high and lower confidence calls. Additionally, the distance field of the DecodedIntensityTable is no longer based on the intensity of the spots in each barcode but is the value that is calculated for the sum of variances of the list of spatial coordinates for each spot in a barcode. This can also be used as a filter in many cases as barcodes made of more tightly clustered spots may be more likely to be true targets.

![image](https://user-images.githubusercontent.com/36525811/137047521-babcfd4f-66f3-4b46-b579-40ba98e4e91d.png)

The major downside to the CheckAll decoder is it's speed. This is no surprise, as it is searching the entire possible barcode space for every spot from all rounds instead of just nearest neighbors to spots in a single round, but the possible barcode space can become quite large as search radius increases which can significantly increase run times. In order to address this, I've added the ability to multi-thread the program and run multiple chunks simultaneously in parallel using the python module ray, though even with this added parallelization, runtimes for CheckAll are much higher than for PerRoundMaxChannel. The above figure shows the runtime in minutes for the CheckAll decoder (using 16 threads) vs PerRoundMaxChannel with nearest neighbors (note: the seqFISH dataset used here is among the larger that are available at 5 rounds, 12 channels, and over 10,000 barcodes in the codebook so for most other seqFISH datasets I expect runtimes will be considerably less than what is shown here, unfortunately I did not have access to another suitable seqFISH dataset to test on). Ongoing work is being done to optimize the method and bring runtimes down. I was unable to figure out how to correctly add ray to the requirements file so that will still need to be done.