### PR TITLE
Explicitly adding read permission to GitHub Actions workflow

### DIFF
--- a/.github/workflows/starfish-prod-ci.yml
+++ b/.github/workflows/starfish-prod-ci.yml
@@ -1,5 +1,7 @@
 
 name: starfish-prod-ci
+permissions:
+  contents: read
 
 on:
 


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration by explicitly setting the `contents: read` permission. This helps clarify and restrict the permissions granted to the workflow.