### PR TITLE
fix: replace ipython.run_line_magic(matplotlib,inline) with if-else for Jupyter vs. Ipython usage

### DIFF
--- a/examples/pipelines/baristaseq_pipeline.py
+++ b/examples/pipelines/baristaseq_pipeline.py
@@ -13,14 +13,23 @@ This example processes a single field of view extracted from a tissue slide that
 expression in mouse primary visual cortex.
 """
 
-from IPython import get_ipython
+import sys
+from functools import partial
+
 import matplotlib
 import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from IPython import get_ipython
+from skimage.morphology import disk, opening
 
-# equivalent to %gui qt and %matplotlib inline
+# equivalent to using in a notebook cell: %matplotlib inline
 ipython = get_ipython()
-ipython.run_line_magic("gui", "qt5")
-ipython.run_line_magic("matplotlib", "inline")
+if ipython is not None:
+    if 'ipykernel' in sys.modules:  # running in Jupyter
+        ipython.run_line_magic('matplotlib', 'inline')
+    else:  # terminal IPython
+        ipython.run_line_magic('matplotlib', 'qt5')
 
 matplotlib.rcParams["figure.dpi"] = 150
 
@@ -29,8 +38,7 @@ matplotlib.rcParams["figure.dpi"] = 150
 # ---------
 # Import starfish and extract a single field of view.
 
-from starfish import data
-from starfish import FieldOfView
+from starfish import data, FieldOfView
 
 exp = data.BaristaSeq(use_test_data=False)
 nissl = exp.fov().get_image('nuclei')
@@ -128,8 +136,6 @@ registration_corrected: ImageStack = z_projected_image.sel(
 # The following matrix contains bleed correction factors for Illumina sequencing-by-synthesis
 # reagents. Starfish provides a LinearUnmixing method that will unmix the fluorescence intensities
 
-import numpy as np
-import pandas as pd
 from starfish.image import Filter
 
 data = np.array(
@@ -180,9 +186,6 @@ f.tight_layout()
 # -----------------------
 # To remove image background, BaristaSeq uses a White Tophat filter, which measures the background
 # with a rolling disk morphological element and subtracts it from the image.
-
-from skimage.morphology import opening, dilation, disk
-from functools import partial
 
 # calculate the background
 opening = partial(opening, footprint=disk(5))

--- a/examples/pipelines/merfish_pipeline.py
+++ b/examples/pipelines/merfish_pipeline.py
@@ -15,14 +15,25 @@ the current Matlab based MERFISH `pipeline`_.
 .. _pipeline: https://github.com/ZhuangLab/MERFISH_analysis
 """
 
-from IPython import get_ipython
+import pprint
+import sys
+import warnings
+from copy import deepcopy
+
 import matplotlib
 import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from IPython import get_ipython
+from scipy.stats import scoreatpercentile
 
-# equivalent to %gui qt and %matplotlib inline
+# equivalent to using in a notebook cell: %matplotlib inline
 ipython = get_ipython()
-ipython.run_line_magic("gui", "qt5")
-ipython.run_line_magic("matplotlib", "inline")
+if ipython is not None:
+    if 'ipykernel' in sys.modules:  # running in Jupyter
+        ipython.run_line_magic('matplotlib', 'inline')
+    else:  # terminal IPython
+        ipython.run_line_magic('matplotlib', 'qt5')
 
 matplotlib.rcParams["figure.dpi"] = 150
 
@@ -34,9 +45,7 @@ matplotlib.rcParams["figure.dpi"] = 150
 # field of view correspond to 18 images from 6 imaging rounds (r) 3 color channels (c) and 1 z-plane
 # (z). Each image is 988x988 (y,x)
 
-import pprint
-from starfish import data
-from starfish import FieldOfView
+from starfish import data, FieldOfView
 
 experiment = data.MERFISH(use_test_data=False)
 
@@ -61,7 +70,6 @@ experiment.codebook
 # Visualize raw data
 # ------------------
 # We can view an image from the first round and color channel.
-
 
 from starfish.types import Axes
 
