### PR TITLE
move docs generation run to a separate job

### DIFF
--- a/.github/workflows/starfish-prod-ci.yml
+++ b/.github/workflows/starfish-prod-ci.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Run tests
         run: |
-          make fast-test docs-html
+          make fast-test
 
   starfish-slow:
     name: Python-${{ matrix.python-version }}-${{ matrix.os }}
@@ -143,6 +143,31 @@ jobs:
   #       run: |
   #         python -c "import vispy; print(vispy.sys_info())"
   #         make napari-test
+
+  sphinx-docs:
+    name: Documentation generation with Sphinx
+    needs: starfish-slow
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Python 3.9
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.9'
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ runner.OS }}-${{ env.pythonLocation }}-${{ hashFiles('requirements/REQUIREMENTS-CI.txt') }}
+
+      - name: Install Dependencies
+        run: |
+          make install-dev
+
+      - name: Generate HTML docs
+        run: |
+          make docs-html
 
   docker-smoketest:
     name: Docker Smoketest


### PR DESCRIPTION
This pull request updates the continuous integration workflow to improve how documentation is built and tested. The main change is separating the documentation generation step into its own dedicated job, rather than running it as part of the main test job. This helps clarify the workflow and isolates documentation build failures from test failures.

Workflow improvements:

* The `docs-html` target is removed from the main `fast-test` job, so documentation is no longer built as part of the primary test run.
* A new `sphinx-docs` job is added to the workflow, which runs after the slow tests, sets up the environment, installs dependencies, and builds the documentation using Sphinx. This job is now responsible for generating the HTML documentation.