### PR TITLE
Add min_distance parameter to peak_local_max call

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -22,6 +22,7 @@ scipy
 showit >= 1.1.4
 slicedimage==4.1.1
 sympy ~= 1.5.0
+urllib3 <1.27, >=1.25.4
 tqdm
 trackpy
 validators

--- a/starfish/core/morphology/Filter/min_distance_label.py
+++ b/starfish/core/morphology/Filter/min_distance_label.py
@@ -63,6 +63,7 @@ class MinDistanceLabel(FilterAlgorithm):
             exclude_border=self._exclude_border,
             footprint=footprint,
             labels=np.asarray(mask),
+            min_distance=self._minimum_distance_xy,
         )
         local_maximum_mask = np.zeros_like(distance, dtype=bool)
         local_maximum_mask[tuple(local_maximum.T)] = True

--- a/starfish/test/full_pipelines/api/test_iss_api.py
+++ b/starfish/test/full_pipelines/api/test_iss_api.py
@@ -105,8 +105,8 @@ def test_iss_pipeline_cropped_data(tmpdir):
 
     masks = iss.masks
 
-    # segmentation identifies only one cell
-    assert len(iss.watershed_markers) == 6
+    # segmentation identifies four cells
+    assert len(iss.watershed_markers) == 4
 
     # assign targets
     lab = AssignTargets.Label()
@@ -143,4 +143,4 @@ def test_iss_pipeline_cropped_data(tmpdir):
     # test that nans were properly removed from the expression matrix
     assert 'nan' not in expression_matrix.genes.data
     # test the number of spots that did not decode per cell
-    assert np.array_equal(expression_matrix.number_of_undecoded_spots.data, [13, 1, 0, 36])
+    assert np.array_equal(expression_matrix.number_of_undecoded_spots.data, [13, 1, 36])


### PR DESCRIPTION
Before this change, multiple local maxima were returned even within the min_distance if their values were identical. This lead to over-segmentation in some cases.

See #2006