@@ -118,7 +126,6 @@ scale_factors = {
 
 # this is a scaling method. It would be great to use image.apply here. It's possible, but we need to expose H & C to
 # at least we can do it with get_slice and set_slice right now.
-from copy import deepcopy
 filtered_imgs = deepcopy(low_passed)
 
 for selector in imgs._iter_axes():
@@ -129,8 +136,6 @@ for selector in imgs._iter_axes():
 ###################################################################################################
 # Visualize processed data
 # ------------------------
-
-import numpy as np
 
 single_plane_filtered = filtered_imgs.sel({Axes.ROUND: 0, Axes.CH: 0, Axes.ZPLANE: 0})
 single_plane_filtered = single_plane_filtered.xarray.squeeze()
@@ -159,12 +164,12 @@ from starfish.types import Features
 
 psd = DetectPixels.PixelSpotDecoder(
     codebook=experiment.codebook,
-    metric='euclidean', # distance metric to use for computing distance between a pixel vector and a codeword
-    norm_order=2, # the L_n norm is taken of each pixel vector and codeword before computing the distance. this is n
-    distance_threshold=0.5176, # minimum distance between a pixel vector and a codeword for it to be called as a gene
-    magnitude_threshold=1.77e-5, # discard any pixel vectors below this magnitude
-    min_area=2, # do not call a 'spot' if it's area is below this threshold (measured in pixels)
-    max_area=np.inf, # do not call a 'spot' if it's area is above this threshold (measured in pixels)
+    metric='euclidean',  # distance metric to use for computing distance between a pixel vector and a codeword
+    norm_order=2,  # the L_n norm is taken of each pixel vector and codeword before computing the distance. this is n
+    distance_threshold=0.5176,  # minimum distance between a pixel vector and a codeword for it to be called as a gene
+    magnitude_threshold=1.77e-5,  # discard any pixel vectors below this magnitude
+    min_area=2,  # do not call a 'spot' if it's area is below this threshold (measured in pixels)
+    max_area=np.inf,  # do not call a 'spot' if it's area is above this threshold (measured in pixels)
 )
 
 initial_spot_intensities, prop_results = psd.run(filtered_imgs)
@@ -178,8 +183,6 @@ spot_intensities = initial_spot_intensities.loc[initial_spot_intensities[Feature
 # the results to the published counts in the MERFISH paper. Note that Starfish detects a lower
 # number of transcripts than the authors' results. This can likely be improved by tweaking the
 # parameters of the algorithms above.
-
-import pandas as pd
 
 bench = pd.read_csv('https://d2nhj9g34unfro.cloudfront.net/MERFISH/benchmark_results.csv',
                     dtype={'barcode': object})
@@ -209,8 +212,6 @@ plt.title(f'r = {r}')
 # called spots in a subset of the test image.
 
 from showit import image as show_image
-from scipy.stats import scoreatpercentile
-import warnings
 
 f, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 5))
 
@@ -219,7 +220,7 @@ with warnings.catch_warnings():
     area_lookup = lambda x: 0 if x == 0 else prop_results.region_properties[x - 1].area
     vfunc = np.vectorize(area_lookup)
     mask = np.squeeze(vfunc(prop_results.label_image))
-    show_image(np.squeeze(prop_results.decoded_image)*(mask > 2), cmap='nipy_spectral', ax=ax1)
+    show_image(np.squeeze(prop_results.decoded_image) * (mask > 2), cmap='nipy_spectral', ax=ax1)
     ax1.axes.set_axis_off()
 
     mp_numpy = filtered_imgs.reduce({Axes.ROUND, Axes.CH, Axes.ZPLANE}, func="max")._squeezed_numpy(

--- a/examples/pipelines/starmap_pipeline.py
+++ b/examples/pipelines/starmap_pipeline.py
@@ -11,14 +11,21 @@ authors.
 
 """
 
-from IPython import get_ipython
+import sys
+from pprint import pprint
+
 import matplotlib
 import matplotlib.pyplot as plt
+import numpy as np
+from IPython import get_ipython
 
-# equivalent to %gui qt and %matplotlib inline
+# equivalent to using in a notebook cell: %matplotlib inline
 ipython = get_ipython()
-ipython.run_line_magic("gui", "qt5")
-ipython.run_line_magic("matplotlib", "inline")
+if ipython is not None:
+    if 'ipykernel' in sys.modules:  # running in Jupyter
+        ipython.run_line_magic('matplotlib', 'inline')
+    else:  # terminal IPython
+        ipython.run_line_magic('matplotlib', 'qt5')
 
 matplotlib.rcParams["figure.dpi"] = 150
 
@@ -35,8 +42,7 @@ matplotlib.rcParams["figure.dpi"] = 150
 # shifts, that can indicate systematic registration offsets which should be corrected prior to
 # analysis.
 
-from starfish import data
-from starfish import FieldOfView
+from starfish import data, FieldOfView
 from starfish.util.plot import imshow_plane
 from starfish.types import Axes
 
@@ -87,8 +93,6 @@ transforms = ltt.run(projection)
 
 ###################################################################################################
 # How big are the identified translations?
-
-from pprint import pprint
 
 pprint([t[2].translation for t in transforms.transforms])
 
@@ -178,7 +182,6 @@ f = plot_scaling_result(stack, scaled)
 # decoding. Because of the stringency built into the STARmap codebook, it is OK to be relatively
 # permissive with the spot finding parameters for this assay.
 
-import numpy as np
 from starfish.spots import FindSpots
 
 bd = FindSpots.BlobDetector(

--- a/notebooks/py/smFISH.py
+++ b/notebooks/py/smFISH.py
@@ -25,12 +25,13 @@
 # EPY: END markdown
 
 # EPY: START code
+import sys
+from functools import partial
 from typing import Optional, Tuple
-from IPython import get_ipython
 
 import starfish
 import starfish.data
-from starfish import FieldOfView, DecodedIntensityTable
+from starfish import DecodedIntensityTable, FieldOfView
 from starfish.types import TraceBuildingStrategies
 # EPY: END code
 
@@ -89,8 +90,6 @@ tlmpf = starfish.spots.FindSpots.TrackpyLocalMaxPeakFinder(
 
 # EPY: START code
 # override print to print to stderr for cromwell
-from functools import partial
-import sys
 print = partial(print, file=sys.stderr)
 
 
@@ -165,8 +164,9 @@ def processing_pipeline(
 experiment = starfish.data.allen_smFISH(use_test_data=True)
 
 image, intensities = processing_pipeline(experiment, fov_name='fov_001')
+# EPY: END code
 
+# EPY: START code
 # uncomment the below line to visualize the output with the spot calls.
-# %gui qt
 # viewer = starfish.display(image, intensities)
 # EPY: END code

--- a/notebooks/smFISH.ipynb
+++ b/notebooks/smFISH.ipynb
@@ -35,17 +35,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import sys\n",
+    "from functools import partial\n",
     "from typing import Optional, Tuple\n",
-    "from IPython import get_ipython\n",
     "\n",
     "import starfish\n",
     "import starfish.data\n",
-    "from starfish import FieldOfView, DecodedIntensityTable\n",
-    "from starfish.types import TraceBuildingStrategies\n",
-    "\n",
-    "# equivalent to %gui qt\n",
-    "ipython = get_ipython()\n",
-    "ipython.run_line_magic(\"gui\", \"qt5\")"
+    "from starfish import DecodedIntensityTable, FieldOfView\n",
+    "from starfish.types import TraceBuildingStrategies"
    ]
   },
   {
@@ -127,8 +124,6 @@
    "outputs": [],
    "source": [
     "# override print to print to stderr for cromwell\n",
-    "from functools import partial\n",
-    "import sys\n",
     "print = partial(print, file=sys.stderr)\n",
     "\n",
     "\n",
@@ -210,8 +205,15 @@
    "source": [
     "experiment = starfish.data.allen_smFISH(use_test_data=True)\n",
     "\n",
-    "image, intensities = processing_pipeline(experiment, fov_name='fov_001')\n",
-    "\n",
+    "image, intensities = processing_pipeline(experiment, fov_name='fov_001')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# uncomment the below line to visualize the output with the spot calls.\n",
     "# viewer = starfish.display(image, intensities)"
    ]


### PR DESCRIPTION
This pull request refactors imports and notebook initialization code across multiple example pipelines and notebooks to improve consistency, reduce redundancy, and better support both Jupyter and terminal environments. The changes also clean up unused imports and streamline code for clarity.

The most important changes are:

**1. Standardization of Notebook and Script Initialization:**
- Updated all example pipelines to check if running in Jupyter or terminal IPython, and set the appropriate matplotlib backend (`'inline'` for Jupyter, `'qt5'` for terminal) instead of always running `%gui qt5` and `%matplotlib inline`. This improves compatibility and user experience across environments. [[1]](diffhunk://#diff-a4632b48a6d3c20de5348758cd745cb51c9150b819116452505a7439ef44314eL16-R32) [[2]](diffhunk://#diff-759eabc8276d03ed355f72890e847bc3093012fa7523b67181fd490387a16d5cL16-R33) [[3]](diffhunk://#diff-d60ee98e86d18df9468196d2965ed2a8d923da60359fa4f777d60b666ce42501L18-R36) [[4]](diffhunk://#diff-15235ef5ff751c406a1434271edeb4d846a6c133d668f5d9463845cd42466788L17-R33) [[5]](diffhunk://#diff-350c6ea759fc34fe1ddd72314e4318a04395fa9fd502b6fc3ae6dd5eec3afa81L14-R28) [[6]](diffhunk://#diff-1417cf83f0904ed6142fe0289cb07bf074fcd1104e9f89ac93f7f54839863555R28-R34) [[7]](diffhunk://#diff-c1e72e8acb0b28135c059dc6e271230bc6296275e875ce34d533ae95ab57e69bR38-R45)

**2. Import Cleanup and Consolidation:**
- Consolidated multiple import statements for `starfish` modules (e.g., `from starfish import data, FieldOfView` instead of separate imports) and removed unused imports across all pipelines for clarity and efficiency. [[1]](diffhunk://#diff-a4632b48a6d3c20de5348758cd745cb51c9150b819116452505a7439ef44314eL32-R41) [[2]](diffhunk://#diff-759eabc8276d03ed355f72890e847bc3093012fa7523b67181fd490387a16d5cL35-R45) [[3]](diffhunk://#diff-d60ee98e86d18df9468196d2965ed2a8d923da60359fa4f777d60b666ce42501L37-R48) [[4]](diffhunk://#diff-15235ef5ff751c406a1434271edeb4d846a6c133d668f5d9463845cd42466788L38-R47) [[5]](diffhunk://#diff-350c6ea759fc34fe1ddd72314e4318a04395fa9fd502b6fc3ae6dd5eec3afa81L38-R45)
- Removed or relocated other unused imports (e.g., `numpy`, `pandas`, `seaborn`, `pickle`, `os`, `warnings`, `pprint`, `functools.partial`) to where they are actually used or eliminated them if not needed. [[1]](diffhunk://#diff-a4632b48a6d3c20de5348758cd745cb51c9150b819116452505a7439ef44314eL131-L132) [[2]](diffhunk://#diff-a4632b48a6d3c20de5348758cd745cb51c9150b819116452505a7439ef44314eL184-L186) [[3]](diffhunk://#diff-759eabc8276d03ed355f72890e847bc3093012fa7523b67181fd490387a16d5cL99-L100) [[4]](diffhunk://#diff-759eabc8276d03ed355f72890e847bc3093012fa7523b67181fd490387a16d5cL160-L161) [[5]](diffhunk://#diff-759eabc8276d03ed355f72890e847bc3093012fa7523b67181fd490387a16d5cL205-L207) [[6]](diffhunk://#diff-d60ee98e86d18df9468196d2965ed2a8d923da60359fa4f777d60b666ce42501L65) [[7]](diffhunk://#diff-d60ee98e86d18df9468196d2965ed2a8d923da60359fa4f777d60b666ce42501L121) [[8]](diffhunk://#diff-d60ee98e86d18df9468196d2965ed2a8d923da60359fa4f777d60b666ce42501L133-L134) [[9]](diffhunk://#diff-d60ee98e86d18df9468196d2965ed2a8d923da60359fa4f777d60b666ce42501L182-L183) [[10]](diffhunk://#diff-d60ee98e86d18df9468196d2965ed2a8d923da60359fa4f777d60b666ce42501L212-L213) [[11]](diffhunk://#diff-15235ef5ff751c406a1434271edeb4d846a6c133d668f5d9463845cd42466788L72-L73) [[12]](diffhunk://#diff-15235ef5ff751c406a1434271edeb4d846a6c133d668f5d9463845cd42466788L125-L129) [[13]](diffhunk://#diff-350c6ea759fc34fe1ddd72314e4318a04395fa9fd502b6fc3ae6dd5eec3afa81L91-L92) [[14]](diffhunk://#diff-350c6ea759fc34fe1ddd72314e4318a04395fa9fd502b6fc3ae6dd5eec3afa81L181) [[15]](diffhunk://#diff-1417cf83f0904ed6142fe0289cb07bf074fcd1104e9f89ac93f7f54839863555L92-L93) [[16]](diffhunk://#diff-c1e72e8acb0b28135c059dc6e271230bc6296275e875ce34d533ae95ab57e69bL130-L131)

**3. Jupyter Notebook (`smFISH.ipynb`) Modernization:**
- Removed legacy `%gui qt5` magic and related code from the notebook, aligning it with the new initialization pattern and cleaning up imports. Also split code cells for improved clarity and usability. [[1]](diffhunk://#diff-c1e72e8acb0b28135c059dc6e271230bc6296275e875ce34d533ae95ab57e69bR38-R45) [[2]](diffhunk://#diff-c1e72e8acb0b28135c059dc6e271230bc6296275e875ce34d533ae95ab57e69bL130-L131) [[3]](diffhunk://#diff-c1e72e8acb0b28135c059dc6e271230bc6296275e875ce34d533ae95ab57e69bL213-R216)

**4. Minor Code and Output Adjustments:**
- Adjusted code cell ordering and output handling in both the Python and notebook versions of the smFISH example to improve clarity and usability (e.g., moving the print override and visualization code). [[1]](diffhunk://#diff-1417cf83f0904ed6142fe0289cb07bf074fcd1104e9f89ac93f7f54839863555L92-L93) [[2]](diffhunk://#diff-1417cf83f0904ed6142fe0289cb07bf074fcd1104e9f89ac93f7f54839863555R167-L170) [[3]](diffhunk://#diff-c1e72e8acb0b28135c059dc6e271230bc6296275e875ce34d533ae95ab57e69bL213-R216)

These changes collectively make the example codebases cleaner, more robust, and easier to use in various environments.