### PR TITLE
Remove redundant location for dependency update and group patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,14 +15,14 @@ updates:
     schedule:
       # Check for updates to pip dependencies once a month
       interval: "monthly"
-    # Allow up to 10 open pull requests for pip dependencies
-    open-pull-requests-limit: 10
+    # Allow up to 5 open pull requests for pip dependencies
+    open-pull-requests-limit: 5
 
-  # Monitor CI requirements
-  - package-ecosystem: "pip"
-    directory: "/requirements"
-    schedule:
-      # Check for updates to CI dependencies once a month
-      interval: "monthly"
-    # Allow up to 10 open pull requests for CI dependencies
-    open-pull-requests-limit: 10
+    # Grouping: combine pip dependency updates into fewer PRs.
+    # - "patch" groups only patch updates together.
+    groups:
+      patch:
+        update-types:
+          - "patch"
+        patterns:
+          - "*"


### PR DESCRIPTION
This pull request makes adjustments to the Dependabot configuration in `.github/dependabot.yml` to better manage pip dependency update pull requests. The main changes are reducing the number of allowed open PRs and introducing grouping for patch updates.

**Dependabot configuration improvements:**

* Reduced the maximum number of open pull requests for pip dependencies from 10 to 5 to limit PR noise.
* Added a grouping configuration to combine patch-level pip dependency updates into fewer PRs, making dependency management more efficient.

**Removed redundant configuration:**

* Removed the separate monitoring and update configuration for CI requirements under `/requirements`, simplifying the overall setup.