### PR TITLE
Fix pandas concat FutureWarnings for empty DataFrames

### DIFF
--- a/starfish/core/spots/DecodeSpots/trace_builders.py
+++ b/starfish/core/spots/DecodeSpots/trace_builders.py
@@ -55,10 +55,20 @@ def build_traces_sequential(spot_results: SpotFindingResults, **kwargs) -> Inten
 
     """
 
-    all_spots = pd.concat([sa.spot_attrs.data for sa in spot_results.values()],
-                          ignore_index=True, sort=True)
+    all_data_list = [sa.spot_attrs.data for sa in spot_results.values()]
+    spot_data_list = [df for df in all_data_list if not df.empty]
+    
+    if spot_data_list:
+        all_spots = pd.concat(spot_data_list, ignore_index=True, sort=True)
+    elif all_data_list:
+        # All DataFrames are empty - use structure from first one
+        all_spots = all_data_list[0].copy()
+    else:
+        all_spots = pd.DataFrame()
+    
     # reassign spot_ids to index number so they are unique
-    all_spots['spot_id'] = all_spots.index
+    if not all_spots.empty:
+        all_spots['spot_id'] = all_spots.index
 
     intensity_table = IntensityTable.zeros(
         spot_attributes=SpotAttributes(all_spots),

--- a/starfish/core/spots/DecodeSpots/util.py
+++ b/starfish/core/spots/DecodeSpots/util.py
@@ -152,9 +152,15 @@ def _merge_spots_by_round(
         round_data[r].append(df)
 
     # create one dataframe per round
-    round_dataframes = {
-        k: pd.concat(v, axis=0).reset_index().drop('index', axis=1)
-        for k, v in round_data.items()
-    }
+    round_dataframes = {}
+    for k, v in round_data.items():
+        non_empty = [df for df in v if not df.empty]
+        if non_empty:
+            round_dataframes[k] = pd.concat(non_empty, axis=0).reset_index(drop=True)
+        elif v:
+            # All DataFrames are empty - use structure from first one
+            round_dataframes[k] = v[0].copy()
+        else:
+            round_dataframes[k] = pd.DataFrame()
 
     return round_dataframes

--- a/starfish/core/types/_spot_attributes.py
+++ b/starfish/core/types/_spot_attributes.py
@@ -36,10 +36,19 @@ class SpotAttributes(ValidatedTable):
 
     @classmethod
     def combine(cls, spot_attribute_tables: Sequence["SpotAttributes"]) -> "SpotAttributes":
-        return cls(pd.concat([
-            spot_attribute_table.data
-            for spot_attribute_table in spot_attribute_tables
-        ]))
+        data_list = [spot_attribute_table.data for spot_attribute_table in spot_attribute_tables]
+        non_empty_list = [df for df in data_list if not df.empty]
+        
+        if non_empty_list:
+            # Concat only non-empty DataFrames to avoid FutureWarning
+            combined = pd.concat(non_empty_list)
+        elif data_list:
+            # All DataFrames are empty - use structure from first one
+            combined = data_list[0].copy()
+        else:
+            # No DataFrames at all - create minimal empty DataFrame
+            combined = pd.DataFrame(columns=[field[0] for field in cls.required_fields])
+        return cls(combined)
 
     def save_geojson(self, output_file_name: str) -> None:
         """Save to geojson for web visualization


### PR DESCRIPTION
- Filter empty DataFrames before pd.concat() to avoid FutureWarning
- Preserve DataFrame structure when all inputs are empty
- Add empty checks before modifying DataFrame columns

Modified files:
- starfish/core/types/_spot_attributes.py: Update combine() method
- starfish/core/spots/DecodeSpots/trace_builders.py: Update build_traces_sequential()
- starfish/core/spots/DecodeSpots/util.py: Update _merge_spots_by_round()

All 386 tests passing with these changes.