### PR TITLE
add MacOS to Github actions workflow

### DIFF
--- a/.github/workflows/starfish-prod-ci.yml
+++ b/.github/workflows/starfish-prod-ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.9'
 
       - uses: actions/cache@v4
         with:
@@ -40,7 +40,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        os: ["windows-latest", "ubuntu-latest"]
+        os: ["windows-latest", "ubuntu-latest", "macos-latest"]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -70,7 +70,7 @@ jobs:
     needs: starfish-fast
     strategy:
       matrix:
-        os: ["windows-latest", "ubuntu-latest"]
+        os: ["windows-latest", "ubuntu-latest", "macos-latest"]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -167,7 +167,7 @@ jobs:
       - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.9'
 
       - uses: actions/cache@v4
         with:
@@ -192,7 +192,7 @@ jobs:
       - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.9'
 
       - uses: actions/cache@v4
         with:
@@ -217,7 +217,7 @@ jobs:
       - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.9'
 
       - uses: actions/cache@v4
         with:
@@ -242,7 +242,7 @@ jobs:
       - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.9'
 
       - uses: actions/cache@v4
         with:
@@ -267,7 +267,7 @@ jobs:
       - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.9'
 
       - uses: actions/cache@v4
         with:
@@ -292,7 +292,7 @@ jobs:
       - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.9'
 
       - uses: actions/cache@v4
         with:
@@ -317,7 +317,7 @@ jobs:
       - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.9'
 
       - uses: actions/cache@v4
         with:
@@ -342,7 +342,7 @@ jobs:
       - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.9'
 
       - uses: actions/cache@v4
         with:
@@ -364,10 +364,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setpu Python 3.9
+      - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.9'
       
       - uses: actions/cache@v4
         with:
@@ -392,7 +392,7 @@ jobs:
       - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.9'
 
       - uses: actions/cache@v4
         with:
@@ -417,7 +417,7 @@ jobs:
       - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.9'
 
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
Thanks to @iimog work on fixing #2062 with #2063 (setting normalization=None instead of default "phase" in starfish wrapper for scikit-image.registration.phase_cross_correlation() and adjusting expected values), it seems that we can now add MacOS to `.github/workflows/starfish-prod-ci.yml` without failing tests. As there is no normalization in the image registration step, we don't get the slight differences in arithmetic calculations on Intel hardware vs. Apple silicon (probably FFT implementation but not important).