### PR TITLE
Fix coords assignment in CombineAdjustFeatures.run

### DIFF
--- a/starfish/core/intensity_table/intensity_table.py
+++ b/starfish/core/intensity_table/intensity_table.py
@@ -33,7 +33,7 @@ class IntensityTable(xr.DataArray):
     An IntensityTable records the numeric intensity of a set of features in each
     :code:`(round, channel)` tile in which the feature is identified.
     The :py:class:`IntensityTable` has shape
-    :code:`(n_feature, n_channel, n_round)`.
+    :code:`(n_feature, n_round, n_channel)`.
 
     Some :py:class:`SpotFinder` methods identify a position and search for
     Gaussian blobs in a small radius, only recording intensities if they are

--- a/starfish/core/spots/DetectPixels/combine_adjacent_features.py
+++ b/starfish/core/spots/DetectPixels/combine_adjacent_features.py
@@ -422,10 +422,13 @@ class CombineAdjacentFeatures:
         # create new indexes for the output IntensityTable
         channel_index = mean_pixel_traces.indexes[Axes.CH]
         round_index = mean_pixel_traces.indexes[Axes.ROUND]
-        coords = IntensityTable._build_xarray_coords(spot_attributes, channel_index, round_index)
+        coords = IntensityTable._build_xarray_coords(
+            spot_attributes=spot_attributes,
+            round_values=round_index,
+            channel_values=channel_index)
 
         # create the output IntensityTable
-        dims = (Features.AXIS, Axes.CH.value, Axes.ROUND.value)
+        dims = (Features.AXIS, Axes.ROUND.value, Axes.CH.value)
         intensity_table = DecodedIntensityTable(
             data=mean_pixel_traces, coords=coords, dims=dims
         )


### PR DESCRIPTION
This PR fixes a bug in with the `CombineAdjustFeatures.run` that was flipping round and channel coordinates in the resulting `DecodedIntensityTable` compare to the input intensities.

The fix:
Use explicit parameter calls when building table coordinates
Correct shape definition for the IntensityTable docstring

This [notebook](https://gist.github.com/sgratiy/2053e72cfc0ff4ca6460ef4f981dc45f) shows demonstrates the intensity table coordinates before and after the fix.