### PR TITLE
fix: blob.py 2d intensities shape and pd.concat instead of append

### DIFF
--- a/starfish/core/spots/FindSpots/blob.py
+++ b/starfish/core/spots/FindSpots/blob.py
@@ -148,7 +148,7 @@ class BlobDetector(FindSpotsAlgorithm):
             y_inds = fitted_blobs_array[:, 0].astype(int)
             x_inds = fitted_blobs_array[:, 1].astype(int)
             radius = np.round(fitted_blobs_array[:, 2] * np.sqrt(2))
-            intensities = data_image[tuple([y_inds, x_inds])]
+            intensities = data_image[tuple([z_inds, y_inds, x_inds])]
 
         # construct dataframe
         spot_data = pd.DataFrame(
@@ -215,8 +215,8 @@ class BlobDetector(FindSpotsAlgorithm):
                         spot_attributes_list[i][1]['z']
                     r = spot_attributes_list[i][1][Axes.ROUND]
                     ch = spot_attributes_list[i][1][Axes.CH]
-                    merged_z_tables[(r, ch)] = merged_z_tables[(r, ch)].append(
-                        spot_attributes_list[i][0].spot_attrs.data)
+                    merged_z_tables[(r, ch)] = pd.concat(
+                        [merged_z_tables[(r, ch)], spot_attributes_list[i][0].spot_attrs.data])
                 new = []
                 r_chs = sorted([*merged_z_tables])
                 selectors = list(image_stack._iter_axes({Axes.ROUND, Axes.CH}))


### PR DESCRIPTION
This closes #2003 

Fixed 2 bugs in blob.py that were discovered when running the BlobDetector how-to example:
https://spacetx-starfish.readthedocs.io/en/latest/gallery/how_to/blob_detector.html#howto-blobdetector

1. Replaced deprecated pandas append() with concat()
2. Fixed the shape of `intensities` in 2d by adding the index `z_inds` as it is still used although it is set to zero.