### PR TITLE
fix: changing pip install flag from -c to -r due to dependabot relative path error

### DIFF
--- a/requirements/REQUIREMENTS-CI.txt.in
+++ b/requirements/REQUIREMENTS-CI.txt.in
@@ -1,6 +1,6 @@
 # requirements to run CI except for napari
 # constrain the CI requirements to packages already in REQUIREMENTS-STRICT.txt
--c ../starfish/REQUIREMENTS-STRICT.txt
+-r ../starfish/REQUIREMENTS-STRICT.txt
 build
 flake8
 flake8-import-order


### PR DESCRIPTION
This closes #2077 by circumventing dependabot bug when handling relative paths of constraint files.
This will allow dependabot to resume its role to open PRs for security updates.