### PR TITLE
set ubuntu version to use latest in readthedocs.yml

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -6,7 +6,7 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-    os: ubuntu-22.04
+    os: ubuntu-lts-latest
     tools:
         python: "3.10"
 


### PR DESCRIPTION
This pull request updates the build environment in the `readthedocs.yml` configuration to use the latest supported Ubuntu LTS version instead of a fixed release. This change ensures the documentation build uses the most up-to-date and secure long-term support OS.

* Build configuration: Changed the `os` setting from `ubuntu-22.04` to `ubuntu-lts-latest` in `readthedocs.yml` to always use the latest Ubuntu LTS version for documentation builds.