### PR TITLE
change Codebook data default dtype to float

### DIFF
--- a/starfish/core/codebook/codebook.py
+++ b/starfish/core/codebook/codebook.py
@@ -110,7 +110,7 @@ class Codebook(xr.DataArray):
             codebook whose values are all zero
 
         """
-        data = np.zeros((len(code_names), n_round, n_channel), dtype=np.uint8)
+        data = np.zeros((len(code_names), n_round, n_channel), dtype=float)
         return cls.from_numpy(code_names, n_round, n_channel, data)
 
     @classmethod
@@ -295,7 +295,7 @@ class Codebook(xr.DataArray):
         target_names = [w[Features.TARGET] for w in code_array]
 
         # fill the codebook
-        data = np.zeros((len(target_names), n_round, n_channel), dtype=np.uint8)
+        data = np.zeros((len(target_names), n_round, n_channel), dtype=float)
         for i, code_dict in enumerate(code_array):
             for bit in code_dict[Features.CODEWORD]:
                 ch = int(bit[Axes.CH])

--- a/starfish/core/codebook/test/test_from_code_array.py
+++ b/starfish/core/codebook/test/test_from_code_array.py
@@ -137,7 +137,7 @@ def test_create_codebook():
     targets = [x[Features.TARGET] for x in code_array]
 
     # Loop performed by from_code_array
-    data = np.zeros((2, 2, 3), dtype=np.uint8)
+    data = np.zeros((2, 2, 3), dtype=float)
     for i, code_dict in enumerate(code_array):
         for bit in code_dict[Features.CODEWORD]:
             ch = int(bit[Axes.CH])


### PR DESCRIPTION
the intended specification for the codebook included non-integer values, but the current implementation uses integers when creating the `Codebook` object from a .json file. Non-integer values already work as desired when a codebook is created using the `Codebook.from_dict` method, so this PR should allow those values to be read in from a file.