### PR TITLE
fix: remove _repr_html function from imagestack

### DIFF
--- a/starfish/core/experiment/test/test_get_image_repr_warning.py
+++ b/starfish/core/experiment/test/test_get_image_repr_warning.py
@@ -26,12 +26,6 @@ def test_imagestack_repr_shows_aligned_group():
     repr_str = repr(stack)
     assert "(aligned_group=2/3)" in repr_str
 
-    # Check _repr_html_ returns pre-formatted HTML with same info
-    html = stack._repr_html_()
-    assert html.startswith("<pre>")
-    assert html.endswith("</pre>")
-    assert "(aligned_group=2/3)" in html
-
 
 def test_get_image_warns_and_sets_attrs(monkeypatch):
     """Test that get_image warns when multiple aligned groups exist and sets attributes."""

--- a/starfish/core/imagestack/imagestack.py
+++ b/starfish/core/imagestack/imagestack.py
@@ -250,10 +250,6 @@ class ImageStack:
             prefix = f"(aligned_group={one_based}/{self._coordinate_group_count}) "
         return f"<starfish.ImageStack {prefix}({shape})>"
 
-    def _repr_html_(self):
-        """Provide HTML representation for Jupyter notebooks."""
-        return f"<pre>{self.__repr__()}</pre>"
-
     @classmethod
     def from_tileset(
             cls,


### PR DESCRIPTION
This pull request removes the HTML representation method for the `ImageStack` class and its corresponding test, added by copilot in #2111 that didn't work and resulted in empty/blank cell output. Thus, also simplifying the codebase by eliminating unused or unnecessary functionality.

Codebase simplification:

* Removed the `_repr_html_` method from the `ImageStack` class in `imagestack.py`.
* Removed the test in `test_get_image_repr_warning.py` that checked the HTML representation output of `ImageStack`.