### PR TITLE
docs: minor improvements in Makefile for new releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,11 +312,11 @@ release-docker: release-check
 # public: print commands for uploading artifacts
 release-upload: release-check
 	@printf '\n# Please execute the following steps\n'
-	@echo git push origin $(VERSION)
+	@echo git push origin tag $(VERSION)
 	@echo docker push $(DOCKER_IMAGE)
 	@echo docker push $(DOCKER_IMAGE):$(VERSION)
 	@echo docker push $(DOCKER_IMAGE):$(VERSION)-$(DOCKER_BUILD)
-	@echo twine upload dist/starfish-$(VERSION).tar.gz
+	@echo twine upload dist/starfish-$(VERSION)*
 
 clean:
 	rm -rf release-env


### PR DESCRIPTION
This pull request makes a minor update to the release instructions in the `Makefile` for the `release-upload` target. The changes clarify the git push command for a tag and generalize the twine upload command for Python package distribution.
This closes #2189 

* Updated the git push command to specify pushing a tag, improving clarity for release publishing.
* Generalized the twine upload command to accept any file matching `starfish-$(VERSION)*`, making it more flexible for uploading release artifacts.