### PR TITLE
Replace scipy.ndimage.filters with scipy.ndimage for scipy v2 support

### DIFF
--- a/starfish/core/image/Filter/bandpass.py
+++ b/starfish/core/image/Filter/bandpass.py
@@ -14,7 +14,7 @@ class Bandpass(FilterAlgorithm):
     """
     Convolve with a Gaussian to remove short-wavelength noise and subtract out long-wavelength
     variations, retaining features of intermediate scale. This implementation relies on
-    scipy.ndimage.filters.gaussian_filter.
+    scipy.ndimage.gaussian_filter.
 
     This method is a thin wrapper around :doc:`trackpy:generated/trackpy.preprocessing.bandpass`.
 

--- a/starfish/core/image/Filter/mean_high_pass.py
+++ b/starfish/core/image/Filter/mean_high_pass.py
@@ -3,7 +3,7 @@ from typing import Callable, Optional, Tuple, Union
 
 import numpy as np
 import xarray as xr
-from scipy.ndimage.filters import uniform_filter
+from scipy.ndimage import uniform_filter
 
 from starfish.core.imagestack.imagestack import ImageStack
 from starfish.core.types import Levels, Number
@@ -22,7 +22,7 @@ class MeanHighPass(FilterAlgorithm):
     The mean filter is also known as a uniform or box filter. It can also be considered as a fast
     approximation to a GaussianHighPass filter.
 
-    This is a pass through for :py:func:`scipy.ndimage.filters.uniform_filter`
+    This is a pass through for :py:func:`scipy.ndimage.uniform_filter`
 
     Parameters
     ----------

--- a/starfish/core/spots/DecodeSpots/test/test_nearest_neighbor_trace_builder.py
+++ b/starfish/core/spots/DecodeSpots/test/test_nearest_neighbor_trace_builder.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.ndimage.filters import gaussian_filter
+from scipy.ndimage import gaussian_filter
 
 from starfish import ImageStack
 from starfish.core.spots.DecodeSpots.trace_builders import build_traces_nearest_neighbors

--- a/starfish/core/test/factories.py
+++ b/starfish/core/test/factories.py
@@ -3,7 +3,7 @@ from itertools import product
 from typing import Tuple
 
 import numpy as np
-from scipy.ndimage.filters import gaussian_filter
+from scipy.ndimage import gaussian_filter
 from skimage import img_as_float32, img_as_uint
 
 from starfish import Codebook, ImageStack, IntensityTable


### PR DESCRIPTION
This closes #2032.